### PR TITLE
Add Project and Access details

### DIFF
--- a/docs/overview/office-add-in-availability.md
+++ b/docs/overview/office-add-in-availability.md
@@ -698,21 +698,21 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     <th><a href="https://docs.microsoft.com/office/dev/add-ins/reference/requirement-sets/office-add-in-requirement-sets"><b>Common APIs</b></a></th>
   </tr>
   <tr>
-    <td>Office for Windows 2013</td>
+    <td>Office 2013 for Windows</td>
     <td> - Taskpane</td>
     <td> - <a href="https://docs.microsoft.com/office/dev/add-ins/reference/requirement-sets/dialog-api-requirement-sets">DialogApi 1.1</a></td>
     <td> - Selection<br>
          - TextCoercion</td>
   </tr>
   <tr>
-    <td>Office for Windows 2016</td>
+    <td>Office 2016 for Windows</td>
     <td> - Taskpane</td>
     <td> - <a href="https://docs.microsoft.com/office/dev/add-ins/reference/requirement-sets/dialog-api-requirement-sets">DialogApi 1.1</a></td>
     <td> - Selection<br>
          - TextCoercion</td>
   </tr>
   <tr>
-    <td>Office for Windows 2019</td>
+    <td>Office 2019 for Windows</td>
     <td> - Taskpane</td>
     <td> - <a href="https://docs.microsoft.com/office/dev/add-ins/reference/requirement-sets/dialog-api-requirement-sets">DialogApi 1.1</a></td>
     <td> - Selection<br>

--- a/docs/overview/office-add-in-availability.md
+++ b/docs/overview/office-add-in-availability.md
@@ -1,14 +1,14 @@
 ---
 title: Office Add-in host and platform availability
 description: Supported requirement sets for Excel, Word, Outlook, PowerPoint, and OneNote.
-ms.date: 10/03/2018
+ms.date: 11/07/2018
 ---
 
 # Office Add-in host and platform availability
 
 To work as expected, your Office Add-in might depend on a specific Office host, a requirement set, an API member, or a version of the API. The following tables contain the available platform, extension points, API requirement sets, and common API requirement sets that are currently supported for each Office application.
 
-If a table cell contains an asterisk ( * ), that means we’re working on it. For requirement sets for Project or Access, see [Office common requirement sets](https://docs.microsoft.com/office/dev/add-ins/reference/requirement-sets/office-add-in-requirement-sets).  
+If a table cell contains an asterisk ( * ), that means we’re working on it.
 
 > [!NOTE]
 > The build number for Office 2016 installed via MSI is 16.0.4266.1001. This version only contains the ExcelApi 1.1, WordApi 1.1, and common API requirement sets.
@@ -343,7 +343,6 @@ If a table cell contains an asterisk ( * ), that means we’re working on it. Fo
     <th>Extension points</th>
     <th>API requirement sets</th>
     <th><a href="https://docs.microsoft.com/office/dev/add-ins/reference/requirement-sets/office-add-in-requirement-sets"><b>Common APIs</b></a></th>
-  </tr> 
   </tr>
   <tr>
     <td>Office Online</td>
@@ -548,7 +547,6 @@ If a table cell contains an asterisk ( * ), that means we’re working on it. Fo
     <th>Extension points</th>
     <th>API requirement sets</th>
     <th><a href="https://docs.microsoft.com/office/dev/add-ins/reference/requirement-sets/office-add-in-requirement-sets"><b>Common APIs</b></a></th>
-  </tr> 
   </tr>
   <tr>
     <td>Office Online</td>
@@ -674,7 +672,6 @@ If a table cell contains an asterisk ( * ), that means we’re working on it. Fo
     <th>Extension points</th>
     <th>API requirement sets</th>
     <th><a href="https://docs.microsoft.com/office/dev/add-ins/reference/requirement-sets/office-add-in-requirement-sets"><b>Common APIs</b></a></th>
-  </tr> 
   </tr>
   <tr>
     <td>Office Online</td>
@@ -688,6 +685,63 @@ If a table cell contains an asterisk ( * ), that means we’re working on it. Fo
          - ImageCoercion<br>
          - Settings<br>
          - TextCoercion</td>
+  </tr>
+</table>
+
+<br/>
+
+## Project
+
+<table style="width:80%">
+  <tr>
+    <th>Platform</th>
+    <th>Extension points</th>
+    <th>API requirement sets</th>
+    <th><a href="https://docs.microsoft.com/office/dev/add-ins/reference/requirement-sets/office-add-in-requirement-sets"><b>Common APIs</b></a></th>
+  </tr>
+  <tr>
+    <td>Office for Windows 2013</td>
+    <td> - Taskpane</td>
+    <td> - <a href="https://docs.microsoft.com/office/dev/add-ins/reference/requirement-sets/dialog-api-requirement-sets">DialogApi 1.1</a></td>
+    <td> - Selection<br>
+         - TextCoercion</td>
+  </tr>
+  <tr>
+    <td>Office for Windows 2016</td>
+    <td> - Taskpane</td>
+    <td> - <a href="https://docs.microsoft.com/office/dev/add-ins/reference/requirement-sets/dialog-api-requirement-sets">DialogApi 1.1</a></td>
+    <td> - Selection<br>
+         - TextCoercion</td>
+  </tr>
+  <tr>
+    <td>Office for Windows 2019</td>
+    <td> - Taskpane</td>
+    <td> - <a href="https://docs.microsoft.com/office/dev/add-ins/reference/requirement-sets/dialog-api-requirement-sets">DialogApi 1.1</a></td>
+    <td> - Selection<br>
+         - TextCoercion</td>
+  </tr>
+</table>
+
+<br/>
+
+## Access
+
+<table style="width:80%">
+  <tr>
+    <th>Platform</th>
+    <th>Extension points</th>
+    <th>API requirement sets</th>
+    <th><a href="https://docs.microsoft.com/office/dev/add-ins/reference/requirement-sets/office-add-in-requirement-sets"><b>Common APIs</b></a></th>
+  </tr>
+  <tr>
+    <td>Office Online</td>
+    <td> - Content</td>
+    <td> - <a href="https://docs.microsoft.com/office/dev/add-ins/reference/requirement-sets/dialog-api-requirement-sets">DialogApi 1.1</a></td>
+    <td> - BindingEvents<br>
+         - PartialTableBindings<br>
+         - Settings<br>
+         - TableBindings<br>
+         - TableCoercion</td>
   </tr>
 </table>
 

--- a/docs/overview/office-add-in-availability.md
+++ b/docs/overview/office-add-in-availability.md
@@ -1,14 +1,12 @@
 ---
 title: Office Add-in host and platform availability
-description: Supported requirement sets for Excel, Word, Outlook, PowerPoint, and OneNote.
+description: Supported requirement sets for Excel, Word, Outlook, PowerPoint, OneNote, and Project.
 ms.date: 11/07/2018
 ---
 
 # Office Add-in host and platform availability
 
 To work as expected, your Office Add-in might depend on a specific Office host, a requirement set, an API member, or a version of the API. The following tables contain the available platform, extension points, API requirement sets, and common API requirement sets that are currently supported for each Office application.
-
-If a table cell contains an asterisk ( * ), that means we’re working on it.
 
 > [!NOTE]
 > The build number for Office 2016 installed via MSI is 16.0.4266.1001. This version only contains the ExcelApi 1.1, WordApi 1.1, and common API requirement sets.
@@ -719,29 +717,6 @@ If a table cell contains an asterisk ( * ), that means we’re working on it.
     <td> - <a href="https://docs.microsoft.com/office/dev/add-ins/reference/requirement-sets/dialog-api-requirement-sets">DialogApi 1.1</a></td>
     <td> - Selection<br>
          - TextCoercion</td>
-  </tr>
-</table>
-
-<br/>
-
-## Access
-
-<table style="width:80%">
-  <tr>
-    <th>Platform</th>
-    <th>Extension points</th>
-    <th>API requirement sets</th>
-    <th><a href="https://docs.microsoft.com/office/dev/add-ins/reference/requirement-sets/office-add-in-requirement-sets"><b>Common APIs</b></a></th>
-  </tr>
-  <tr>
-    <td>Office Online</td>
-    <td> - Content</td>
-    <td> - <a href="https://docs.microsoft.com/office/dev/add-ins/reference/requirement-sets/dialog-api-requirement-sets">DialogApi 1.1</a></td>
-    <td> - BindingEvents<br>
-         - PartialTableBindings<br>
-         - Settings<br>
-         - TableBindings<br>
-         - TableCoercion</td>
   </tr>
 </table>
 


### PR DESCRIPTION
Added host/platform availability info for Project and Access based on [SOT](https://github.com/OfficeDev/Office-Js-Requirement-Sets/blob/master/mapping/requirements_officejs.json). This addresses issue https://github.com/OfficeDev/office-js-docs-pr/issues/508.