### PR TITLE
Resolve broken link to API object model doc

### DIFF
--- a/docs/develop/understanding-the-javascript-api-for-office.md
+++ b/docs/develop/understanding-the-javascript-api-for-office.md
@@ -68,7 +68,7 @@ For more information, see [Office.initialize Event](https://dev.office.com/refer
 
 ## Office JavaScript API object model
 
-Once initialized, the add-in can interact with the host (e.g. Excel, Outlook). The [Office JavaScript API object model](/office-javascript-api-object-model.md)) page has more details on specific usage patterns. There is also detailed reference documentation for both [shared APIs](https://dev.office.com/reference/add-ins/javascript-api-for-office) and specific hosts.
+Once initialized, the add-in can interact with the host (e.g. Excel, Outlook). The [Office JavaScript API object model](office-javascript-api-object-model.md)) page has more details on specific usage patterns. There is also detailed reference documentation for both [shared APIs](https://dev.office.com/reference/add-ins/javascript-api-for-office) and specific hosts.
 
 ## API support matrix
 


### PR DESCRIPTION
## Problem

In the understanding doc, the link to the object model 404s. I realized this was because the leading slash linked to the incorrect relative location.

## Solution

Remove leading / from API object model docs

This should lead it to link to the correct place now, since it’s in the same location.