### PR TITLE
Add section on RunOptions

### DIFF
--- a/docs/excel/excel-add-ins-core-concepts.md
+++ b/docs/excel/excel-add-ins-core-concepts.md
@@ -36,7 +36,7 @@ Excel.run(function (context) {
 
 **Excel.run** has an overload that takes in a [RunOptions](/javascript/api/excel/excel.runoptions) object. This contains a set of properties that affect platform behavior when the function runs. The following are some of the most commonly used option properties:
 
- - `delayForCellEdit`: Determines whether Excel delays the batch request until the user exits cell edit mode. When **true**, the batch request is delayed and executes when the user exits cell edit mode. When **false**, the batch request automatically fails if the user is in cell edit mode (causing an error to reach the user). The default behavior with no `delayForCellEdit` property specified is equivalent to when it is **false**.
+ - `delayForCellEdit`: Determines whether Excel delays the batch request until the user exits cell edit mode. When **true**, the batch request is delayed and runs when the user exits cell edit mode. When **false**, the batch request automatically fails if the user is in cell edit mode (causing an error to reach the user). The default behavior with no `delayForCellEdit` property specified is equivalent to when it is **false**.
 
 ```js
 Excel.run({ delayForCellEdit: true }, function (context) { ... })

--- a/docs/excel/excel-add-ins-core-concepts.md
+++ b/docs/excel/excel-add-ins-core-concepts.md
@@ -1,7 +1,7 @@
 ---
 title: Fundamental programming concepts with the Excel JavaScript API
 description: Use the Excel JavaScript API to build add-ins for Excel.
-ms.date: 10/16/2018
+ms.date: 11/29/2018
 ---
 
 
@@ -31,6 +31,16 @@ Excel.run(function (context) {
   }
 });
 ```
+
+### Run options
+
+**Excel.run** has an overload to take in a [RunOptions](https://docs.microsoft.com/javascript/api/excel/excel.runoptions) object. This contains a set of properties affecting platform behavior during the function's execution.
+
+ - `delayForCellEdit`: Determines whether Excel delays the batch request until the user exits cell edit mode. When false (which is the default), the batch request automatically fails if the user is in cell edit mode. When true, the batch request is delayed and executes when the user exits cell edit mode.
+ 
+ ```js
+ Excel.run({ delayForCellEdit: true }, function (context) { ... }
+ ```
 
 ## Request context
  

--- a/docs/excel/excel-add-ins-core-concepts.md
+++ b/docs/excel/excel-add-ins-core-concepts.md
@@ -34,7 +34,7 @@ Excel.run(function (context) {
 
 ### Run options
 
-**Excel.run** has an overload that takes in a [RunOptions](/javascript/api/excel/excel.runoptions) object. This contains a set of properties that affect platform behavior when the function runs. The following are some of the most commonly used option properties:
+**Excel.run** has an overload that takes in a [RunOptions](/javascript/api/excel/excel.runoptions) object. This contains a set of properties that affect platform behavior when the function runs. The following property is currently supported:
 
  - `delayForCellEdit`: Determines whether Excel delays the batch request until the user exits cell edit mode. When **true**, the batch request is delayed and runs when the user exits cell edit mode. When **false**, the batch request automatically fails if the user is in cell edit mode (causing an error to reach the user). The default behavior with no `delayForCellEdit` property specified is equivalent to when it is **false**.
 

--- a/docs/excel/excel-add-ins-core-concepts.md
+++ b/docs/excel/excel-add-ins-core-concepts.md
@@ -37,10 +37,10 @@ Excel.run(function (context) {
 **Excel.run** has an overload to take in a [RunOptions](https://docs.microsoft.com/javascript/api/excel/excel.runoptions) object. This contains a set of properties affecting platform behavior during the function's execution.
 
  - `delayForCellEdit`: Determines whether Excel delays the batch request until the user exits cell edit mode. When false (which is the default), the batch request automatically fails if the user is in cell edit mode. When true, the batch request is delayed and executes when the user exits cell edit mode.
- 
- ```js
- Excel.run({ delayForCellEdit: true }, function (context) { ... }
- ```
+
+```js
+Excel.run({ delayForCellEdit: true }, function (context) { ... }
+```
 
 ## Request context
  

--- a/docs/excel/excel-add-ins-core-concepts.md
+++ b/docs/excel/excel-add-ins-core-concepts.md
@@ -34,7 +34,7 @@ Excel.run(function (context) {
 
 ### Run options
 
-**Excel.run** has an overload to take in a [RunOptions](https://docs.microsoft.com/javascript/api/excel/excel.runoptions) object. This contains a set of properties affecting platform behavior during the function's execution.
+**Excel.run** has an overload that takes in a [RunOptions](https://docs.microsoft.com/javascript/api/excel/excel.runoptions) object. This contains a set of properties affecting platform behavior during the function's execution. The following are some of the most commonly used option properties:
 
  - `delayForCellEdit`: Determines whether Excel delays the batch request until the user exits cell edit mode. When false (which is the default), the batch request automatically fails if the user is in cell edit mode. When true, the batch request is delayed and executes when the user exits cell edit mode.
 

--- a/docs/excel/excel-add-ins-core-concepts.md
+++ b/docs/excel/excel-add-ins-core-concepts.md
@@ -34,12 +34,12 @@ Excel.run(function (context) {
 
 ### Run options
 
-**Excel.run** has an overload that takes in a [RunOptions](https://docs.microsoft.com/javascript/api/excel/excel.runoptions) object. This contains a set of properties affecting platform behavior during the function's execution. The following are some of the most commonly used option properties:
+**Excel.run** has an overload that takes in a [RunOptions](/javascript/api/excel/excel.runoptions) object. This contains a set of properties that affect platform behavior when the function runs. The following are some of the most commonly used option properties:
 
- - `delayForCellEdit`: Determines whether Excel delays the batch request until the user exits cell edit mode. When false (which is the default), the batch request automatically fails if the user is in cell edit mode. When true, the batch request is delayed and executes when the user exits cell edit mode.
+ - `delayForCellEdit`: Determines whether Excel delays the batch request until the user exits cell edit mode. When **true**, the batch request is delayed and executes when the user exits cell edit mode. When **false**, the batch request automatically fails if the user is in cell edit mode (causing an error to reach the user). The default behavior with no `delayForCellEdit` property specified is equivalent to when it is **false**.
 
 ```js
-Excel.run({ delayForCellEdit: true }, function (context) { ... }
+Excel.run({ delayForCellEdit: true }, function (context) { ... })
 ```
 
 ## Request context


### PR DESCRIPTION
Inspired by [this UserVoice request](https://officespdev.uservoice.com/forums/224641-feature-requests-and-feedback/suggestions/16952863-add-workbook-canceledit-or-worksheet-canceledit-to), we received a request to share how to avoid failure when the user is in cell edit mode. Since this is a RunOption passed to `Excel.run` it made the most sense to add the information here. If there's a better location, please suggest it.