### PR TITLE
Clarifying domain scope

### DIFF
--- a/docs/develop/dialog-api-in-office-add-ins.md
+++ b/docs/develop/dialog-api-in-office-add-ins.md
@@ -42,7 +42,10 @@ Office.context.ui.displayDialogAsync('https://myAddinDomain/myDialog.html');
 
 > [!NOTE]
 > - The URL uses the HTTP**S** protocol. This is mandatory for all pages loaded in a dialog box, not just the first page loaded.
-> - The domain is the same as the domain of the host page, which can be the page in a task pane or the [function file](https://docs.microsoft.com/javascript/office/manifest/functionfile?view=office-js) of an add-in command. This is required: the page, controller method, or other resource that is passed to the `displayDialogAsync` method must be in the same domain as the host page.
+> - The dialog resource's domain is the same as the domain of the host page, which can be the page in a task pane or the [function file](https://docs.microsoft.com/javascript/office/manifest/functionfile?view=office-js) of an add-in command. This is required: the page, controller method, or other resource that is passed to the `displayDialogAsync` method must be in the same domain as the host page.
+
+> [!IMPORTANT]
+> The host page and the resources of the dialog must have the same domain. Subdomains are not considered to be part of a domain for the purposes of `displayDialogAsync`.
 
 After the first page (or other resource) is loaded, a user can go to any website (or other resource) that uses HTTPS. You can also design the first page to immediately redirect to another site.
 

--- a/docs/develop/dialog-api-in-office-add-ins.md
+++ b/docs/develop/dialog-api-in-office-add-ins.md
@@ -45,7 +45,7 @@ Office.context.ui.displayDialogAsync('https://myAddinDomain/myDialog.html');
 > - The dialog resource's domain is the same as the domain of the host page, which can be the page in a task pane or the [function file](https://docs.microsoft.com/javascript/office/manifest/functionfile?view=office-js) of an add-in command. This is required: the page, controller method, or other resource that is passed to the `displayDialogAsync` method must be in the same domain as the host page.
 
 > [!IMPORTANT]
-> The host page and the resources of the dialog must have the same domain. Subdomains are not considered to be part of a domain for the purposes of `displayDialogAsync`.
+> The host page and the resources of the dialog must have the same full domain. If you attempt to pass `displayDialogAsync` a subdomain of the add-in's domain, it will not work. The full domain, including any subdomain, must match.
 
 After the first page (or other resource) is loaded, a user can go to any website (or other resource) that uses HTTPS. You can also design the first page to immediately redirect to another site.
 


### PR DESCRIPTION
Based on [this thread](https://github.com/OfficeDev/office-js/issues/73#issuecomment-370204722), we should clarify the scope of "same domain" to explicitly rule out subdomains.

This PR is in response to [Issue #107](https://github.com/OfficeDev/office-js-docs-pr/issues/107).

@Rick-Kirkham, if I misunderstood the intent, please let me know. Thanks!