### PR TITLE
[excel] (SpecialCells) Reorganizing special cells content between range areas and adv. ranges articles

### DIFF
--- a/docs/excel/excel-add-ins-multiple-ranges.md
+++ b/docs/excel/excel-add-ins-multiple-ranges.md
@@ -173,6 +173,6 @@ Excel.run(function (context) {
 
 ## See also
 
-- [Fundamental programming concepts with the Excel JavaScript API](../reference/overview/excel-add-ins-reference-overview)
+- [Fundamental programming concepts with the Excel JavaScript API](../reference/overview/excel-add-ins-reference-overview.md)
 - [Work with ranges using the Excel JavaScript API (fundamental)](excel-add-ins-ranges.md)
 - [Work with ranges using the Excel JavaScript API (advanced)](excel-add-ins-ranges-advanced.md)

--- a/docs/excel/excel-add-ins-multiple-ranges.md
+++ b/docs/excel/excel-add-ins-multiple-ranges.md
@@ -122,8 +122,8 @@ The `getSpecialCells` and `getSpecialCellsOrNullObject` methods on the `RangeAre
 
 When calling the `getSpecialCells` or `getSpecialCellsOrNullObject` method on a `RangeAreas` object:
 
-- If you pass `sameConditionalFormat` as the first parameter, the method returns all cells with the same conditional formatting as the upper-leftmost cell in the first range in the `RangeAreas.areas` collection.
-- If you pass `sameDataValidation` as the first parameter, the method returns all cells with the same data validation rule as the upper-leftmost cell in the first range in the `RangeAreas.areas` collection.
+- If you pass `Excel.SpecialCellType.sameConditionalFormat` as the first parameter, the method returns all cells with the same conditional formatting as the upper-leftmost cell in the first range in the `RangeAreas.areas` collection.
+- If you pass `Excel.SpecialCellType.sameDataValidation` as the first parameter, the method returns all cells with the same data validation rule as the upper-leftmost cell in the first range in the `RangeAreas.areas` collection.
 
 ## Read properties of RangeAreas
 

--- a/docs/excel/excel-add-ins-multiple-ranges.md
+++ b/docs/excel/excel-add-ins-multiple-ranges.md
@@ -1,10 +1,10 @@
 ---
 title: Work with multiple ranges simultaneously in Excel add-ins
 description: ''
-ms.date: 12/20/2018
+ms.date: 12/26/2018
 ---
 
-# Work with multiple ranges simultaneously in Excel add-ins (Preview)
+# Work with multiple ranges simultaneously in Excel add-ins (preview)
 
 The Excel JavaScript library enables your add-in to perform operations, and set properties, on multiple ranges simultaneously. The ranges do not have to be contiguous. In addition to making your code simpler, this way of setting a property runs much faster than setting the same property individually for each of the ranges.
 
@@ -80,7 +80,7 @@ The `RangeAreas` type has some properties and methods that are not on the `Range
 - `areaCount`: The total number of ranges in the `RangeAreas`.
 - `getOffsetRangeAreas`: Works just like [Range.getOffsetRange](/javascript/api/excel/excel.range#getoffsetrange-rowoffset--columnoffset-), except that a `RangeAreas` is returned and it contains ranges that are each offset from one of the ranges in the original `RangeAreas`.
 
-## Create RangeAreas and set properties
+## Create RangeAreas
 
 You can create `RangeAreas` object in two basic ways:
 
@@ -94,6 +94,8 @@ Once you have a `RangeAreas` object, you can create others using the methods on 
 
 > [!WARNING]
 > Do not attempt to directly add or delete members of the the `RangeAreas.areas.items` array. This will lead to undesirable behavior in your code. For example, it is possible to push an additional `Range` object onto the array, but doing so will cause errors because `RangeAreas` properties and methods behave as if the new item isn't there. For example, the `areaCount` property does not include ranges pushed in this way, and the `RangeAreas.getItemAt(index)` throws an error if `index` is larger than `areasCount-1`. Similarly, deleting a `Range` object in the `RangeAreas.areas.items` array by getting a reference to it and calling its `Range.delete` method causes bugs: although the `Range` object *is* deleted, the properties and methods of the parent `RangeAreas` object behave, or try to, as if it is still in existence. For example, if your code calls `RangeAreas.calculate`, Office will try to calculate the range, but will error because the range object is gone.
+
+## Set properties on multiple ranges
 
 Setting a property on a `RangeAreas` sets the corresponding property on all the ranges in the `RangeAreas.areas` collection.
 
@@ -114,11 +116,14 @@ This example applies to scenarios in which you can hard code the range addresses
 - The code runs in the context of a known template.
 - The code runs in the context of imported data where the schema of the data is known.
 
-### Get special cells from a RangeAreas object
+## Get special cells from multiple ranges
 
-The `RangeAreas` object itself has `getSpecialCells` and `getSpecialCellsOrNullObject` methods which work analogously to the `Range` object's methods of the same names. These methods return all the targeted cells from all of the ranges in the `RangeAreas.areas` collection. See the [Find special cells within a range](excel-add-ins-ranges-advanced.md#find-special-cells-within-a-range-preview) section for more details on special cells.
+The `getSpecialCells` and `getSpecialCellsOrNullObject` methods on the `RangeAreas` object work analogously to methods of the same name on the `Range` object. These methods return the cells with the specified characteristic from all of the ranges in the `RangeAreas.areas` collection. See the [Find special cells within a range](excel-add-ins-ranges-advanced.md#find-special-cells-within-a-range-preview) section for more details on special cells.
 
-There is one small difference in the behavior of the `getSpecialCells` methods when called on a `RangeAreas` object instead of a `Range` object: when you pass "SameConditionalFormat" as the first parameter, the method returns all cells that have the same conditional formatting as the upper leftmost cell *in the first range in the `RangeAreas.areas` collection*. The same point applies to "SameDataValidation": when passed to `Range.getSpecialCells`, it returns all cells that have the same data validation rule as the upper leftmost cell *in the range*. But when it is passed to `RangeAreas.getSpecialCells`, it returns all cells that have the same data validation rule as the upper leftmost cell *in the first range in the `RangeAreas.areas` collection*.
+When calling the `getSpecialCells` or `getSpecialCellsOrNullObject` method on a `RangeAreas` object:
+
+- If you pass "SameConditionalFormat" as the first parameter, the method returns all cells with the same conditional formatting as the upper-leftmost cell in the first range in the RangeAreas.areas collection.
+- If you pass "SameDataValidation" as the first parameter, the method returns all cells with the same data validation rule as the upper-leftmost cell in the first range in the RangeAreas.areas collection.
 
 ## Read properties of RangeAreas
 

--- a/docs/excel/excel-add-ins-multiple-ranges.md
+++ b/docs/excel/excel-add-ins-multiple-ranges.md
@@ -97,7 +97,7 @@ Once you have a `RangeAreas` object, you can create others using the methods on 
 
 ## Set properties on multiple ranges
 
-Setting a property on a `RangeAreas` sets the corresponding property on all the ranges in the `RangeAreas.areas` collection.
+Setting a property on a `RangeAreas` object sets the corresponding property on all the ranges in the `RangeAreas.areas` collection.
 
 The following is an example of setting a property on multiple ranges. The function highlights the ranges **F3:F5** and **H3:H5**.
 
@@ -122,8 +122,8 @@ The `getSpecialCells` and `getSpecialCellsOrNullObject` methods on the `RangeAre
 
 When calling the `getSpecialCells` or `getSpecialCellsOrNullObject` method on a `RangeAreas` object:
 
-- If you pass "SameConditionalFormat" as the first parameter, the method returns all cells with the same conditional formatting as the upper-leftmost cell in the first range in the RangeAreas.areas collection.
-- If you pass "SameDataValidation" as the first parameter, the method returns all cells with the same data validation rule as the upper-leftmost cell in the first range in the RangeAreas.areas collection.
+- If you pass "SameConditionalFormat" as the first parameter, the method returns all cells with the same conditional formatting as the upper-leftmost cell in the first range in the `RangeAreas.areas` collection.
+- If you pass "SameDataValidation" as the first parameter, the method returns all cells with the same data validation rule as the upper-leftmost cell in the first range in the `RangeAreas.areas` collection.
 
 ## Read properties of RangeAreas
 

--- a/docs/excel/excel-add-ins-multiple-ranges.md
+++ b/docs/excel/excel-add-ins-multiple-ranges.md
@@ -116,7 +116,7 @@ This example applies to scenarios in which you can hard code the range addresses
 
 ### Get special cells from a RangeAreas object
 
-The `RangeAreas` object itself has `getSpecialCells` and `getSpecialCellsOrNullObject` methods which work analogously to the `Range` object's methods of the same names. These methods return all the targeted cells from all of the ranges in the `RangeAreas.areas` collection. See the [Find special cells within a range](excel-add-ins-ranges-advanced.md#find-special-cells-within-a-range) section for more details on special cells.
+The `RangeAreas` object itself has `getSpecialCells` and `getSpecialCellsOrNullObject` methods which work analogously to the `Range` object's methods of the same names. These methods return all the targeted cells from all of the ranges in the `RangeAreas.areas` collection. See the [Find special cells within a range](excel-add-ins-ranges-advanced.md#find-special-cells-within-a-range-preview) section for more details on special cells.
 
 There is one small difference in the behavior of the `getSpecialCells` methods when called on a `RangeAreas` object instead of a `Range` object: when you pass "SameConditionalFormat" as the first parameter, the method returns all cells that have the same conditional formatting as the upper leftmost cell *in the first range in the `RangeAreas.areas` collection*. The same point applies to "SameDataValidation": when passed to `Range.getSpecialCells`, it returns all cells that have the same data validation rule as the upper leftmost cell *in the range*. But when it is passed to `RangeAreas.getSpecialCells`, it returns all cells that have the same data validation rule as the upper leftmost cell *in the first range in the `RangeAreas.areas` collection*.
 
@@ -149,7 +149,7 @@ Things get more complicated when consistency isn't possible. The behavior of `Ra
 - Non-boolean properties, with the exception of the `address` property, return `null` unless the corresponding property on all the member ranges has the same value.
 - The `address` property returns a comma-delimited string of the addresses of the member ranges.
 
-For example, the following code creates a `RangeAreas` in which only one range is an entire column and only one is filled with pink. The console will show `null` for the fill color, `false` for the `isEntireRow` property, and "Sheet1!F3:F5, Sheet1!H:H" (assuming the sheet name is "Sheet1") for the `address` property. 
+For example, the following code creates a `RangeAreas` in which only one range is an entire column and only one is filled with pink. The console will show `null` for the fill color, `false` for the `isEntireRow` property, and "Sheet1!F3:F5, Sheet1!H:H" (assuming the sheet name is "Sheet1") for the `address` property.
 
 ```js
 Excel.run(function (context) {

--- a/docs/excel/excel-add-ins-multiple-ranges.md
+++ b/docs/excel/excel-add-ins-multiple-ranges.md
@@ -122,8 +122,8 @@ The `getSpecialCells` and `getSpecialCellsOrNullObject` methods on the `RangeAre
 
 When calling the `getSpecialCells` or `getSpecialCellsOrNullObject` method on a `RangeAreas` object:
 
-- If you pass "SameConditionalFormat" as the first parameter, the method returns all cells with the same conditional formatting as the upper-leftmost cell in the first range in the `RangeAreas.areas` collection.
-- If you pass "SameDataValidation" as the first parameter, the method returns all cells with the same data validation rule as the upper-leftmost cell in the first range in the `RangeAreas.areas` collection.
+- If you pass `sameConditionalFormat` as the first parameter, the method returns all cells with the same conditional formatting as the upper-leftmost cell in the first range in the `RangeAreas.areas` collection.
+- If you pass `sameDataValidation` as the first parameter, the method returns all cells with the same data validation rule as the upper-leftmost cell in the first range in the `RangeAreas.areas` collection.
 
 ## Read properties of RangeAreas
 

--- a/docs/excel/excel-add-ins-ranges-advanced.md
+++ b/docs/excel/excel-add-ins-ranges-advanced.md
@@ -90,7 +90,7 @@ The following example uses the `getSpecialCells` method. About this code, note:
 Excel.run(function (context) {
     var sheet = context.workbook.worksheets.getActiveWorksheet();
     var usedRange = sheet.getUsedRange();
-    var formulaRanges = usedRange.getSpecialCells("Formulas");
+    var formulaRanges = usedRange.getSpecialCells(Excel.SpecialCellType.formulas);
     formulaRanges.format.fill.color = "pink";
 
     return context.sync();
@@ -158,7 +158,7 @@ Excel.run(function (context) {
 })
 ```
 
-#### Test for a multiple cell value types
+#### Test for multiple cell value types
 
 Sometimes you need to operate on more than one cell value type, such as all text-valued and all boolean-valued ("Logical") cells. The `Excel.SpecialCellValueType` enum has values that let you combine types. For example, "LogicalText" targets all boolean and all text-valued cells. You can combine any two or any three of the four basic types. The names of these enum values that combine basic types are always in alphabetical order. So to combine error-valued, text-valued, and boolean-valued cells, use "ErrorLogicalText", not "LogicalErrorText" or "TextErrorLogical". "All" is the default value, which does not limit the cell value types returned. The following example colors all cells with formulas that produce number or boolean value.
 

--- a/docs/excel/excel-add-ins-ranges-advanced.md
+++ b/docs/excel/excel-add-ins-ranges-advanced.md
@@ -1,7 +1,7 @@
 ---
 title: Work with ranges using the Excel JavaScript API (advanced)
 description: ''
-ms.date: 12/18/2018
+ms.date: 12/20/2018
 ---
 
 # Work with ranges using the Excel JavaScript API (advanced)
@@ -63,6 +63,96 @@ Your add-in will have to format the ranges to display the dates in a more human-
 > If you are using TypeScript or your code editor uses TypeScript type definition files for IntelliSense, use https://appsforoffice.microsoft.com/lib/beta/hosted/office.d.ts.
 
 The `RangeAreas` object lets your add-in perform operations on multiple ranges at once. These ranges may be contiguous, but do not have to be. `RangeAreas` are further discussed in the article [Work with multiple ranges simultaneously in Excel add-ins](excel-add-ins-multiple-ranges.md).
+
+## Find special cells within a range (preview)
+
+The `Range.getSpecialCells()` and `Range.getSpecialCellsOrNullObject()` methods enable you to find at runtime the ranges that you want to operate on based on the characteristics of the cells and the type of the values of the cells. Both these methods return `RangeAreas` objects. Here are the signatures of the methods from the TypeScript data types file:
+
+```typescript
+getSpecialCells(cellType: Excel.SpecialCellType, cellValueType?: Excel.SpecialCellValueType): Excel.RangeAreas;
+```
+
+```typescript
+getSpecialCellsOrNullObject(cellType: Excel.SpecialCellType, cellValueType?: Excel.SpecialCellValueType): Excel.RangeAreas;
+```
+
+The following is an example of using the first one. About this code, note:
+
+- It limits the part of the sheet that needs to be searched by first calling `Worksheet.getUsedRange` and calling `getSpecialCells` for only that range.
+- It passes as a parameter to `getSpecialCells` the string version of a value from the `Excel.SpecialCellType` enum. Some of the other values that could be passed instead are "Blanks" for empty cells, "Constants" for cells with literal values instead of formulas, and "SameConditionalFormat" for cells that have the same conditional formatting as the first cell in the `usedRange`. The first cell is the upper leftmost cell. For a complete list of the values in the enum, see [beta office.d.ts](https://appsforoffice.microsoft.com/lib/beta/hosted/office.d.ts).
+- The `getSpecialCells` method returns a `RangeAreas` object, so all of the cells with formulas will be colored pink even if they are not all contiguous.
+
+```js
+Excel.run(function (context) {
+    var sheet = context.workbook.worksheets.getActiveWorksheet();
+    var usedRange = sheet.getUsedRange();
+    var formulaRanges = usedRange.getSpecialCells("Formulas");
+    formulaRanges.format.fill.color = "pink";
+
+    return context.sync();
+})
+```
+
+Sometimes the range doesn't have *any* cells with the targeted characteristic. If `getSpecialCells` doesn't find any, it throws an **ItemNotFound** error. This would divert the flow of control to a `catch` block/method, if there is one. If there isn't, the error halts the function. There may be scenarios in which throwing the error is exactly what you want to happen when there are no cells with the targeted characteristic.
+
+But in scenarios in which it is normal, but perhaps uncommon, for there to be no matching cells; your code should check for this possibility and handle it gracefully without throwing an error. For these scenarios, use the `getSpecialCellsOrNullObject` method and test the `RangeAreas.isNullObject` property. The following is an example. Note about this code:
+
+- The `getSpecialCellsOrNullObject` method always returns a proxy object, so it is never `null` in the ordinary JavaScript sense. But if no matching cells are found, the `isNullObject` property of the object is set to `true`.
+- It calls `context.sync` *before* it tests the `isNullObject` property. This is a requirement with all `*OrNullObject` methods and properties, because you always have to load and sync a property in order to read it. However, it is not necessary to *explicitly* load the `isNullObject` property. It is automatically loaded by the `context.sync` even if `load` is not called on the object. For more information, see [\*OrNullObject](https://docs.microsoft.com/office/dev/add-ins/excel/excel-add-ins-advanced-concepts#42ornullobject-methods).
+- You can test this code by first selecting a range that has no formula cells and running it. Then select a range that has at least one cell with a formula and run it again.
+
+```js
+Excel.run(function (context) {
+    var range = context.workbook.getSelectedRange();
+    var formulaRanges = range.getSpecialCellsOrNullObject("Formulas");
+    return context.sync()
+        .then(function() {
+            if (formulaRanges.isNullObject) {
+                console.log("No cells have formulas");
+            }
+            else {
+                formulaRanges.format.fill.color = "pink";
+            }
+        })
+        .then(context.sync);
+})
+```
+
+For simplicity, all other examples in this article use the `getSpecialCells` method instead of  `getSpecialCellsOrNullObject`.
+
+### Narrow the target cells with cell value types
+
+There is an optional second parameter, of enum type `Excel.SpecialCellValueType`, that further narrows down the cells to target. You can use it only when you pass either "Formulas" or "Constants" to `getSpecialCells` or `getSpecialCellsOrNullObject`. The parameter specifies that you only want cells with certain types of values. There are four basic types: "Error", "Logical" (which means boolean), "Numbers", and "Text". (The enum has other values besides these four which are discussed below.) The following is an example. About this code, note:
+
+- It will only highlight cells that have a literal number value. It will not highlight cells that have a formula (even if the result is a number) or a boolean, text, or error state cells.
+- To test the code, be sure the worksheet has some cells with literal number values, some with other kinds of literal values, and some with formulas.
+
+```js
+Excel.run(function (context) {
+    var sheet = context.workbook.worksheets.getActiveWorksheet();
+    var usedRange = sheet.getUsedRange();
+    var constantNumberRanges = usedRange.getSpecialCells("Constants", "Numbers");
+    constantNumberRanges.format.fill.color = "pink";
+
+    return context.sync();
+})
+```
+
+Sometimes you need to operate on more than one cell value type, such as all text-valued and all boolean-valued ("Logical") cells. The `Excel.SpecialCellValueType` enum has values that let you combine types. For example, "LogicalText" will target all boolean and all text-valued cells. You can combine any two or any three of the four basic types. The names of these enum values that combine basic types are always in alphabetical order. So to combine error-valued, text-valued, and boolean-valued cells, use "ErrorLogicalText", not "LogicalErrorText" or "TextErrorLogical". The default parameter of "All" combines all four types. The following example highlights all cells with formulas that produce number or boolean values:
+
+```js
+Excel.run(function (context) {
+    var sheet = context.workbook.worksheets.getActiveWorksheet();
+    var usedRange = sheet.getUsedRange();
+    var formulaLogicalNumberRanges = usedRange.getSpecialCells("Formulas", "LogicalNumbers");
+    formulaLogicalNumberRanges.format.fill.color = "pink";
+
+    return context.sync();
+})
+```
+
+> [!NOTE]
+> The `Excel.SpecialCellValueType` parameter can only be used if the `Excel.SpecialCellType` parameter is "Formulas" or "Constants".
 
 ## Copy and paste (preview)
 
@@ -173,3 +263,4 @@ Excel.run(async (context) => {
 
 - [Work with ranges using the Excel JavaScript API](excel-add-ins-ranges.md)
 - [Fundamental programming concepts with the Excel JavaScript API](excel-add-ins-core-concepts.md)
+- [Work with multiple ranges simultaneously in Excel add-ins](excel.add-ins-multiple-ranges.md)

--- a/docs/excel/excel-add-ins-ranges-advanced.md
+++ b/docs/excel/excel-add-ins-ranges-advanced.md
@@ -83,7 +83,7 @@ getSpecialCellsOrNullObject(cellType: Excel.SpecialCellType, cellValueType?: Exc
 The following example uses the `getSpecialCells` method. About this code, note:
 
 - It limits the part of the sheet that needs to be searched by first calling `Worksheet.getUsedRange` and calling `getSpecialCells` for only that range.
-- It passes as a parameter to `getSpecialCells` the string version of a value from the `Excel.SpecialCellType` enum. Some of the other values that could be passed instead are "Blanks" for empty cells, "Constants" for cells with literal values instead of formulas, and "SameConditionalFormat" for cells that have the same conditional formatting as the first cell in the `usedRange`. The first cell is the upper leftmost cell. For a complete list of the values in the enum, see [beta office.d.ts](https://appsforoffice.microsoft.com/lib/beta/hosted/office.d.ts).
+- It passes as a parameter to `getSpecialCells` the string version of a value from the `Excel.SpecialCellType` enum. Some of the other values that could be passed instead are `blanks` for empty cells, `constants` for cells with literal values instead of formulas, and `sameConditionalFormat` for cells that have the same conditional formatting as the first cell in the `usedRange`. The first cell is the upper leftmost cell. For a complete list of the values in the enum, see [beta office.d.ts](https://appsforoffice.microsoft.com/lib/beta/hosted/office.d.ts).
 - The `getSpecialCells` method returns a `RangeAreas` object, so all of the cells with formulas will be colored pink even if they are not all contiguous.
 
 ```js
@@ -129,16 +129,16 @@ For simplicity, all other examples in this article use the `getSpecialCells` met
 The `Range.getSpecialCells()` and `Range.getSpecialCellsOrNullObject()` methods accept an optional second parameter used to further narrow down the targeted cells. This second parameter is an `Excel.SpecialCellValueType` you use to specify that you only want cells that contain certain types of values.
 
 > [!NOTE]
-> The `Excel.SpecialCellValueType` parameter can only be used if the `Excel.SpecialCellType` parameter is "Formulas" or "Constants".
+> The `Excel.SpecialCellValueType` parameter can only be used if the `Excel.SpecialCellType` parameter is `formulas` or `constants`.
 
 #### Test for a single cell value type
 
 The `Excel.SpecialCellValueType` enum has these four basic types (in addition to the other combined values described later in this section):
 
-- "Error"
-- "Logical" (which means boolean)
-- "Numbers"
-- "Text"
+- `errors`
+- `logical` (which means boolean)
+- `numbers`
+- `text`
 
 The following example finds special cells that are numerical constants and colors those cells pink. About this code, note:
 
@@ -160,7 +160,7 @@ Excel.run(function (context) {
 
 #### Test for multiple cell value types
 
-Sometimes you need to operate on more than one cell value type, such as all text-valued and all boolean-valued ("Logical") cells. The `Excel.SpecialCellValueType` enum has values that let you combine types. For example, "LogicalText" targets all boolean and all text-valued cells. You can combine any two or any three of the four basic types. The names of these enum values that combine basic types are always in alphabetical order. So to combine error-valued, text-valued, and boolean-valued cells, use "ErrorLogicalText", not "LogicalErrorText" or "TextErrorLogical". "All" is the default value, which does not limit the cell value types returned. The following example colors all cells with formulas that produce number or boolean value.
+Sometimes you need to operate on more than one cell value type, such as all text-valued and all boolean-valued (`logical`) cells. The `Excel.SpecialCellValueType` enum has values with combined types. For example, `logicalText` targets all boolean and all text-valued cells. `all` is the default value, which does not limit the cell value types returned. The following example colors all cells with formulas that produce number or boolean value.
 
 ```js
 Excel.run(function (context) {
@@ -197,15 +197,15 @@ Excel.run(function (context) {
 `Range.copyFrom` has three optional parameters.
 
 ```TypeScript
-copyFrom(sourceRange: Range | string, copyType?: "All" | "Formulas" | "Values" | "Formats", skipBlanks?: boolean, transpose?: boolean): void;
+copyFrom(sourceRange: Range | RangeAreas | string, copyType?: Excel.RangeCopyType, skipBlanks?: boolean, transpose?: boolean): void;
 ```
 
 `copyType` specifies what data gets copied from the source to the destination.
 
-- `"Formulas"` transfers the formulas in the source cells and preserves the relative positioning of those formulas’ ranges. Any non-formula entries are copied as-is.
-- `"Values"` copies the data values and, in the case of formulas, the result of the formula.
-- `"Formats"` copies the formatting of the range, including font, color, and other format settings, but no values.
-- `"All"` (the default option) copies both data and formatting, preserving cells’ formulas if found.
+- `formulas` transfers the formulas in the source cells and preserves the relative positioning of those formulas’ ranges. Any non-formula entries are copied as-is.
+- `values` copies the data values and, in the case of formulas, the result of the formula.
+- `formats` copies the formatting of the range, including font, color, and other format settings, but no values.
+- `all` (the default option) copies both data and formatting, preserving cells’ formulas if found.
 
 `skipBlanks` sets whether blank cells are copied into the destination. When true, `copyFrom` skips blank cells in the source range.
 Skipped cells will not overwrite the existing data of their corresponding cells in the destination range. The default is false.

--- a/docs/excel/excel-add-ins-ranges-advanced.md
+++ b/docs/excel/excel-add-ins-ranges-advanced.md
@@ -80,10 +80,9 @@ getSpecialCells(cellType: Excel.SpecialCellType, cellValueType?: Excel.SpecialCe
 getSpecialCellsOrNullObject(cellType: Excel.SpecialCellType, cellValueType?: Excel.SpecialCellValueType): Excel.RangeAreas;
 ```
 
-The following example uses the `getSpecialCells` method. About this code, note:
+The following example uses the `getSpecialCells` method to find all the cells with formulas. About this code, note:
 
 - It limits the part of the sheet that needs to be searched by first calling `Worksheet.getUsedRange` and calling `getSpecialCells` for only that range.
-- It passes as a parameter to `getSpecialCells` the string version of a value from the `Excel.SpecialCellType` enum. Some of the other values that could be passed instead are `blanks` for empty cells, `constants` for cells with literal values instead of formulas, and `sameConditionalFormat` for cells that have the same conditional formatting as the first cell in the `usedRange`. The first cell is the upper leftmost cell. For a complete list of the values in the enum, see [beta office.d.ts](https://appsforoffice.microsoft.com/lib/beta/hosted/office.d.ts).
 - The `getSpecialCells` method returns a `RangeAreas` object, so all of the cells with formulas will be colored pink even if they are not all contiguous.
 
 ```js
@@ -129,16 +128,16 @@ For simplicity, all other examples in this article use the `getSpecialCells` met
 The `Range.getSpecialCells()` and `Range.getSpecialCellsOrNullObject()` methods accept an optional second parameter used to further narrow down the targeted cells. This second parameter is an `Excel.SpecialCellValueType` you use to specify that you only want cells that contain certain types of values.
 
 > [!NOTE]
-> The `Excel.SpecialCellValueType` parameter can only be used if the `Excel.SpecialCellType` parameter is `formulas` or `constants`.
+> The `Excel.SpecialCellValueType` parameter can only be used if the `Excel.SpecialCellType` is `Excel.SpecialCellType.formulas` or `Excel.SpecialCellType.constants`.
 
 #### Test for a single cell value type
 
 The `Excel.SpecialCellValueType` enum has these four basic types (in addition to the other combined values described later in this section):
 
-- `errors`
-- `logical` (which means boolean)
-- `numbers`
-- `text`
+- `Excel.SpecialCellValueType.errors`
+- `Excel.SpecialCellValueType.logical` (which means boolean)
+- `Excel.SpecialCellValueType.numbers`
+- `Excel.SpecialCellValueType.text`
 
 The following example finds special cells that are numerical constants and colors those cells pink. About this code, note:
 
@@ -160,7 +159,7 @@ Excel.run(function (context) {
 
 #### Test for multiple cell value types
 
-Sometimes you need to operate on more than one cell value type, such as all text-valued and all boolean-valued (`logical`) cells. The `Excel.SpecialCellValueType` enum has values with combined types. For example, `logicalText` targets all boolean and all text-valued cells. `all` is the default value, which does not limit the cell value types returned. The following example colors all cells with formulas that produce number or boolean value.
+Sometimes you need to operate on more than one cell value type, such as all text-valued and all boolean-valued (`Excel.SpecialCellValueType.logical`) cells. The `Excel.SpecialCellValueType` enum has values with combined types. For example, `Excel.SpecialCellValueType.logicalText` targets all boolean and all text-valued cells. `Excel.SpecialCellValueType.all` is the default value, which does not limit the cell value types returned. The following example colors all cells with formulas that produce number or boolean value.
 
 ```js
 Excel.run(function (context) {
@@ -202,10 +201,10 @@ copyFrom(sourceRange: Range | RangeAreas | string, copyType?: Excel.RangeCopyTyp
 
 `copyType` specifies what data gets copied from the source to the destination.
 
-- `formulas` transfers the formulas in the source cells and preserves the relative positioning of those formulas’ ranges. Any non-formula entries are copied as-is.
-- `values` copies the data values and, in the case of formulas, the result of the formula.
-- `formats` copies the formatting of the range, including font, color, and other format settings, but no values.
-- `all` (the default option) copies both data and formatting, preserving cells’ formulas if found.
+- `Excel.RangeCopyType.formulas` transfers the formulas in the source cells and preserves the relative positioning of those formulas’ ranges. Any non-formula entries are copied as-is.
+- `Excel.RangeCopyType.values` copies the data values and, in the case of formulas, the result of the formula.
+- `Excel.RangeCopyType.formats` copies the formatting of the range, including font, color, and other format settings, but no values.
+- `Excel.RangeCopyType.all` (the default option) copies both data and formatting, preserving cells’ formulas if found.
 
 `skipBlanks` sets whether blank cells are copied into the destination. When true, `copyFrom` skips blank cells in the source range.
 Skipped cells will not overwrite the existing data of their corresponding cells in the destination range. The default is false.

--- a/docs/excel/excel-add-ins-ranges-advanced.md
+++ b/docs/excel/excel-add-ins-ranges-advanced.md
@@ -70,7 +70,7 @@ The `RangeAreas` object lets your add-in perform operations on multiple ranges a
 > The `getSpecialCells` and `getSpecialCellsOrNullObject` methods are currently available only in public preview (beta). To use this feature, you must use the beta library of the Office.js CDN: https://appsforoffice.microsoft.com/lib/beta/hosted/office.js.
 > If you are using TypeScript or your code editor uses TypeScript type definition files for IntelliSense, use https://appsforoffice.microsoft.com/lib/beta/hosted/office.d.ts.
 
-The `Range.getSpecialCells()` and `Range.getSpecialCellsOrNullObject()` methods enable you to find the ranges that you want to operate on based on the characteristics of the cells and the types of values of the cells. Both of these methods return `RangeAreas` objects. Here are the signatures of the methods from the TypeScript data types file:
+The `Range.getSpecialCells()` and `Range.getSpecialCellsOrNullObject()` methods find ranges based on the characteristics of their cells and the types of values of their cells. Both of these methods return `RangeAreas` objects. Here are the signatures of the methods from the TypeScript data types file:
 
 ```typescript
 getSpecialCells(cellType: Excel.SpecialCellType, cellValueType?: Excel.SpecialCellValueType): Excel.RangeAreas;
@@ -97,9 +97,9 @@ Excel.run(function (context) {
 })
 ```
 
-If no cells with the targeted characteristic exist in the range, `getSpecialCells` throws an **ItemNotFound** error. This would divert the flow of control to a `catch` block, if there is one. If there isn't a `catch` block, the error halts the function. There may be scenarios in which throwing the error is exactly what you want to happen when there are no cells with the targeted characteristic.
+If no cells with the targeted characteristic exist in the range, `getSpecialCells` throws an **ItemNotFound** error. This diverts the flow of control to a `catch` block, if there is one. If there isn't a `catch` block, the error halts the function.
 
-If you expect that cells with the targeted characteristic should always exist, you'll likely want your code to throw an error if those cells aren't there. If its a valid scenario that there aren't any matching cells, your code should check for this possibility and handle it gracefully without throwing an error. You can achieve this with the `getSpecialCellsOrNullObject` method and its returned `isNullObject` property. The following example uses this pattern. About this code, note:
+If you expect that cells with the targeted characteristic should always exist, you'll likely want your code to throw an error if those cells aren't there. If its a valid scenario that there aren't any matching cells, your code should check for this possibility and handle it gracefully without throwing an error. You can achieve this behavior with the `getSpecialCellsOrNullObject` method and its returned `isNullObject` property. The following example uses this pattern. About this code, note:
 
 - The `getSpecialCellsOrNullObject` method always returns a proxy object, so it is never `null` in the ordinary JavaScript sense. But if no matching cells are found, the `isNullObject` property of the object is set to `true`.
 - It calls `context.sync` *before* it tests the `isNullObject` property. This is a requirement with all `*OrNullObject` methods and properties, because you always have to load and sync a property in order to read it. However, it is not necessary to *explicitly* load the `isNullObject` property. It is automatically loaded by the `context.sync` even if `load` is not called on the object. For more information, see [\*OrNullObject](https://docs.microsoft.com/office/dev/add-ins/excel/excel-add-ins-advanced-concepts#42ornullobject-methods).
@@ -140,7 +140,7 @@ The `Excel.SpecialCellValueType` enum has these four basic types (in addition to
 - "Numbers"
 - "Text"
 
-The following example finds special cells that are numerical constants and highlights those cells pink. About this code, note:
+The following example finds special cells that are numerical constants and colors those cells pink. About this code, note:
 
 - It will only highlight cells that have a literal number value. It will not highlight cells that have a formula (even if the result is a number) or a boolean, text, or error state cells.
 - To test the code, be sure the worksheet has some cells with literal number values, some with other kinds of literal values, and some with formulas.
@@ -160,7 +160,7 @@ Excel.run(function (context) {
 
 #### Test for a multiple cell value types
 
-Sometimes you need to operate on more than one cell value type, such as all text-valued and all boolean-valued ("Logical") cells. The `Excel.SpecialCellValueType` enum has values that let you combine types. For example, "LogicalText" will target all boolean and all text-valued cells. You can combine any two or any three of the four basic types. The names of these enum values that combine basic types are always in alphabetical order. So to combine error-valued, text-valued, and boolean-valued cells, use "ErrorLogicalText", not "LogicalErrorText" or "TextErrorLogical". "All" is the default value, which does not limit the cell value types returned. The following example highlights all cells with formulas that produce number or boolean value.
+Sometimes you need to operate on more than one cell value type, such as all text-valued and all boolean-valued ("Logical") cells. The `Excel.SpecialCellValueType` enum has values that let you combine types. For example, "LogicalText" targets all boolean and all text-valued cells. You can combine any two or any three of the four basic types. The names of these enum values that combine basic types are always in alphabetical order. So to combine error-valued, text-valued, and boolean-valued cells, use "ErrorLogicalText", not "LogicalErrorText" or "TextErrorLogical". "All" is the default value, which does not limit the cell value types returned. The following example colors all cells with formulas that produce number or boolean value.
 
 ```js
 Excel.run(function (context) {

--- a/docs/excel/excel-add-ins-ranges-advanced.md
+++ b/docs/excel/excel-add-ins-ranges-advanced.md
@@ -263,4 +263,4 @@ Excel.run(async (context) => {
 
 - [Work with ranges using the Excel JavaScript API](excel-add-ins-ranges.md)
 - [Fundamental programming concepts with the Excel JavaScript API](excel-add-ins-core-concepts.md)
-- [Work with multiple ranges simultaneously in Excel add-ins](excel.add-ins-multiple-ranges.md)
+- [Work with multiple ranges simultaneously in Excel add-ins](excel-add-ins-multiple-ranges.md)


### PR DESCRIPTION
This PR is to balance the special cells content appropriately between the Range and RangeAreas articles. the `getSpecialCells` methods are on both `Range` and `RangeAreas`, but return a `RangeAreas` object. In my mind, this makes them a `Range` topic, with the more advanced, multi-range behavior described in `RangeAreas`. 

Most of the text was directly moved from the RangeAreas article, with some small changes to make it contextually fit.

I'm open to organizational suggestions, as well as content edits across the board.