### PR TITLE
Excel Core and Advanced Concepts TOC Restructure

### DIFF
--- a/docs/excel/excel-add-ins-advanced-concepts.md
+++ b/docs/excel/excel-add-ins-advanced-concepts.md
@@ -6,7 +6,7 @@ ms.date: 10/3/2018
 
 
 
-# Excel JavaScript API advanced concepts
+# Advanced Excel JavaScript add-in programming
 
 This article builds upon the information in [Excel JavaScript API core concepts](excel-add-ins-core-concepts.md) to describe some of the more advanced concepts that are essential to building complex add-ins for Excel 2016 or later.
 

--- a/docs/excel/excel-add-ins-advanced-concepts.md
+++ b/docs/excel/excel-add-ins-advanced-concepts.md
@@ -1,11 +1,11 @@
 ---
-title: Advanced Excel add-in programming
+title: Advanced programming concepts with the Excel JavaScript API
 description: ''
 ms.date: 10/03/2018
 ---
 
 
-# Advanced Excel JavaScript add-in programming
+# Advanced programming concepts with the Excel JavaScript API
 
 This article builds upon the information in [Fundamental Excel add-in programming](excel-add-ins-core-concepts.md) to describe some of the more advanced concepts that are essential to building complex add-ins for Excel 2016 or later.
 

--- a/docs/excel/excel-add-ins-advanced-concepts.md
+++ b/docs/excel/excel-add-ins-advanced-concepts.md
@@ -5,10 +5,9 @@ ms.date: 10/03/2018
 ---
 
 
-
 # Advanced Excel JavaScript add-in programming
 
-This article builds upon the information in [Excel JavaScript API core concepts](excel-add-ins-core-concepts.md) to describe some of the more advanced concepts that are essential to building complex add-ins for Excel 2016 or later.
+This article builds upon the information in [Fundamental Excel add-in programming](excel-add-ins-core-concepts.md) to describe some of the more advanced concepts that are essential to building complex add-ins for Excel 2016 or later.
 
 ## Office.js APIs for Excel
 
@@ -235,7 +234,7 @@ return context.sync()
 
 ## See also
  
-* [Beginner Excel add-in programming](excel-add-ins-core-concepts.md)
+* [Fundamental Excel add-in programming](excel-add-ins-core-concepts.md)
 * [Excel add-ins code samples](https://developer.microsoft.com/office/gallery/?filterBy=Samples,Excel)
 * [Excel JavaScript API performance optimization](performance.md)
 * [Excel JavaScript API reference](https://docs.microsoft.com/javascript/office/overview/excel-add-ins-reference-overview?view=office-js)

--- a/docs/excel/excel-add-ins-advanced-concepts.md
+++ b/docs/excel/excel-add-ins-advanced-concepts.md
@@ -7,7 +7,7 @@ ms.date: 10/03/2018
 
 # Advanced programming concepts with the Excel JavaScript API
 
-This article builds upon the information in [Fundamental Excel add-in programming](excel-add-ins-core-concepts.md) to describe some of the more advanced concepts that are essential to building complex add-ins for Excel 2016 or later.
+This article builds upon the information in [Fundamental programming concepts with the Excel JavaScript API](excel-add-ins-core-concepts.md) to describe some of the more advanced concepts that are essential to building complex add-ins for Excel 2016 or later.
 
 ## Office.js APIs for Excel
 
@@ -234,7 +234,7 @@ return context.sync()
 
 ## See also
  
-* [Fundamental Excel add-in programming](excel-add-ins-core-concepts.md)
+* [Fundamental programming concepts with the Excel JavaScript API](excel-add-ins-core-concepts.md)
 * [Excel add-ins code samples](https://developer.microsoft.com/office/gallery/?filterBy=Samples,Excel)
 * [Excel JavaScript API performance optimization](performance.md)
 * [Excel JavaScript API reference](https://docs.microsoft.com/javascript/office/overview/excel-add-ins-reference-overview?view=office-js)

--- a/docs/excel/excel-add-ins-advanced-concepts.md
+++ b/docs/excel/excel-add-ins-advanced-concepts.md
@@ -1,7 +1,7 @@
 ---
 title: Advanced Excel add-in programming
 description: ''
-ms.date: 10/3/2018
+ms.date: 10/03/2018
 ---
 
 

--- a/docs/excel/excel-add-ins-advanced-concepts.md
+++ b/docs/excel/excel-add-ins-advanced-concepts.md
@@ -1,7 +1,7 @@
 ---
-title: Excel JavaScript API advanced concepts
+title: Advanced Excel add-in programming
 description: ''
-ms.date: 1/18/2018
+ms.date: 10/3/2018
 ---
 
 
@@ -235,7 +235,7 @@ return context.sync()
 
 ## See also
  
-* [Excel JavaScript API core concepts](excel-add-ins-core-concepts.md)
+* [Beginner Excel add-in programming](excel-add-ins-core-concepts.md)
 * [Excel add-ins code samples](https://developer.microsoft.com/office/gallery/?filterBy=Samples,Excel)
 * [Excel JavaScript API performance optimization](performance.md)
 * [Excel JavaScript API reference](https://docs.microsoft.com/javascript/office/overview/excel-add-ins-reference-overview?view=office-js)

--- a/docs/excel/excel-add-ins-charts.md
+++ b/docs/excel/excel-add-ins-charts.md
@@ -186,4 +186,4 @@ Excel.run(function (context) {
 
 ## See also
 
-- [Excel JavaScript API core concepts](excel-add-ins-core-concepts.md)
+- [Fundamental programming concepts with the Excel JavaScript API](excel-add-ins-core-concepts.md)

--- a/docs/excel/excel-add-ins-core-concepts.md
+++ b/docs/excel/excel-add-ins-core-concepts.md
@@ -1,7 +1,7 @@
 ---
 title: Beginner Excel add-in programming
 description: Use the Excel JavaScript API to build add-ins for Excel.
-ms.date: 12/04/2017
+ms.date: 10/03/2018
 ---
 
 

--- a/docs/excel/excel-add-ins-core-concepts.md
+++ b/docs/excel/excel-add-ins-core-concepts.md
@@ -1,5 +1,5 @@
 ---
-title: Excel JavaScript API core concepts
+title: Beginner Excel add-in programming
 description: Use the Excel JavaScript API to build add-ins for Excel.
 ms.date: 12/04/2017
 ---
@@ -254,5 +254,6 @@ When an API error occurs, the API will return an **error** object that contains 
  
 * [Get started with Excel add-ins](excel-add-ins-get-started-overview.md)
 * [Excel add-ins code samples](https://developer.microsoft.com/office/gallery/?filterBy=Samples)
+* [Advanced Excel add-ins programming](excel-add-ins-advanced-concepts.md)
 * [Excel JavaScript API performance optimization](https://docs.microsoft.com/office/dev/add-ins/excel/performance)
 * [Excel JavaScript API reference](https://docs.microsoft.com/javascript/office/overview/excel-add-ins-reference-overview?view=office-js)

--- a/docs/excel/excel-add-ins-core-concepts.md
+++ b/docs/excel/excel-add-ins-core-concepts.md
@@ -5,7 +5,7 @@ ms.date: 12/04/2017
 ---
 
 
-# Excel JavaScript API core concepts
+# Beginner Excel JavaScript add-in programming
  
 This article describes how to use the [Excel JavaScript API](https://docs.microsoft.com/javascript/office/overview/excel-add-ins-reference-overview?view=office-js) to build add-ins for Excel 2016 or later. It introduces core concepts that are fundamental to using the API and provides guidance for performing specific tasks such as reading or writing to a large range, updating all cells in range, and more.
 

--- a/docs/excel/excel-add-ins-core-concepts.md
+++ b/docs/excel/excel-add-ins-core-concepts.md
@@ -254,6 +254,6 @@ When an API error occurs, the API will return an **error** object that contains 
  
 * [Get started with Excel add-ins](excel-add-ins-get-started-overview.md)
 * [Excel add-ins code samples](https://developer.microsoft.com/office/gallery/?filterBy=Samples)
-* [Advanced Excel add-ins programming](excel-add-ins-advanced-concepts.md)
+* [Advanced programming concepts with the Excel JavaScript API](excel-add-ins-advanced-concepts.md)
 * [Excel JavaScript API performance optimization](https://docs.microsoft.com/office/dev/add-ins/excel/performance)
 * [Excel JavaScript API reference](https://docs.microsoft.com/javascript/office/overview/excel-add-ins-reference-overview?view=office-js)

--- a/docs/excel/excel-add-ins-core-concepts.md
+++ b/docs/excel/excel-add-ins-core-concepts.md
@@ -1,11 +1,11 @@
 ---
-title: Beginner Excel add-in programming
+title: Fundamental Excel add-in programming
 description: Use the Excel JavaScript API to build add-ins for Excel.
 ms.date: 10/03/2018
 ---
 
 
-# Beginner Excel JavaScript add-in programming
+# Fundamental Excel JavaScript add-in programming
  
 This article describes how to use the [Excel JavaScript API](https://docs.microsoft.com/javascript/office/overview/excel-add-ins-reference-overview?view=office-js) to build add-ins for Excel 2016 or later. It introduces core concepts that are fundamental to using the API and provides guidance for performing specific tasks such as reading or writing to a large range, updating all cells in range, and more.
 

--- a/docs/excel/excel-add-ins-core-concepts.md
+++ b/docs/excel/excel-add-ins-core-concepts.md
@@ -1,11 +1,11 @@
 ---
-title: Fundamental Excel add-in programming
+title: Fundamental programming concepts with the Excel JavaScript API
 description: Use the Excel JavaScript API to build add-ins for Excel.
 ms.date: 10/03/2018
 ---
 
 
-# Fundamental Excel JavaScript add-in programming
+# Fundamental programming concepts with the Excel JavaScript API
  
 This article describes how to use the [Excel JavaScript API](https://docs.microsoft.com/javascript/office/overview/excel-add-ins-reference-overview?view=office-js) to build add-ins for Excel 2016 or later. It introduces core concepts that are fundamental to using the API and provides guidance for performing specific tasks such as reading or writing to a large range, updating all cells in range, and more.
 
@@ -113,7 +113,7 @@ Excel.run(function (context) {
  
 In the previous example, because `format/font` is not specified in the call to **myRange.load()**, the `format.font.color` property cannot be read.
 
-To optimize performance, you should explicitly specify the properties and relationships to load when using the **load()** method on an object, as covered in [Excel JavaScript API performance optimizations](performance.md). For more information about the **load()** method, see [Excel JavaScript API advanced concepts](excel-add-ins-advanced-concepts.md).
+To optimize performance, you should explicitly specify the properties and relationships to load when using the **load()** method on an object, as covered in [Excel JavaScript API performance optimizations](performance.md). For more information about the **load()** method, see [Advanced programming concepts with the Excel JavaScript API](excel-add-ins-advanced-concepts.md).
 
 ## null or blank property values
  

--- a/docs/excel/excel-add-ins-data-validation.md
+++ b/docs/excel/excel-add-ins-data-validation.md
@@ -218,7 +218,7 @@ It isn't necessary that the range you clear is exactly the same range as a range
 
 ## See also
 
-- [Excel JavaScript API core concepts](excel-add-ins-core-concepts.md)
+- [Fundamental programming concepts with the Excel JavaScript API](excel-add-ins-core-concepts.md)
 - [DataValidation Object (JavaScript API for Excel)](https://docs.microsoft.com/javascript/api/excel/excel.datavalidation)
 - [Range Object (JavaScript API for Excel)](https://docs.microsoft.com/javascript/api/excel/excel.range)
 

--- a/docs/excel/excel-add-ins-error-handling.md
+++ b/docs/excel/excel-add-ins-error-handling.md
@@ -10,7 +10,7 @@ ms.date: 12/04/2017
 When you build an add-in using the Excel JavaScript API, be sure to include error handling logic to account for runtime errors. Doing so is critical, due to the asynchronous nature of the API.
 
 > [!NOTE]
-> For more information about the **sync()** method and the asynchronous nature of Excel JavaScript API, see [Excel JavaScript API core concepts](excel-add-ins-core-concepts.md).
+> For more information about the **sync()** method and the asynchronous nature of Excel JavaScript API, see [Fundamental programming concepts with the Excel JavaScript API](excel-add-ins-core-concepts.md).
 
 ## Best practices
 
@@ -44,5 +44,5 @@ When an Excel JavaScript API request fails to run successfully, the API returns 
 
 ## See also
 
-- [Excel JavaScript API core concepts](excel-add-ins-core-concepts.md)
+- [Fundamental programming concepts with the Excel JavaScript API](excel-add-ins-core-concepts.md)
 - [OfficeExtension.Error object (JavaScript API for Excel)](https://docs.microsoft.com/javascript/api/office/officeextension.error?view=office-js)

--- a/docs/excel/excel-add-ins-events.md
+++ b/docs/excel/excel-add-ins-events.md
@@ -144,4 +144,4 @@ Excel.run(function (context) {
 
 ## See also
 
-- [Excel JavaScript API core concepts](excel-add-ins-core-concepts.md)
+- [Fundamental programming concepts with the Excel JavaScript API](excel-add-ins-core-concepts.md)

--- a/docs/excel/excel-add-ins-multiple-ranges.md
+++ b/docs/excel/excel-add-ins-multiple-ranges.md
@@ -264,6 +264,6 @@ Excel.run(function (context) {
 
 ## See also
 
-- [Excel JavaScript API core concepts](https://docs.microsoft.com/javascript/office/overview/excel-add-ins-reference-overview)
+- [Fundamental programming concepts with the Excel JavaScript API](https://docs.microsoft.com/javascript/office/overview/excel-add-ins-reference-overview)
 - [Range Object (JavaScript API for Excel)](https://docs.microsoft.com/javascript/api/excel/excel.range)
 - [RangeAreas Object (JavaScript API for Excel)](https://docs.microsoft.com/javascript/api/excel/excel.rangeareas) (This link may not work while the API is in preview. As an alternative, see [beta office.d.ts](https://appsforoffice.microsoft.com/lib/beta/hosted/office.d.ts).)

--- a/docs/excel/excel-add-ins-overview.md
+++ b/docs/excel/excel-add-ins-overview.md
@@ -107,5 +107,5 @@ Get started by [creating your first Excel add-in](excel-add-ins-get-started-over
 - [Office Add-ins platform overview](../overview/office-add-ins.md)
 - [Best practices for developing Office Add-ins](../concepts/add-in-development-best-practices.md)
 - [Design guidelines for Office Add-ins](../design/add-in-design.md)
-- [Excel JavaScript API core concepts](excel-add-ins-core-concepts.md)
+- [Fundamental programming concepts with the Excel JavaScript API](excel-add-ins-core-concepts.md)
 - [Excel JavaScript API reference](https://docs.microsoft.com/javascript/office/overview/excel-add-ins-reference-overview?view=office-js)

--- a/docs/excel/excel-add-ins-pivottables.md
+++ b/docs/excel/excel-add-ins-pivottables.md
@@ -304,5 +304,5 @@ await Excel.run(async (context) => {
 
 ## See also
 
-- [Excel JavaScript API core concepts](excel-add-ins-core-concepts.md)
+- [Fundamental programming concepts with the Excel JavaScript API](excel-add-ins-core-concepts.md)
 - [Excel JavaScript API Reference](https://docs.microsoft.com/javascript/api/excel)

--- a/docs/excel/excel-add-ins-ranges.md
+++ b/docs/excel/excel-add-ins-ranges.md
@@ -598,5 +598,5 @@ A transposed range is flipped along the main diagonal, so rows **1**, **2**, and
 
 ## See also
 
-- [Excel JavaScript API core concepts](excel-add-ins-core-concepts.md)
+- [Fundamental programming concepts with the Excel JavaScript API](excel-add-ins-core-concepts.md)
 

--- a/docs/excel/excel-add-ins-tables.md
+++ b/docs/excel/excel-add-ins-tables.md
@@ -444,5 +444,5 @@ Excel.run(function (context) {
 
 ## See also
 
-- [Excel JavaScript API core concepts](excel-add-ins-core-concepts.md)
+- [Fundamental programming concepts with the Excel JavaScript API](excel-add-ins-core-concepts.md)
 

--- a/docs/excel/excel-add-ins-worksheet-functions.md
+++ b/docs/excel/excel-add-ins-worksheet-functions.md
@@ -448,6 +448,6 @@ The following built-in Excel worksheet functions can be called using the Excel J
 
 ## See also
 
-- [Excel JavaScript API core concepts](excel-add-ins-core-concepts.md)
+- [Fundamental programming concepts with the Excel JavaScript API](excel-add-ins-core-concepts.md)
 - [Excel JavaScript API Open Specification](https://github.com/OfficeDev/office-js-docs/tree/ExcelJs_OpenSpec)
 - [Worksheet Functions Object (JavaScript API for Excel)](https://docs.microsoft.com/javascript/api/excel/excel.worksheet?view=office-js)

--- a/docs/excel/excel-add-ins-worksheets.md
+++ b/docs/excel/excel-add-ins-worksheets.md
@@ -277,5 +277,5 @@ For examples that show how to get a range within a worksheet, see [Work with Ran
 
 ## See also
 
-- [Excel JavaScript API core concepts](excel-add-ins-core-concepts.md)
+- [Fundamental programming concepts with the Excel JavaScript API](excel-add-ins-core-concepts.md)
 

--- a/docs/excel/performance.md
+++ b/docs/excel/performance.md
@@ -164,7 +164,7 @@ A code sample showing how to enable and disable events is in the [Work with Even
 
 ## See also
 
-- [Excel JavaScript API core concepts](excel-add-ins-core-concepts.md)
-- [Excel JavaScript API advanced concepts](excel-add-ins-advanced-concepts.md)
+- [Fundamental programming concepts with the Excel JavaScript API](excel-add-ins-core-concepts.md)
+- [Advanced programming concepts with the Excel JavaScript API](excel-add-ins-advanced-concepts.md)
 - [Excel JavaScript API Open Specification](https://github.com/OfficeDev/office-js-docs/tree/ExcelJs_OpenSpec)
 - [Worksheet Functions Object (JavaScript API for Excel)](https://docs.microsoft.com/javascript/api/excel/excel.functions)

--- a/docs/includes/file-get-started-excel-angular.md
+++ b/docs/includes/file-get-started-excel-angular.md
@@ -249,6 +249,6 @@ Congratulations, you've successfully created an Excel add-in using Angular! Next
 ## See also
 
 * [Excel add-in tutorial](../tutorials/excel-tutorial-create-table.md)
-* [Excel JavaScript API core concepts](../excel/excel-add-ins-core-concepts.md)
+* [Fundamental programming concepts with the Excel JavaScript API](../excel/excel-add-ins-core-concepts.md)
 * [Excel add-in code samples](https://developer.microsoft.com/office/gallery/?filterBy=Samples,Excel)
 * [Excel JavaScript API reference](https://docs.microsoft.com/javascript/office/overview/excel-add-ins-reference-overview?view=office-js)

--- a/docs/includes/file-get-started-excel-jquery.md
+++ b/docs/includes/file-get-started-excel-jquery.md
@@ -323,6 +323,6 @@ Congratulations, you've successfully created an Excel add-in using jQuery! Next,
 ## See also
 
 * [Excel add-in tutorial](../tutorials/excel-tutorial-create-table.md)
-* [Excel JavaScript API core concepts](../excel/excel-add-ins-core-concepts.md)
+* [Fundamental programming concepts with the Excel JavaScript API](../excel/excel-add-ins-core-concepts.md)
 * [Excel add-in code samples](https://developer.microsoft.com/office/gallery/?filterBy=Samples,Excel)
 * [Excel JavaScript API reference](https://docs.microsoft.com/javascript/office/overview/excel-add-ins-reference-overview?view=office-js)

--- a/docs/includes/file-get-started-excel-react.md
+++ b/docs/includes/file-get-started-excel-react.md
@@ -94,6 +94,6 @@ Congratulations, you've successfully created an Excel add-in using React! Next, 
 ## See also
 
 * [Excel add-in tutorial](../tutorials/excel-tutorial-create-table.md)
-* [Excel JavaScript API core concepts](../excel/excel-add-ins-core-concepts.md)
+* [Fundamental programming concepts with the Excel JavaScript API](../excel/excel-add-ins-core-concepts.md)
 * [Excel add-in code samples](https://developer.microsoft.com/office/gallery/?filterBy=Samples,Excel)
 * [Excel JavaScript API reference](https://docs.microsoft.com/javascript/office/overview/excel-add-ins-reference-overview?view=office-js)

--- a/docs/includes/file-get-started-excel-vue.md
+++ b/docs/includes/file-get-started-excel-vue.md
@@ -208,6 +208,6 @@ Congratulations, you've successfully created an Excel add-in using Vue! Next, le
 ## See also
 
 * [Excel add-in tutorial](../tutorials/excel-tutorial-create-table.md)
-* [Excel JavaScript API core concepts](../excel/excel-add-ins-core-concepts.md)
+* [Fundamental programming concepts with the Excel JavaScript API](../excel/excel-add-ins-core-concepts.md)
 * [Excel add-in code samples](https://developer.microsoft.com/office/gallery/?filterBy=Samples,Excel)
 * [Excel JavaScript API reference](https://docs.microsoft.com/javascript/office/overview/excel-add-ins-reference-overview?view=office-js)

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -230,10 +230,24 @@
     - name: Excel add-in tutorial
       href: tutorials/excel-tutorial.yml
       displayName: Excel
-    - name: Core concepts
-      href: excel/excel-add-ins-core-concepts.md
+    - name: Concepts
       displayName: Excel
       items:
+      - name: Beginner Excel add-in programming
+        href: excel/excel-add-ins-core-concepts.md
+        displayName: Excel
+      - name: Advanced Excel add-in programming
+        href: excel/excel-add-ins-advanced-concepts.md
+        displayName: Excel
+      - name: Calling built-in functions
+        href: excel/excel-add-ins-worksheet-functions.md
+        displayName: Excel
+      - name: Charts
+        href: excel/excel-add-ins-charts.md
+        displayName: Excel
+      - name: Coauthoring in Excel add-ins
+        href: excel/co-authoring-in-excel-add-ins.md
+        displayName: Excel
       - name: Custom functions
         items:
         - name: Custom functions overview
@@ -251,11 +265,17 @@
         - name: Custom functions best practices
           href: excel/custom-functions-best-practices.md
           displayName: Excel
-      - name: Charts
-        href: excel/excel-add-ins-charts.md
+      - name: Data validation
+        href: excel/excel-add-ins-data-validation.md
+        displayName: Excel
+      - name: Error handling
+        href: excel/excel-add-ins-error-handling.md
         displayName: Excel
       - name: Events
         href: excel/excel-add-ins-events.md
+        displayName: Excel
+      - name: Performance optimization
+        href: excel/performance.md
         displayName: Excel
       - name: PivotTables
         href: excel/excel-add-ins-pivottables.md
@@ -266,30 +286,11 @@
       - name: Tables
         href: excel/excel-add-ins-tables.md
         displayName: Excel
-      - name: Worksheets
-        href: excel/excel-add-ins-worksheets.md
-        displayName: Excel
-    - name: Advanced concepts
-      href: excel/excel-add-ins-advanced-concepts.md
-      displayName: Excel
-      items:
-      - name: Calling built-in functions
-        href: excel/excel-add-ins-worksheet-functions.md
-        displayName: Excel
-      - name: Coauthoring in Excel add-ins
-        href: excel/co-authoring-in-excel-add-ins.md
-        displayName: Excel
-      - name: Data validation
-        href: excel/excel-add-ins-data-validation.md
-        displayName: Excel
-      - name: Error handling
-        href: excel/excel-add-ins-error-handling.md
-        displayName: Excel
-      - name: Performance optimization
-        href: excel/performance.md
-        displayName: Excel
       - name: Working with multiple ranges
         href: excel/excel-add-ins-multiple-ranges.md
+        displayName: Excel
+      - name: Worksheets
+        href: excel/excel-add-ins-worksheets.md
         displayName: Excel
     - name: Excel JavaScript API overview
       href: https://docs.microsoft.com/javascript/office/overview/excel-add-ins-reference-overview?view=office-js

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -233,7 +233,7 @@
     - name: Concepts
       displayName: Excel
       items:
-      - name: Beginner Excel add-in programming
+      - name: Fundamental Excel add-in programming
         href: excel/excel-add-ins-core-concepts.md
         displayName: Excel
       - name: Advanced Excel add-in programming

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -233,10 +233,10 @@
     - name: Concepts
       displayName: Excel
       items:
-      - name: Fundamental Excel add-in programming
+      - name: Fundamental programming concepts
         href: excel/excel-add-ins-core-concepts.md
         displayName: Excel
-      - name: Advanced Excel add-in programming
+      - name: Advanced programming concepts
         href: excel/excel-add-ins-advanced-concepts.md
         displayName: Excel
       - name: Calling built-in functions


### PR DESCRIPTION
This takes the content out of the category nodes themselves and makes it into pages under the category. It also removes the distinction between "core" and "advanced" concepts.

I'm open to naming suggestion for the new pages. My rationale for the "* Excel add-in programming" is it stands out as a thing I, as a developer, should read.