### PR TITLE
Fix typo

### DIFF
--- a/docs/excel/custom-functions-overview.md
+++ b/docs/excel/custom-functions-overview.md
@@ -16,9 +16,9 @@ function ADD42(a, b) {
 
 Custom functions are now available in Developer Preview on Windows, Mac, and Excel Online. Follow these steps to try them:
 
-1.  Install Office (build 9325 on Windows or 13.329 on Mac) and join the [Office Insider](https://products.office.com/office-insider) program. (Note that it isn't enough just to get the latest build; the feature will be disabled on any build until you join the Insider program)
-2.  Create an Excel Custom Functions Add-in project using [Yo Office](https://github.com/OfficeDev/generator-office), and follow the instructions in the [project README.md](https://github.com/OfficeDev/Excel-Custom-Functions/blob/master/README.md) to start the add-in in Excel, make changes in the code, and debug.
-3.  Type `=CONTOSO.ADD42(1,2)` into any cell, and press **Enter** to run the custom function.
+1. Install Office (build 9325 on Windows or 13.329 on Mac) and join the [Office Insider](https://products.office.com/office-insider) program. (Note that it isn't enough just to get the latest build; the feature will be disabled on any build until you join the Insider program)
+2. Create an Excel Custom Functions Add-in project using [Yo Office](https://github.com/OfficeDev/generator-office), and follow the instructions in the [project README.md](https://github.com/OfficeDev/Excel-Custom-Functions/blob/master/README.md) to start the add-in in Excel, make changes in the code, and debug.
+3. Type `=CONTOSO.ADD42(1,2)` into any cell, and press **Enter** to run the custom function.
 
 See the **Known Issues** section at the end of this article, which includes current limitations of custom functions and will be updated over time.
 

--- a/docs/excel/excel-add-ins-events.md
+++ b/docs/excel/excel-add-ins-events.md
@@ -139,7 +139,7 @@ Turning events off is useful when performance is critical or when editing multip
 
 The following code sample shows how to toggle events on and off.
 
-```ts
+```typescript
 async function toggleEvents() {
     await Excel.run(async (context) => {
         context.runtime.load("enableEvents");


### PR DESCRIPTION
Language specification should be 'typescript' not 'ts' for code samples. Also, minor update to second file to trigger update of doc in OPS.