### PR TITLE
Remove misplaced curly bracket

### DIFF
--- a/docs/develop/create-sso-office-add-ins-aspnet.md
+++ b/docs/develop/create-sso-office-add-ins-aspnet.md
@@ -361,7 +361,6 @@ The following instruction are written generically so they can be used in multipl
     ```javascript
     var exceptionMessage = JSON.parse(result.responseText).ExceptionMessage;
     var message = JSON.parse(result.responseText).Message;
-    }
     ```
 
 1. Replace `TODO11` with the following code. Note about this code:


### PR DESCRIPTION
There is a misplaced closing curly bracket in TODO10 replacement JavaScript.