### PR TITLE
adding info on alphanumeric characters and periods

### DIFF
--- a/docs/excel/custom-functions-best-practices.md
+++ b/docs/excel/custom-functions-best-practices.md
@@ -71,7 +71,7 @@ Keep in mind the following best practices when creating custom functions in your
 
 * In the JSON metadata file, specify the value of each `id` property in uppercase. Doing so makes it obvious which part of the `CustomFunctionMappings` statement in your JavaScript code corresponds to the `id` property in the JSON metadata file (provided that your function name uses camelCase, as recommended earlier).
 
-* It is required that the value of each `id` property contain alphanumeric characters. `id` property values *may* also contain periods. 
+* In the JSON metadata file, ensure that the value of each `id` property contains only alphanumeric characters and periods. 
 
 * In the JSON metadata file, ensure that the value of each `id` property is unique within the scope of the file. That is, no two function objects in the metadata file should have the same `id` value. Additionally, do not specify two `id` values in the metadata file that only differ by case. For example, do not define one function object with an `id` value of **add** and another function object with an `id` value of **ADD**.
 

--- a/docs/excel/custom-functions-best-practices.md
+++ b/docs/excel/custom-functions-best-practices.md
@@ -71,6 +71,8 @@ Keep in mind the following best practices when creating custom functions in your
 
 * In the JSON metadata file, specify the value of each `id` property in uppercase. Doing so makes it obvious which part of the `CustomFunctionMappings` statement in your JavaScript code corresponds to the `id` property in the JSON metadata file (provided that your function name uses camelCase, as recommended earlier).
 
+* It is required that the value of each `id` property contain alphanumeric characters. `id` values *may* also contain periods. 
+
 * In the JSON metadata file, ensure that the value of each `id` property is unique within the scope of the file. That is, no two function objects in the metadata file should have the same `id` value. Additionally, do not specify two `id` values in the metadata file that only differ by case. For example, do not define one function object with an `id` value of **add** and another function object with an `id` value of **ADD**.
 
 * Do not change the value of an `id` property in the JSON metadata file after it's been mapped to a corresponding JavaScript function name. You can change the function name that end users see in Excel by updating the `name` property within the JSON metadata file, but you should never change the value of an `id` property after it's been established.

--- a/docs/excel/custom-functions-best-practices.md
+++ b/docs/excel/custom-functions-best-practices.md
@@ -71,7 +71,7 @@ Keep in mind the following best practices when creating custom functions in your
 
 * In the JSON metadata file, specify the value of each `id` property in uppercase. Doing so makes it obvious which part of the `CustomFunctionMappings` statement in your JavaScript code corresponds to the `id` property in the JSON metadata file (provided that your function name uses camelCase, as recommended earlier).
 
-* It is required that the value of each `id` property contain alphanumeric characters. `id` values *may* also contain periods. 
+* It is required that the value of each `id` property contain alphanumeric characters. `id` property values *may* also contain periods. 
 
 * In the JSON metadata file, ensure that the value of each `id` property is unique within the scope of the file. That is, no two function objects in the metadata file should have the same `id` value. Additionally, do not specify two `id` values in the metadata file that only differ by case. For example, do not define one function object with an `id` value of **add** and another function object with an `id` value of **ADD**.
 

--- a/docs/excel/custom-functions-json.md
+++ b/docs/excel/custom-functions-json.md
@@ -108,7 +108,7 @@ The `functions` property is an array of custom function objects. The following t
 |:-----|:-----|:-----|:-----|
 |  `description`  |  string  |  No  |  The description of the function that end users see in Excel. For example, **Converts a Celsius value to Fahrenheit**. |
 |  `helpUrl`  |  string  |   No  |  URL that provides information about the function. (It is displayed in a task pane.) For example, **http://contoso.com/help/convertcelsiustofahrenheit.html**. |
-| `id`     | string | Yes | A unique ID for the function. This ID should not be changed after it is set. |
+| `id`     | string | Yes | A unique ID for the function. This ID should not be changed after it is set and should only contain alphanumeric characters and periods. |
 |  `name`  |  string  |  Yes  |  The name of the function that end users see in Excel. In Excel, this function name will be prefixed by the custom functions namespace that's specified in the XML manifest file. |
 |  `options`  |  object  |  No  |  Enables you to customize some aspects of how and when Excel executes the function. See [options object](#options-object) for details. |
 |  `parameters`  |  array  |  Yes  |  Array that defines the input parameters for the function. See [parameters array](#parameters-array)  for details. |

--- a/docs/excel/custom-functions-json.md
+++ b/docs/excel/custom-functions-json.md
@@ -108,7 +108,7 @@ The `functions` property is an array of custom function objects. The following t
 |:-----|:-----|:-----|:-----|
 |  `description`  |  string  |  No  |  The description of the function that end users see in Excel. For example, **Converts a Celsius value to Fahrenheit**. |
 |  `helpUrl`  |  string  |   No  |  URL that provides information about the function. (It is displayed in a task pane.) For example, **http://contoso.com/help/convertcelsiustofahrenheit.html**. |
-| `id`     | string | Yes | A unique ID for the function. This ID should not be changed after it is set and should only contain alphanumeric characters and/or periods. |
+| `id`     | string | Yes | A unique ID for the function. This ID can only contain alphanumeric characters and periods and should not be changed after it is set. |
 |  `name`  |  string  |  Yes  |  The name of the function that end users see in Excel. In Excel, this function name will be prefixed by the custom functions namespace that's specified in the XML manifest file. |
 |  `options`  |  object  |  No  |  Enables you to customize some aspects of how and when Excel executes the function. See [options object](#options-object) for details. |
 |  `parameters`  |  array  |  Yes  |  Array that defines the input parameters for the function. See [parameters array](#parameters-array)  for details. |

--- a/docs/excel/custom-functions-json.md
+++ b/docs/excel/custom-functions-json.md
@@ -108,7 +108,7 @@ The `functions` property is an array of custom function objects. The following t
 |:-----|:-----|:-----|:-----|
 |  `description`  |  string  |  No  |  The description of the function that end users see in Excel. For example, **Converts a Celsius value to Fahrenheit**. |
 |  `helpUrl`  |  string  |   No  |  URL that provides information about the function. (It is displayed in a task pane.) For example, **http://contoso.com/help/convertcelsiustofahrenheit.html**. |
-| `id`     | string | Yes | A unique ID for the function. This ID should not be changed after it is set and should only contain alphanumeric characters and periods. |
+| `id`     | string | Yes | A unique ID for the function. This ID should not be changed after it is set and should only contain alphanumeric characters and/or periods. |
 |  `name`  |  string  |  Yes  |  The name of the function that end users see in Excel. In Excel, this function name will be prefixed by the custom functions namespace that's specified in the XML manifest file. |
 |  `options`  |  object  |  No  |  Enables you to customize some aspects of how and when Excel executes the function. See [options object](#options-object) for details. |
 |  `parameters`  |  array  |  Yes  |  Array that defines the input parameters for the function. See [parameters array](#parameters-array)  for details. |

--- a/docs/excel/custom-functions-overview.md
+++ b/docs/excel/custom-functions-overview.md
@@ -133,7 +133,7 @@ The following table lists the properties that are typically present in the JSON 
 
 | Property 	| Description |
 |---------|---------|
-| `id` | A unique ID for the function. This ID should not be changed after it is set. |
+| `id` | A unique ID for the function. This ID should not be changed after it is set and should only contain alphanumeric characters and periods. |
 | `name` | Name of the function that the end user sees in Excel. In Excel, this function name will be prefixed by the custom functions namespace that's specified in the [XML manifest file](#manifest-file). |
 | `helpUrl`	| URL for the page that is shown when a user requests help. |
 | `description`	| Describes what the function does. This value appears as a tooltip when the function is the selected item in the autocomplete menu within Excel. |
@@ -179,7 +179,7 @@ The XML manifest file for an add-in that defines custom functions (**./manifest.
 ```
 
 > [!NOTE]
-> Functions in Excel are prepended by the namespace specified in your XML manifest file. A function's namespace comes before the function name and they are separated by a period. For example, to call the function `ADD42` in the cell of an Excel worksheet, you would type `=CONTOSO.ADD42`, because CONTOSO is the namespace and `ADD42` is the name of the function specified in the JSON file. The namespace is intended to be used as an identifier for your company or the add-in. 
+> Functions in Excel are prepended by the namespace specified in your XML manifest file. A function's namespace comes before the function name and they are separated by a period. For example, to call the function `ADD42` in the cell of an Excel worksheet, you would type `=CONTOSO.ADD42`, because CONTOSO is the namespace and `ADD42` is the name of the function specified in the JSON file. The namespace is intended to be used as an identifier for your company or the add-in. A namespace may only contain alphanumeric characters and periods.
 
 ## Functions that return data from external sources
 

--- a/docs/excel/custom-functions-overview.md
+++ b/docs/excel/custom-functions-overview.md
@@ -172,7 +172,7 @@ The XML manifest file for an add-in that defines custom functions (**./manifest.
             <bt:Url id="HTML-URL" DefaultValue="http://127.0.0.1:8080/index.html" /> <!--specifies the location of your HTML file-->
         </bt:Urls>
         <bt:ShortStrings>
-            <bt:String id="namespace" DefaultValue="CONTOSO" /> <!--specifies the namespace that will be prepended to a function's name when it is called in Excel. -->
+            <bt:String id="namespace" DefaultValue="CONTOSO" /> <!--specifies the namespace that will be prepended to a function's name when it is called in Excel. Can only contain alphanumeric characters and/or periods.-->
         </bt:ShortStrings>
     </Resources>
 </VersionOverrides>

--- a/docs/excel/custom-functions-overview.md
+++ b/docs/excel/custom-functions-overview.md
@@ -179,7 +179,7 @@ The XML manifest file for an add-in that defines custom functions (**./manifest.
 ```
 
 > [!NOTE]
-> Functions in Excel are prepended by the namespace specified in your XML manifest file. A function's namespace comes before the function name and they are separated by a period. For example, to call the function `ADD42` in the cell of an Excel worksheet, you would type `=CONTOSO.ADD42`, because CONTOSO is the namespace and `ADD42` is the name of the function specified in the JSON file. The namespace is intended to be used as an identifier for your company or the add-in. A namespace may only contain alphanumeric characters and periods.
+> Functions in Excel are prepended by the namespace specified in your XML manifest file. A function's namespace comes before the function name and they are separated by a period. For example, to call the function `ADD42` in the cell of an Excel worksheet, you would type `=CONTOSO.ADD42`, because CONTOSO is the namespace and `ADD42` is the name of the function specified in the JSON file. The namespace is intended to be used as an identifier for your company or the add-in. A namespace may only contain alphanumeric characters and/or periods.
 
 ## Functions that return data from external sources
 

--- a/docs/excel/custom-functions-overview.md
+++ b/docs/excel/custom-functions-overview.md
@@ -179,7 +179,7 @@ The XML manifest file for an add-in that defines custom functions (**./manifest.
 ```
 
 > [!NOTE]
-> Functions in Excel are prepended by the namespace specified in your XML manifest file. A function's namespace comes before the function name and they are separated by a period. For example, to call the function `ADD42` in the cell of an Excel worksheet, you would type `=CONTOSO.ADD42`, because CONTOSO is the namespace and `ADD42` is the name of the function specified in the JSON file. The namespace is intended to be used as an identifier for your company or the add-in. A namespace may only contain alphanumeric characters and/or periods.
+> Functions in Excel are prepended by the namespace specified in your XML manifest file. A function's namespace comes before the function name and they are separated by a period. For example, to call the function `ADD42` in the cell of an Excel worksheet, you would type `=CONTOSO.ADD42`, because `CONTOSO` is the namespace and `ADD42` is the name of the function specified in the JSON file. The namespace is intended to be used as an identifier for your company or the add-in. A namespace can only contain alphanumeric characters and periods.
 
 ## Functions that return data from external sources
 

--- a/docs/excel/custom-functions-overview.md
+++ b/docs/excel/custom-functions-overview.md
@@ -133,7 +133,7 @@ The following table lists the properties that are typically present in the JSON 
 
 | Property 	| Description |
 |---------|---------|
-| `id` | A unique ID for the function. This ID should not be changed after it is set and should only contain alphanumeric characters and periods. |
+| `id` | A unique ID for the function. This ID should not be changed after it is set and should only contain alphanumeric characters and/or periods. |
 | `name` | Name of the function that the end user sees in Excel. In Excel, this function name will be prefixed by the custom functions namespace that's specified in the [XML manifest file](#manifest-file). |
 | `helpUrl`	| URL for the page that is shown when a user requests help. |
 | `description`	| Describes what the function does. This value appears as a tooltip when the function is the selected item in the autocomplete menu within Excel. |

--- a/docs/excel/custom-functions-overview.md
+++ b/docs/excel/custom-functions-overview.md
@@ -133,7 +133,7 @@ The following table lists the properties that are typically present in the JSON 
 
 | Property 	| Description |
 |---------|---------|
-| `id` | A unique ID for the function. This ID should not be changed after it is set and should only contain alphanumeric characters and/or periods. |
+| `id` | A unique ID for the function. This ID can only contain alphanumeric characters and periods and should not be changed after it is set. |
 | `name` | Name of the function that the end user sees in Excel. In Excel, this function name will be prefixed by the custom functions namespace that's specified in the [XML manifest file](#manifest-file). |
 | `helpUrl`	| URL for the page that is shown when a user requests help. |
 | `description`	| Describes what the function does. This value appears as a tooltip when the function is the selected item in the autocomplete menu within Excel. |
@@ -172,7 +172,7 @@ The XML manifest file for an add-in that defines custom functions (**./manifest.
             <bt:Url id="HTML-URL" DefaultValue="http://127.0.0.1:8080/index.html" /> <!--specifies the location of your HTML file-->
         </bt:Urls>
         <bt:ShortStrings>
-            <bt:String id="namespace" DefaultValue="CONTOSO" /> <!--specifies the namespace that will be prepended to a function's name when it is called in Excel. Can only contain alphanumeric characters and/or periods.-->
+            <bt:String id="namespace" DefaultValue="CONTOSO" /> <!--specifies the namespace that will be prepended to a function's name when it is called in Excel. Can only contain alphanumeric characters and periods.-->
         </bt:ShortStrings>
     </Resources>
 </VersionOverrides>


### PR DESCRIPTION
Updating to reflect current info on namespace and function id. They now can only contain alphanumeric characters and/or periods. 