### PR TITLE
Moving error list to error handling article

### DIFF
--- a/docs/excel/excel-add-ins-core-concepts.md
+++ b/docs/excel/excel-add-ins-core-concepts.md
@@ -1,7 +1,7 @@
 ---
 title: Fundamental programming concepts with the Excel JavaScript API
 description: Use the Excel JavaScript API to build add-ins for Excel.
-ms.date: 10/03/2018
+ms.date: 10/16/2018
 ---
 
 
@@ -224,31 +224,9 @@ Excel.run(function (context) {
 });
 ```
  
-## Error messages
- 
-When an API error occurs, the API will return an **error** object that contains a code and a message. The following table defines a list of errors that the API may return.
- 
-|error.code | error.message |
-|:----------|:--------------|
-|InvalidArgument |The argument is invalid or missing or has an incorrect format.|
-|InvalidRequest  |Cannot process the request.|
-|InvalidReference|This reference is not valid for the current operation.|
-|InvalidBinding  |This object binding is no longer valid due to previous updates.|
-|InvalidSelection|The current selection is invalid for this operation.|
-|Unauthenticated |Required authentication information is either missing or invalid.|
-|AccessDenied |You cannot perform the requested operation.|
-|ItemNotFound |The requested resource doesn't exist.|
-|ActivityLimitReached|Activity limit has been reached.|
-|GeneralException|There was an internal error while processing the request.|
-|NotImplemented  |The requested feature isn't implemented.|
-|ServiceNotAvailable|The service is unavailable.|
-|Conflict              |Request could not be processed because of a conflict.|
-|ItemAlreadyExists|The resource being created already exists.|
-|UnsupportedOperation|The operation being attempted is not supported.|
-|RequestAborted|The request was aborted during run time.|
-|ApiNotAvailable|The requested API is not available.|
-|InsertDeleteConflict|The insert or delete operation attempted resulted in a conflict.|
-|InvalidOperation|The operation attempted is invalid on the object.|
+##Handle errors
+
+When an API error occurs, the API will return an **error** object that contains a code and a message. For detailed information about error handling, including a list of the errors that the API may return, see [Error handling](excel-add-ins-error-handling.md).
  
 ## See also
  

--- a/docs/excel/excel-add-ins-core-concepts.md
+++ b/docs/excel/excel-add-ins-core-concepts.md
@@ -226,7 +226,7 @@ Excel.run(function (context) {
  
 ##Handle errors
 
-When an API error occurs, the API will return an **error** object that contains a code and a message. For detailed information about error handling, including a list of the errors that the API may return, see [Error handling](excel-add-ins-error-handling.md).
+When an API error occurs, the API returns an **error** object that contains a code and a message. For detailed information about error handling, including a list of API errors, see [Error handling](excel-add-ins-error-handling.md).
  
 ## See also
  

--- a/docs/excel/excel-add-ins-error-handling.md
+++ b/docs/excel/excel-add-ins-error-handling.md
@@ -1,7 +1,7 @@
 ---
 title: Error handling
 description: ''
-ms.date: 12/04/2017
+ms.date: 10/16/2018
 ---
 
 
@@ -41,6 +41,32 @@ When an Excel JavaScript API request fails to run successfully, the API returns 
 
 > [!NOTE]
 > If you use `console.log()` to print error messages to the console, those messages will only be visible on the server. End users will not see those error messages in the add-in taskpane or anywhere in the host application.
+
+## Error Messages
+
+The following table defines a list of errors that the API may return.
+
+|error.code | error.message |
+|:----------|:--------------|
+|InvalidArgument |The argument is invalid or missing or has an incorrect format.|
+|InvalidRequest  |Cannot process the request.|
+|InvalidReference|This reference is not valid for the current operation.|
+|InvalidBinding  |This object binding is no longer valid due to previous updates.|
+|InvalidSelection|The current selection is invalid for this operation.|
+|Unauthenticated |Required authentication information is either missing or invalid.|
+|AccessDenied |You cannot perform the requested operation.|
+|ItemNotFound |The requested resource doesn't exist.|
+|ActivityLimitReached|Activity limit has been reached.|
+|GeneralException|There was an internal error while processing the request.|
+|NotImplemented  |The requested feature isn't implemented.|
+|ServiceNotAvailable|The service is unavailable.|
+|Conflict|Request could not be processed because of a conflict.|
+|ItemAlreadyExists|The resource being created already exists.|
+|UnsupportedOperation|The operation being attempted is not supported.|
+|RequestAborted|The request was aborted during run time.|
+|ApiNotAvailable|The requested API is not available.|
+|InsertDeleteConflict|The insert or delete operation attempted resulted in a conflict.|
+|InvalidOperation|The operation attempted is invalid on the object.|
 
 ## See also
 

--- a/docs/excel/excel-add-ins-error-handling.md
+++ b/docs/excel/excel-add-ins-error-handling.md
@@ -44,7 +44,7 @@ When an Excel JavaScript API request fails to run successfully, the API returns 
 
 ## Error Messages
 
-The following table defines a list of errors that the API may return.
+The following table is a list of errors the API return.
 
 |error.code | error.message |
 |:----------|:--------------|


### PR DESCRIPTION
This change helps consolidate the Fundamentals article by moving a long table of error codes to the error handling article. 