### PR TITLE
Fixing links

### DIFF
--- a/docs/design/content-add-ins.md
+++ b/docs/design/content-add-ins.md
@@ -45,12 +45,12 @@ For Mac, the personality menu measures 26x26 pixels, but floats 8 pixels in from
 For a sample that implements a content add-in, see [Excel Content Add-in Humongous Insurance](https://github.com/OfficeDev/Excel-Content-Add-in-Humongous-Insurance) in GitHub.
 
 ## Support considerations
-- Check to see if your Office Add-in will work on a [specific Office host platform](https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-in-availability). 
-- Some content add-ins may require the user to "trust" the add-in to read and write to Excel or PowerPoint. You can declare what [level of permissions](https://docs.microsoft.com/en-us/office/dev/add-ins/develop/requesting-permissions-for-api-use-in-content-and-task-pane-add-ins) you want your user to have in the add-in's manifest.  
+- Check to see if your Office Add-in will work on a [specific Office host platform](https://docs.microsoft.com/office/dev/add-ins/overview/office-add-in-availability). 
+- Some content add-ins may require the user to "trust" the add-in to read and write to Excel or PowerPoint. You can declare what [level of permissions](https://docs.microsoft.com/office/dev/add-ins/develop/requesting-permissions-for-api-use-in-content-and-task-pane-add-ins) you want your user to have in the add-in's manifest.  
 - Content add-ins are supported in Excel and PowerPoint in Office 2013 version and later. If you open an add-in in a version of Office that doesn't support Office web add-ins, the add-in will be displayed as an image.
 
 ## See also
-- [Office Add-in host and platform availability](https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-in-availability)
-- [Office UI Fabric in Office Add-ins](https://docs.microsoft.com/en-us/office/dev/add-ins/design/office-ui-fabric) 
-- [UX design patterns for Office Add-ins](https://docs.microsoft.com/en-us/office/dev/add-ins/design/ux-design-patterns)
-- [Requesting permissions for API use in content and task pane add-ins](https://docs.microsoft.com/en-us/office/dev/add-ins/develop/requesting-permissions-for-api-use-in-content-and-task-pane-add-ins)
+- [Office Add-in host and platform availability](https://docs.microsoft.com/office/dev/add-ins/overview/office-add-in-availability)
+- [Office UI Fabric in Office Add-ins](https://docs.microsoft.com/office/dev/add-ins/design/office-ui-fabric) 
+- [UX design patterns for Office Add-ins](https://docs.microsoft.com/office/dev/add-ins/design/ux-design-patterns)
+- [Requesting permissions for API use in content and task pane add-ins](https://docs.microsoft.com/office/dev/add-ins/develop/requesting-permissions-for-api-use-in-content-and-task-pane-add-ins)

--- a/docs/design/content-add-ins.md
+++ b/docs/design/content-add-ins.md
@@ -52,5 +52,5 @@ For a sample that implements a content add-in, see [Excel Content Add-in Humongo
 ## See also
 - [Office Add-in host and platform availability](https://docs.microsoft.com/office/dev/add-ins/overview/office-add-in-availability)
 - [Office UI Fabric in Office Add-ins](https://docs.microsoft.com/office/dev/add-ins/design/office-ui-fabric) 
-- [UX design patterns for Office Add-ins](https://docs.microsoft.com/office/dev/add-ins/design/ux-design-patterns)
+- [UX design patterns for Office Add-ins](https://docs.microsoft.com/office/dev/add-ins/design/ux-design-pattern-templates)
 - [Requesting permissions for API use in content and task pane add-ins](https://docs.microsoft.com/office/dev/add-ins/develop/requesting-permissions-for-api-use-in-content-and-task-pane-add-ins)


### PR DESCRIPTION
Some links had the en-us localization already inserted. One link was pointing to a renamed file.