### PR TITLE
Update documentation to account for addition of new sideloading commands to Yo Office (see https://github.com/OfficeDev/generator-office/commit/f95809fc1c2b8490cbedb3827d0d1754ad3d2238)

### DIFF
--- a/docs/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins.md
+++ b/docs/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins.md
@@ -6,7 +6,10 @@ ms.date: 01/25/2018
 
 # Sideload Office Add-ins for testing
 
-You can install an Office Add-in for testing in an Office client running on Windows by either 1) using a shared folder catalog to publish the manifest to a network file share, or 2) [running the "**npm run sideload**" command from the root of the add-in project folder (**NOTE**: this method only works for Excel, Word and PowerPoint add-ins)](sideload-office-addin-using-sideload-command.md).
+You can install an Office Add-in for testing in an Office client running on Windows by one of the following methods:
+
+- using a shared folder catalog to publish the manifest to a network file share (instructions below)
+- [running the "**npm run sideload**" command from the root of the add-in project folder.](sideload-office-addin-using-sideload-command.md) [!NOTE] this method only works for Excel, Word, and PowerPoint add-ins).
 
 If you're not testing a Word, Excel, or PowerPoint add-in on Windows, see one of the following topics to sideload your add-in:
 

--- a/docs/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins.md
+++ b/docs/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins.md
@@ -6,14 +6,14 @@ ms.date: 01/25/2018
 
 # Sideload Office Add-ins for testing
 
-You can install an Office Add-in for testing in an Office client running on Windows by using a shared folder catalog to publish the manifest to a network file share. 
+You can install an Office Add-in for testing in an Office client running on Windows by either 1) using a shared folder catalog to publish the manifest to a network file share, or 2) [running the "**npm run sideload**" command from the root of the add-in project folder (**NOTE**: this method only works for Excel, Word and PowerPoint add-ins)](sideload-office-addin-using-sideload-command.md).
 
 If you're not testing a Word, Excel, or PowerPoint add-in on Windows, see one of the following topics to sideload your add-in:
 
 - [Sideload Office Add-ins in Office Online for testing](sideload-office-add-ins-for-testing.md)
 - [Sideload Office Add-ins on iPad and Mac for testing](sideload-an-office-add-in-on-ipad-and-mac.md)
 
-The following video walks you through the process of sideloading your add-in on Office desktop or Office Online.  
+The following video walks you through the process of sideloading your add-in on Office desktop or Office Online using a shared folder catalog.  
 
 
 > [!VIDEO https://www.youtube.com/embed/XXsAw2UUiQo]

--- a/docs/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins.md
+++ b/docs/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins.md
@@ -8,8 +8,10 @@ ms.date: 01/25/2018
 
 You can install an Office Add-in for testing in an Office client running on Windows by one of the following methods:
 
-- using a shared folder catalog to publish the manifest to a network file share (instructions below)
-- [running the "**npm run sideload**" command from the root of the add-in project folder.](sideload-office-addin-using-sideload-command.md) [!NOTE] this method only works for Excel, Word, and PowerPoint add-ins).
+- Using a shared folder catalog to publish the manifest to a network file share (instructions below)
+- [Running the "**npm run sideload**" command from the root of the add-in project folder.](sideload-office-addin-using-sideload-command.md) 
+>[!NOTE]
+>The "npm run sideload" method only works for Excel, Word, and PowerPoint add-ins).
 
 If you're not testing a Word, Excel, or PowerPoint add-in on Windows, see one of the following topics to sideload your add-in:
 

--- a/docs/testing/sideload-office-addin-using-sideload-command.md
+++ b/docs/testing/sideload-office-addin-using-sideload-command.md
@@ -1,0 +1,21 @@
+---
+title: Sideload Office Add-ins Using Sideload Command
+description: ''
+ms.date: 07/24/2018
+---
+
+# Sideload Office Add-ins for testing using the **sideload command**
+ (**NOTE**: this method only works for Excel, Word and PowerPoint add-ins).
+
+1. Open a command prompt as an administrator, and change directories to the root of your add-in project folder.
+
+2. Run the following command to start a local web server instance on port 3000 to serve up your add-in project: "**npm run start**"
+
+3. Open a second command prompt as an administrator, and change directories to the root of your add-in project folder.
+
+4. Run the following command to boot the host application (e.g. Excel, Word) and register your add-in in the host application: "**npm run sideload**"
+
+## See also
+
+- [Validate and troubleshoot issues with your manifest](troubleshoot-manifest.md)
+- [Publish your Office Add-in](../publish/publish.md)

--- a/docs/testing/sideload-office-addin-using-sideload-command.md
+++ b/docs/testing/sideload-office-addin-using-sideload-command.md
@@ -5,7 +5,8 @@ ms.date: 07/24/2018
 ---
 
 # Sideload Office Add-ins for testing using the **sideload command**
- [!NOTE] this method only works for Excel, Word, and PowerPoint add-ins).
+ >[!NOTE]
+>The "npm run sideload" method only works for Excel, Word, and PowerPoint add-ins).
 
 1. Open a command prompt as an administrator.
 

--- a/docs/testing/sideload-office-addin-using-sideload-command.md
+++ b/docs/testing/sideload-office-addin-using-sideload-command.md
@@ -1,19 +1,23 @@
 ---
-title: Sideload Office Add-ins Using Sideload Command
+title: Sideload Office Add-ins using the sideload command
 description: ''
 ms.date: 07/24/2018
 ---
 
 # Sideload Office Add-ins for testing using the **sideload command**
- (**NOTE**: this method only works for Excel, Word and PowerPoint add-ins).
+ [!NOTE] this method only works for Excel, Word, and PowerPoint add-ins).
 
-1. Open a command prompt as an administrator, and change directories to the root of your add-in project folder.
+1. Open a command prompt as an administrator.
 
-2. Run the following command to start a local web server instance on port 3000 to serve up your add-in project: "**npm run start**"
+2. Change directories to the root of your add-in project folder.
 
-3. Open a second command prompt as an administrator, and change directories to the root of your add-in project folder.
+3. Run the following command to start a local web server instance on port 3000 to serve up your add-in project: "**npm run start**"
 
-4. Run the following command to boot the host application (e.g. Excel, Word) and register your add-in in the host application: "**npm run sideload**"
+4. Open a second command prompt as an administrator.
+
+5. Change directories to the root of your add-in project folder.
+
+6. Run the following command to boot the host application (e.g. Excel, Word) and register your add-in in the host application: "**npm run sideload**"
 
 ## See also
 

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -362,6 +362,8 @@
       items:
       - name: Sideload Office Add-ins on Windows
         href: testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins.md
+      - name: Sideload Office Add-ins using the sideload command
+        href: testing/sideload-office-addin-using-sideload-command.md
       - name: Attach a debugger from the task pane
         href: testing/attach-debugger-from-task-pane.md
       - name: Debug using F12 developer tools


### PR DESCRIPTION
-Add new help topic for sideloading add-ins via "npm run sideload"
- Link to new help topic off existing create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins.md