### PR TITLE
Minor edits.

### DIFF
--- a/docs/excel/performance.md
+++ b/docs/excel/performance.md
@@ -66,7 +66,7 @@ See [Application Object](https://dev.office.com/reference/add-ins/excel/applicat
 
 ## Update all cells in a range 
 
-When you need to update all cells in a range with the same value or property, it can be slow to do this via a 2-dimensional array full of a single value, since that approach requires Excel to iterate over all of the cells in the range to set each one separately. Excel has a more efficient way to update all the cells in a range with the same value or property.
+When you need to update all cells in a range with the same value or property, it can be slow to do this via a 2-dimensional array that repeatedly specifies the same value, since that approach requires Excel to iterate over all of the cells in the range to set each one separately. Excel has a more efficient way to update all the cells in a range with the same value or property.
 
 If you need to apply the same value, the same number format, or the same formula to a range of cells, it's more efficient to specify a single value instead of an array of values. Doing so will significantly improve performance. For a code sample that shows this approach in action, see [Core concepts - Update all cells in a range](excel-add-ins-core-concepts.md#update-all-cells-in-a-range).
 

--- a/docs/excel/performance.md
+++ b/docs/excel/performance.md
@@ -6,13 +6,13 @@ ms.date: 03/13/2017
 
 # Performance optimization
 
-Some common tasks can be accomplished via the Excel JavaScript API in more than one way, and there may be significant performance differences between various approaches. This article provides guides and code samples that show how to perform common task in an efficient way using Excel JavaScript API.
+Some common tasks can be accomplished via the Excel JavaScript API in more than one way, and there may be significant performance differences between various approaches. This article provides guidance and code samples that show how to perform common tasks in an efficient way using Excel JavaScript API.
 
 ## Minimize the number of sync() calls
 
 In the Excel JavaScript API, ```sync()``` is the only asynchronous operation, and it can be slow under some circumstances. To optimize performance, minimize the number of calls to ```sync()``` by queueing up as many changes as possible before calling it.
 
-See [Core Concepts - sync()](https://docs.microsoft.com/en-us/office/dev/add-ins/excel/excel-add-ins-core-concepts#sync) for code samples that follow this practice.
+See [Core Concepts - sync()](excel-add-ins-core-concepts#sync) for code samples that follow this practice.
 
 ## Minimize the number of proxy objects created
 
@@ -33,7 +33,7 @@ range.values = [[1]];
 
 ## Load necessary properties only
 
-In the Excel JavaScript API, you need to explicitly load the properties and relationships of a proxy object. Although you are able to load all the properties at once with an empty ```load()``` call, that approach can have significant performance overhead. Instead, we strongly suggest that you only load the necessary properties, especially for those objects which have a large number of properties.
+In the Excel JavaScript API, you need to explicitly load the properties of a proxy object. Although you are able to load all the properties at once with an empty ```load()``` call, that approach can have significant performance overhead. Instead, we strongly suggest that you only load the necessary properties, especially for those objects which have a large number of properties.
 
 For example, if you only intend to read back the **address** property of a range object, specify only that property when you call the **load()** method:
  
@@ -55,29 +55,29 @@ object.load({ loadOption });
  
 _Where:_
  
-* `properties` is the list of properties and/or relationship names to be loaded specified as comma-delimited strings, or an array of names. For more information, see the **load()** methods defined for objects in [Excel JavaScript API reference](https://dev.office.com/reference/add-ins/excel/excel-add-ins-reference-overview).
+* `properties` is the list of properties to be loaded, specified as comma-delimited strings or as an array of names. For more information, see the **load()** methods defined for objects in [Excel JavaScript API reference](https://dev.office.com/reference/add-ins/excel/excel-add-ins-reference-overview).
 * `loadOption` specifies an object that describes the selection, expansion, top, and skip options. See object load [options](https://dev.office.com/reference/add-ins/excel/loadoption) for details.
 
 ## Suspend calculation temporarily
 
-If you are trying to perform an operation on a large number of cells (for example, setting the value of a huge range object) and you don’t mind suspending the calculation in Excel temporarily while your operation finishes, we recommend that you suspend calculation until the next ```context.sync()``` is called.
+If you are trying to perform an operation on a large number of cells (for example, setting the value of a huge range object) and you don't mind suspending the calculation in Excel temporarily while your operation finishes, we recommend that you suspend calculation until the next ```context.sync()``` is called.
 
 See [Application Object](https://dev.office.com/reference/add-ins/excel/application) reference documentation for code samples that demonstrate how to use the ```suspendApiCalculationUntilNextSync()``` API to suspend and reactivate calculations in a very convenient way.
 
 ## Update all cells in a range 
 
-When you need to update all cells in a range with the same value or property, it can be slow to do this via a 2-dimensional array full of a single value. That approach requires Excel to iterate over all of the cells in the range to set each one separately, but Excel has a more efficient way to update all the cells in a range with the same value or property.
+When you need to update all cells in a range with the same value or property, it can be slow to do this via a 2-dimensional array full of a single value, since that approach requires Excel to iterate over all of the cells in the range to set each one separately. Excel has a more efficient way to update all the cells in a range with the same value or property.
 
-So if you’re trying to apply the same value, the same number format or the same formula to a range of cells, it’s much better to use a single value instead of an array of values. This will help you gain a huge performance improvement. For an example code sample that shows this approach in action, see [Update all cells in a range](https://docs.microsoft.com/en-us/office/dev/add-ins/excel/excel-add-ins-core-concepts#update-all-cells-in-a-range) in [Core Concepts](https://docs.microsoft.com/en-us/office/dev/add-ins/excel/excel-add-ins-core-concepts).
+If you need to apply the same value, the same number format, or the same formula to a range of cells, it's more efficient to specify a single value instead of an array of values. Doing so will significantly improve performance. For a code sample that shows this approach in action, see [Core concepts - Update all cells in a range](excel-add-ins-core-concepts#update-all-cells-in-a-range).
 
-A very common scenario is to apply different number formats on different columns. In this case, you just need to loop over columns and set the number format on each column with a single value. Handle each column as a range as shown in the [Update all cells in a range](https://docs.microsoft.com/en-us/office/dev/add-ins/excel/excel-add-ins-core-concepts#update-all-cells-in-a-range) code sample.
+A common scenario where this approach can be applied is when setting different number formats on different columns in a worksheet. In this case, you can simply iterate through the columns and set the number format on each column with a single value. Handle each column as a range, as shown in the [Update all cells in a range](excel-add-ins-core-concepts#update-all-cells-in-a-range) code sample.
 
-## Convert between Range and Table
+## Convert between range and table
 
-If you’re trying to import a huge amount of data into a Table object directly (for example, using ```TableRowCollection.add()```),  you might experience a slow performance. You could try to write the data into a range object via ```table.getDataBodyRange()```, and the table will expand automatically.
+When trying to import a huge amount of data directly into a [Table](https://dev.office.com/reference/add-ins/excel/table) (for example, by using `TableRowCollection.add()`), you might experience slow performance. In this case, we recommend that you instead write the data into a range object by using `table.getDataBodyRange()`, and the table will expand automatically to accommodate the data.
 
-> NOTE:
-> you can conveniently convert between Table objects and Range objects using the [convertToRange()](https://dev.office.com/reference/add-ins/excel/table#converttorange) method of the [Table Object](https://dev.office.com/reference/add-ins/excel/table).
+> [!NOTE]
+> You can conveniently convert a Table object to a Range object by using the [Table.convertToRange()](https://dev.office.com/reference/add-ins/excel/table#converttorange) method.
 
 ## See also
 

--- a/docs/excel/performance.md
+++ b/docs/excel/performance.md
@@ -68,9 +68,9 @@ See [Application Object](https://dev.office.com/reference/add-ins/excel/applicat
 
 When you need to update all cells in a range with the same value or property, it can be slow to do this via a 2-dimensional array full of a single value, since that approach requires Excel to iterate over all of the cells in the range to set each one separately. Excel has a more efficient way to update all the cells in a range with the same value or property.
 
-If you need to apply the same value, the same number format, or the same formula to a range of cells, it's more efficient to specify a single value instead of an array of values. Doing so will significantly improve performance. For a code sample that shows this approach in action, see [Core concepts - Update all cells in a range](excel-add-ins-core-concepts#update-all-cells-in-a-range.md).
+If you need to apply the same value, the same number format, or the same formula to a range of cells, it's more efficient to specify a single value instead of an array of values. Doing so will significantly improve performance. For a code sample that shows this approach in action, see [Core concepts - Update all cells in a range](excel-add-ins-core-concepts.md#update-all-cells-in-a-range).
 
-A common scenario where this approach can be applied is when setting different number formats on different columns in a worksheet. In this case, you can simply iterate through the columns and set the number format on each column with a single value. Handle each column as a range, as shown in the [Update all cells in a range](excel-add-ins-core-concepts#update-all-cells-in-a-range.md) code sample.
+A common scenario where this approach can be applied is when setting different number formats on different columns in a worksheet. In this case, you can simply iterate through the columns and set the number format on each column with a single value. Handle each column as a range, as shown in the [Update all cells in a range](excel-add-ins-core-concepts.md#update-all-cells-in-a-range) code sample.
 
 ## Convert between range and table
 

--- a/docs/excel/performance.md
+++ b/docs/excel/performance.md
@@ -12,7 +12,7 @@ Some common tasks can be accomplished via the Excel JavaScript API in more than 
 
 In the Excel JavaScript API, ```sync()``` is the only asynchronous operation, and it can be slow under some circumstances. To optimize performance, minimize the number of calls to ```sync()``` by queueing up as many changes as possible before calling it.
 
-See [Core Concepts - sync()](excel-add-ins-core-concepts#sync) for code samples that follow this practice.
+See [Core Concepts - sync()](excel-add-ins-core-concepts.md#sync) for code samples that follow this practice.
 
 ## Minimize the number of proxy objects created
 
@@ -68,9 +68,9 @@ See [Application Object](https://dev.office.com/reference/add-ins/excel/applicat
 
 When you need to update all cells in a range with the same value or property, it can be slow to do this via a 2-dimensional array full of a single value, since that approach requires Excel to iterate over all of the cells in the range to set each one separately. Excel has a more efficient way to update all the cells in a range with the same value or property.
 
-If you need to apply the same value, the same number format, or the same formula to a range of cells, it's more efficient to specify a single value instead of an array of values. Doing so will significantly improve performance. For a code sample that shows this approach in action, see [Core concepts - Update all cells in a range](excel-add-ins-core-concepts#update-all-cells-in-a-range).
+If you need to apply the same value, the same number format, or the same formula to a range of cells, it's more efficient to specify a single value instead of an array of values. Doing so will significantly improve performance. For a code sample that shows this approach in action, see [Core concepts - Update all cells in a range](excel-add-ins-core-concepts#update-all-cells-in-a-range.md).
 
-A common scenario where this approach can be applied is when setting different number formats on different columns in a worksheet. In this case, you can simply iterate through the columns and set the number format on each column with a single value. Handle each column as a range, as shown in the [Update all cells in a range](excel-add-ins-core-concepts#update-all-cells-in-a-range) code sample.
+A common scenario where this approach can be applied is when setting different number formats on different columns in a worksheet. In this case, you can simply iterate through the columns and set the number format on each column with a single value. Handle each column as a range, as shown in the [Update all cells in a range](excel-add-ins-core-concepts#update-all-cells-in-a-range.md) code sample.
 
 ## Convert between range and table
 


### PR DESCRIPTION
Misc comments:

- links within the same doc set should use relative paths (not complete URLs) -- I've updated links accordingly
- the distinction between `relationships` and `properties` will be going away soon (when we start auto-generating docs), so I've removed mention of 'relationships' in this article.
- `Note` formats in OPS use a special markdown syntax -- I've updated the note in this article to use that syntax.

Also, maybe consider adding code samples for the **Suspend calculation temporarily** section and the **Convert between range and table** section? 