### PR TITLE
Referencing event toggling to performance page

### DIFF
--- a/docs/excel/excel-add-ins-events.md
+++ b/docs/excel/excel-add-ins-events.md
@@ -133,10 +133,10 @@ function remove() {
 > [!NOTE]
 > This feature is currently available only in public preview (beta). To use it, you must reference the beta library of the Office.js CDN: https://appsforoffice.microsoft.com/lib/beta/hosted/office.js.
 
-Some scenarios benefit from the performance boost given by turning off events. 
-Your app might never need to receive events, or it could ignore events while performing batch-edits of multiple entities. 
+The performance of an add-in may be improved by disabling events. 
+For example, your app might never need to receive events, or it could ignore events while performing batch-edits of multiple entities. 
 
-Events are turned on and off at the [runtime](https://docs.microsoft.com/javascript/api/excel/excel.runtime) level. 
+Events are enabled and disabled at the [runtime](https://docs.microsoft.com/javascript/api/excel/excel.runtime) level. 
 The `enableEvents` property determines if events are fired and their handlers are activated. 
 
 The following code sample shows how to toggle events on and off.

--- a/docs/excel/excel-add-ins-events.md
+++ b/docs/excel/excel-add-ins-events.md
@@ -136,7 +136,7 @@ function remove() {
 Some scenarios benefit from the performance boost given by turning off events. 
 Your app might never need to receive events, or it could ignore events while performing batch-edits of multiple entities. 
 
-Events are turned on and off at the [runtime](https://docs.microsoft.com/en-us/javascript/api/excel/excel.runtime?view=office-js) level. 
+Events are turned on and off at the [runtime](https://docs.microsoft.com/javascript/api/excel/excel.runtime) level. 
 The `enableEvents` property determines if events are fired and their handlers are activated. 
 
 The following code sample shows how to toggle events on and off.

--- a/docs/excel/excel-add-ins-events.md
+++ b/docs/excel/excel-add-ins-events.md
@@ -14,14 +14,14 @@ Each time certain types of changes occur in an Excel workbook, an event notifica
 
 | Event | Description | Supported objects |
 |:---------------|:-------------|:-----------|
-| `onAdded` | Event that occurs when an object is added. | [**WorksheetCollection**](https://dev.office.com/reference/add-ins/excel/worksheetcollection) |
-| `onDeleted` | Event that occurs when an object is deleted. | [**WorksheetCollection**](https://dev.office.com/reference/add-ins/excel/worksheetcollection) |
-| `onActivated` | Event that occurs when an object is activated. | [**WorksheetCollection**](https://dev.office.com/reference/add-ins/excel/worksheetcollection), [**Worksheet**](https://dev.office.com/reference/add-ins/excel/worksheet) |
-| `onDeactivated` | Event that occurs when an object is deactivated. | [**WorksheetCollection**](https://dev.office.com/reference/add-ins/excel/worksheetcollection), [**Worksheet**](https://dev.office.com/reference/add-ins/excel/worksheet) |
-| `onChanged` | Event that occurs when data within cells is changed. | [**Worksheet**](https://dev.office.com/reference/add-ins/excel/worksheet), [**Table**](https://dev.office.com/reference/add-ins/excel/table), [**TableCollection**](https://dev.office.com/reference/add-ins/excel/tablecollection) |
-| `onDataChanged` | Event that occurs when data or formatting within the binding is changed. | [**Binding**](https://dev.office.com/reference/add-ins/excel/binding) |
-| `onSelectionChanged` | Event that occurs when the active cell or selected range is changed. | [**Worksheet**](https://dev.office.com/reference/add-ins/excel/worksheet), [**Table**](https://dev.office.com/reference/add-ins/excel/table), [**Binding**](https://dev.office.com/reference/add-ins/excel/binding) |
-| `onSettingsChanged` | Event that occurs when the Settings in the document are changed. | [**SettingCollection**](https://dev.office.com/reference/add-ins/excel/settingcollection) |
+| `onAdded` | Event that occurs when an object is added. | [**WorksheetCollection**](https://docs.microsoft.com/javascript/api/excel/excel.worksheetcollection) |
+| `onDeleted` | Event that occurs when an object is deleted. | [**WorksheetCollection**](https://docs.microsoft.com/javascript/api/excel/excel.worksheetcollection) |
+| `onActivated` | Event that occurs when an object is activated. | [**WorksheetCollection**](https://docs.microsoft.com/javascript/api/excel/excel.worksheetcollection), [**Worksheet**](https://docs.microsoft.com/javascript/api/excel/excel.worksheet) |
+| `onDeactivated` | Event that occurs when an object is deactivated. | [**WorksheetCollection**](https://docs.microsoft.com/javascript/api/excel/excel.worksheetcollection), [**Worksheet**](https://docs.microsoft.com/javascript/api/excel/excel.worksheet) |
+| `onChanged` | Event that occurs when data within cells is changed. | [**Worksheet**](https://docs.microsoft.com/javascript/api/excel/excel.worksheet), [**Table**](https://docs.microsoft.com/javascript/api/excel/excel.table), [**TableCollection**](https://docs.microsoft.com/javascript/api/excel/excel.tablecollection) |
+| `onDataChanged` | Event that occurs when data or formatting within the binding is changed. | [**Binding**](https://docs.microsoft.com/javascript/api/excel/excel.binding) |
+| `onSelectionChanged` | Event that occurs when the active cell or selected range is changed. | [**Worksheet**](https://docs.microsoft.com/javascript/api/excel/excel.worksheet), [**Table**](https://docs.microsoft.com/javascript/api/excel/excel.table), [**Binding**](https://docs.microsoft.com/javascript/api/excel/excel.binding) |
+| `onSettingsChanged` | Event that occurs when the Settings in the document are changed. | [**SettingCollection**](https://docs.microsoft.com/javascript/api/excel/excel.settingcollection) |
 
 ## Preview (Beta) Events in Excel
 

--- a/docs/excel/excel-add-ins-events.md
+++ b/docs/excel/excel-add-ins-events.md
@@ -128,34 +128,6 @@ function remove() {
 }
 ```
 
-## Enable and disable events
-
-> [!NOTE]
-> This feature is currently available only in public preview (beta). To use it, you must reference the beta library of the Office.js CDN: https://appsforoffice.microsoft.com/lib/beta/hosted/office.js.
-
-Events are turned on and off at the [runtime](https://docs.microsoft.com/en-us/javascript/api/excel/excel.runtime?view=office-js) level. 
-The `enableEvents` property determines if events are fired and their handlers are activated. 
-Turning events off is useful when performance is critical or when editing multiple entities and want to avoid firing events until you have finished.
-
-The following code sample shows how to toggle events on and off.
-
-```typescript
-async function toggleEvents() {
-    await Excel.run(async (context) => {
-        context.runtime.load("enableEvents");
-        await context.sync();
-        const eventBoolean = !context.runtime.enableEvents
-        context.runtime.enableEvents = eventBoolean;
-        if (eventBoolean) {
-            console.log("Events are currently on.");
-        } else {
-            console.log("Events are currently off.");
-        }
-        await context.sync();
-    });
-}
-```
-
 ## See also
 
 - [Excel JavaScript API core concepts](excel-add-ins-core-concepts.md)

--- a/docs/excel/excel-add-ins-events.md
+++ b/docs/excel/excel-add-ins-events.md
@@ -142,18 +142,19 @@ The `enableEvents` property determines if events are fired and their handlers ar
 The following code sample shows how to toggle events on and off.
 
 ```js
-Excel.run(async (context) => {
+Excel.run(function (context) {
 	context.runtime.load("enableEvents");
-	await context.sync();
-	var eventBoolean = !context.runtime.enableEvents
-	context.runtime.enableEvents = eventBoolean;
-	if (eventBoolean) {
-		console.log("Events are currently on.");
-	} else {
-		console.log("Events are currently off.");
-	}
-	await context.sync();
-})
+	return context.sync()
+		.then(function () {
+			var eventBoolean = !context.runtime.enableEvents;
+			context.runtime.enableEvents = eventBoolean;
+			if (eventBoolean) {
+				console.log("Events are currently on.");
+			} else {
+				console.log("Events are currently off.");
+			}
+		}).then(context.sync);
+}).catch(errorHandlerFunction);
 ```
 
 ## See also

--- a/docs/excel/excel-add-ins-events.md
+++ b/docs/excel/excel-add-ins-events.md
@@ -128,6 +128,34 @@ function remove() {
 }
 ```
 
+## Enable and disable events
+
+> [!NOTE]
+> This feature is currently available only in public preview (beta). To use it, you must reference the beta library of the Office.js CDN: https://appsforoffice.microsoft.com/lib/beta/hosted/office.js.
+
+Some scenarios benefit from the performance boost given by turning off events. 
+Your app might never need to receive events, or it could ignore events while performing batch-edits of multiple entities. 
+
+Events are turned on and off at the [runtime](https://docs.microsoft.com/en-us/javascript/api/excel/excel.runtime?view=office-js) level. 
+The `enableEvents` property determines if events are fired and their handlers are activated. 
+
+The following code sample shows how to toggle events on and off.
+
+```js
+Excel.run(async (context) => {
+	context.runtime.load("enableEvents");
+	await context.sync();
+	var eventBoolean = !context.runtime.enableEvents
+	context.runtime.enableEvents = eventBoolean;
+	if (eventBoolean) {
+		console.log("Events are currently on.");
+	} else {
+		console.log("Events are currently off.");
+	}
+	await context.sync();
+})
+```
+
 ## See also
 
 - [Excel JavaScript API core concepts](excel-add-ins-core-concepts.md)

--- a/docs/excel/performance.md
+++ b/docs/excel/performance.md
@@ -162,8 +162,9 @@ Excel.run(async (ctx) => {
 > [!NOTE]
 > This feature is currently available only in public preview (beta). To use it, you must reference the beta library of the Office.js CDN: https://appsforoffice.microsoft.com/lib/beta/hosted/office.js.
 
-Some apps do not require handling events. This could be the pattern for the entire app or during batch-edits of multiple entities when events are only needed after the batch is done. 
-These scenarios benefit from the performance boost given by turning off events. 
+Some scenarios benefit from the performance boost given by turning off events. 
+Your app might never need to receive events, or it could ignore events while performing batch-edits of multiple entities. 
+
 Events are turned on and off at the [runtime](https://docs.microsoft.com/en-us/javascript/api/excel/excel.runtime?view=office-js) level. 
 The `enableEvents` property determines if events are fired and their handlers are activated. 
 

--- a/docs/excel/performance.md
+++ b/docs/excel/performance.md
@@ -159,10 +159,8 @@ Excel.run(async (ctx) => {
 
 ## Enable and disable events
 
-> [!NOTE]
-> This feature is currently available only in public preview (beta). To use it, you must reference the beta library of the Office.js CDN: https://appsforoffice.microsoft.com/lib/beta/hosted/office.js.
-
-You can disable events to improve performance. A code sample demonstrating this toggle is in the [Work with Events](excel-add-ins-events.md#enable-and-disable-events) article.
+You can disable events to improve performance. 
+A code sample showing how to enable and disable events is in the [Work with Events](excel-add-ins-events.md#enable-and-disable-events) article.
 
 ## See also
 

--- a/docs/excel/performance.md
+++ b/docs/excel/performance.md
@@ -66,8 +66,8 @@ object.load({ loadOption });
  
 _Where:_
  
-* `properties` is the list of properties to load, specified as comma-delimited strings or as an array of names. For more information, see the **load()** methods defined for objects in [Excel JavaScript API reference](https://dev.office.com/reference/add-ins/excel/excel-add-ins-reference-overview).
-* `loadOption` specifies an object that describes the selection, expansion, top, and skip options. See object load [options](https://dev.office.com/reference/add-ins/excel/loadoption) for details.
+* `properties` is the list of properties to load, specified as comma-delimited strings or as an array of names. For more information, see the **load()** methods defined for objects in [Excel JavaScript API reference](https://docs.microsoft.com/javascript/office/overview/excel-add-ins-reference-overview).
+* `loadOption` specifies an object that describes the selection, expansion, top, and skip options. See object load [options](https://docs.microsoft.com/javascript/api/office/officeextension.loadoption) for details.
 
 Please be aware that some of the “properties” under an object may have the same name as another object. For example, `format` is a property under range object, but `format` itself is an object as well. So, if you make a call such as `range.load("format")`, this is equivalent to `range.format.load()`, which is an empty load() call that can cause performance problems as outlined previously. To avoid this, your code should only load the “leaf nodes” in an object tree. 
 
@@ -75,7 +75,7 @@ Please be aware that some of the “properties” under an object may have the s
 
 If you are trying to perform an operation on a large number of cells (for example, setting the value of a huge range object) and you don't mind suspending the calculation in Excel temporarily while your operation finishes, we recommend that you suspend calculation until the next ```context.sync()``` is called.
 
-See [Application Object](https://dev.office.com/reference/add-ins/excel/application) reference documentation for information about how to use the ```suspendApiCalculationUntilNextSync()``` API to suspend and reactivate calculations in a very convenient way. The following code demonstrates how to suspend calculation temporarily:
+See [Application Object](https://docs.microsoft.com/javascript/api/excel/excel.application) reference documentation for information about how to use the ```suspendApiCalculationUntilNextSync()``` API to suspend and reactivate calculations in a very convenient way. The following code demonstrates how to suspend calculation temporarily:
 
 ```js
 Excel.run(async function(ctx) {
@@ -129,7 +129,7 @@ A common scenario where you can apply this approach is when setting different nu
 
 ## Importing data into tables
 
-When trying to import a huge amount of data directly into a [Table](https://dev.office.com/reference/add-ins/excel/table) object directly (for example, by using `TableRowCollection.add()`), you might experience slow performance. If you are trying to add a new table, you should fill in the data first by setting `range.values`, and then call `worksheet.tables.add()` to create a table over the range. If you are trying to write data into an existing table, write the data into a range object via `table.getDataBodyRange()`, and the table will expand automatically. 
+When trying to import a huge amount of data directly into a [Table](https://docs.microsoft.com/javascript/api/excel/excel.table) object directly (for example, by using `TableRowCollection.add()`), you might experience slow performance. If you are trying to add a new table, you should fill in the data first by setting `range.values`, and then call `worksheet.tables.add()` to create a table over the range. If you are trying to write data into an existing table, write the data into a range object via `table.getDataBodyRange()`, and the table will expand automatically. 
 
 Here is an example of this approach:
 
@@ -155,39 +155,18 @@ Excel.run(async (ctx) => {
 ```
 
 > [!NOTE]
-> You can conveniently convert a Table object to a Range object by using the [Table.convertToRange()](https://dev.office.com/reference/add-ins/excel/table#converttorange) method.
+> You can conveniently convert a Table object to a Range object by using the [Table.convertToRange()](https://docs.microsoft.com/javascript/api/excel/excel.table#converttorange--) method.
 
 ## Enable and disable events
 
 > [!NOTE]
 > This feature is currently available only in public preview (beta). To use it, you must reference the beta library of the Office.js CDN: https://appsforoffice.microsoft.com/lib/beta/hosted/office.js.
 
-Some scenarios benefit from the performance boost given by turning off events. 
-Your app might never need to receive events, or it could ignore events while performing batch-edits of multiple entities. 
-
-Events are turned on and off at the [runtime](https://docs.microsoft.com/en-us/javascript/api/excel/excel.runtime?view=office-js) level. 
-The `enableEvents` property determines if events are fired and their handlers are activated. 
-
-The following code sample shows how to toggle events on and off.
-
-```js
-Excel.run(async (context) => {
-	context.runtime.load("enableEvents");
-	await context.sync();
-	var eventBoolean = !context.runtime.enableEvents
-	context.runtime.enableEvents = eventBoolean;
-	if (eventBoolean) {
-		console.log("Events are currently on.");
-	} else {
-		console.log("Events are currently off.");
-	}
-	await context.sync();
-})
-```
+You can disable events to improve performance. A code sample demonstrating this toggle is in the [Work with Events](excel-add-ins-events.md#enable-and-disable-events) article.
 
 ## See also
 
 - [Excel JavaScript API core concepts](excel-add-ins-core-concepts.md)
 - [Excel JavaScript API advanced concepts](excel-add-ins-advanced-concepts.md)
 - [Excel JavaScript API Open Specification](https://github.com/OfficeDev/office-js-docs/tree/ExcelJs_OpenSpec)
-- [Worksheet Functions Object (JavaScript API for Excel)](https://dev.office.com/reference/add-ins/excel/functions)
+- [Worksheet Functions Object (JavaScript API for Excel)](https://docs.microsoft.com/javascript/api/excel/excel.functions)

--- a/docs/excel/performance.md
+++ b/docs/excel/performance.md
@@ -159,7 +159,7 @@ Excel.run(async (ctx) => {
 
 ## Enable and disable events
 
-You can disable events to improve performance. 
+Performance of an add-in may be improved by disabling events. 
 A code sample showing how to enable and disable events is in the [Work with Events](excel-add-ins-events.md#enable-and-disable-events) article.
 
 ## See also

--- a/docs/excel/performance.md
+++ b/docs/excel/performance.md
@@ -157,6 +157,33 @@ Excel.run(async (ctx) => {
 > [!NOTE]
 > You can conveniently convert a Table object to a Range object by using the [Table.convertToRange()](https://dev.office.com/reference/add-ins/excel/table#converttorange) method.
 
+## Enable and disable events
+
+> [!NOTE]
+> This feature is currently available only in public preview (beta). To use it, you must reference the beta library of the Office.js CDN: https://appsforoffice.microsoft.com/lib/beta/hosted/office.js.
+
+Some apps do not require handling events. This could be the pattern for the entire app or during batch-edits of multiple entities when events are only needed after the batch is done. 
+These scenarios benefit from the performance boost given by turning off events. 
+Events are turned on and off at the [runtime](https://docs.microsoft.com/en-us/javascript/api/excel/excel.runtime?view=office-js) level. 
+The `enableEvents` property determines if events are fired and their handlers are activated. 
+
+The following code sample shows how to toggle events on and off.
+
+```js
+Excel.run(async (context) => {
+	context.runtime.load("enableEvents");
+	await context.sync();
+	var eventBoolean = !context.runtime.enableEvents
+	context.runtime.enableEvents = eventBoolean;
+	if (eventBoolean) {
+		console.log("Events are currently on.");
+	} else {
+		console.log("Events are currently off.");
+	}
+	await context.sync();
+})
+```
+
 ## See also
 
 - [Excel JavaScript API core concepts](excel-add-ins-core-concepts.md)


### PR DESCRIPTION
The preview section on event toggling seems like a better fit for the advanced concept page on performance, rather than the basic page about events.

Also reworded the text to better match the new context.