### PR TITLE
Adding 'manifest XML' here to clarify for React

### DIFF
--- a/docs/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins.md
+++ b/docs/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins.md
@@ -15,7 +15,8 @@ This article applies only to testing a Word, Excel, or PowerPoint add-ins on Win
 
 - [Sideload Office Add-ins in Office Online for testing](sideload-office-add-ins-for-testing.md)
 - [Sideload Office Add-ins on iPad and Mac for testing](sideload-an-office-add-in-on-ipad-and-mac.md)
-- [Sideload Outlook Add-ins for testing](../../../../outlook/add-insSideload Outlook Add-ins for testing)
+- [Sideload Outlook Add-ins for testing](../../../../outlook/add-ins/sideload-outlook-add-ins-for-testing)
+
 
 The following video walks you through the process of sideloading your add-in on Office desktop or Office Online using a shared folder catalog.  
 

--- a/docs/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins.md
+++ b/docs/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins.md
@@ -15,7 +15,7 @@ This article applies only to testing a Word, Excel, or PowerPoint add-ins on Win
 
 - [Sideload Office Add-ins in Office Online for testing](sideload-office-add-ins-for-testing.md)
 - [Sideload Office Add-ins on iPad and Mac for testing](sideload-an-office-add-in-on-ipad-and-mac.md)
-- [Sideload Outlook Add-ins for testing](../../../../outlook/add-ins/sideload-outlook-add-ins-for-testing)
+- [Sideload Outlook Add-ins for testing](../../../../outlook/add-ins/sideload-outlook-add-ins-for-testing.md)
 
 
 The following video walks you through the process of sideloading your add-in on Office desktop or Office Online using a shared folder catalog.  

--- a/docs/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins.md
+++ b/docs/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins.md
@@ -56,7 +56,7 @@ The following video walks you through the process of sideloading your add-in on 
 
 ## Sideload your add-in
 
-1. Put the manifest file of any add-in that you are testing in the shared folder catalog. Note that you deploy the web application itself to a web server. Be sure to specify the URL in the **SourceLocation** element of the manifest file.
+1. Put the manifest XML file of any add-in that you are testing in the shared folder catalog. Note that you deploy the web application itself to a web server. Be sure to specify the URL in the **SourceLocation** element of the manifest file.
 
     > [!IMPORTANT]
     > [!include[HTTPS guidance](../includes/https-guidance.md)]

--- a/docs/testing/sideload-office-addin-using-sideload-command.md
+++ b/docs/testing/sideload-office-addin-using-sideload-command.md
@@ -12,7 +12,7 @@ ms.date: 07/24/2018
 > 
 > - [Sideload Office Add-ins in Office Online for testing](sideload-office-add-ins-for-testing.md)
 > - [Sideload Office Add-ins on iPad and Mac for testing](sideload-an-office-add-in-on-ipad-and-mac.md)
-> - [Sideload Outlook Add-ins for testing](../../../../outlook/add-insSideload Outlook Add-ins for testing)
+> - [Sideload Outlook Add-ins for testing](../../../../outlook/add-ins/sideload-outlook-add-ins-for-testing)
 
 1. Open a command prompt as an administrator.
 


### PR DESCRIPTION
The React tutorial also creates a manifest.json file in a public folder which seemed like it should be the manifest file to me as a first go through of this. However, turns out they want you to select my-office-addin-manifest.xml, which I totally didn't even see because of the name. So, I tried to clarify here by stating explicitly that it's an XML file. I don't think this problem happens in the others, though I haven't done Vue or Angular. 