### PR TITLE
Update CDN link to office-ui-fabric-core

### DIFF
--- a/docs/design/office-ui-fabric.md
+++ b/docs/design/office-ui-fabric.md
@@ -14,7 +14,7 @@ If you are building an add-in, we encourage you to use Office UI Fabric to creat
 The following sections explain how to get started using Fabric to meet your requirements. 
 
 ## Use Fabric Core: icons, fonts, colors
-Fabric Core contains basic elements of the design language such as icons, colors, type, and grid. Fabric core is framework independent. Both Fabric React and Fabric JS use Fabric Core.
+Fabric Core contains basic elements of the design language such as icons, colors, type, and grid. Fabric core is framework independent. Fabric Core is used by and included with Fabric React.
 
 To get started using Fabric Core:
 

--- a/docs/design/office-ui-fabric.md
+++ b/docs/design/office-ui-fabric.md
@@ -21,7 +21,7 @@ To get started using Fabric Core:
 1. Add the CDN reference to the HTML on your page.  
 
 	```html
-	<link rel="stylesheet" href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-js/1.4.0/css/fabric.min.css">
+	<link rel="stylesheet" href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/9.6.1/css/fabric.min.css">
 	```   
     
 2. Use Fabric icons and fonts. 


### PR DESCRIPTION
The link to Office UI Fabric Core's CSS pointed to an out-of-date version that was associated with Office UI Fabric JS. Though it works functionally the same as the "standalone" Fabric Core CSS, it's quite out of date and isn't the most appropriate for this context.