### PR TITLE
[Admin] (metadata) - Add metadata to markdown files to resolve CATS errors.

### DIFF
--- a/docs/design/accessibility-guidelines.md
+++ b/docs/design/accessibility-guidelines.md
@@ -1,3 +1,9 @@
+---
+title: Accessibility guidelines for Office Add-ins
+description: ''
+ms.date: 09/24/2018
+---
+
 # Accessibility guidelines
 
 As you design and develop your Office Add-ins, you'll want to ensure that all potential users and customers are able to use your add-in successfully. Apply the following guidelines to ensure that your solution is accessible to all audiences.

--- a/docs/design/add-in-color.md
+++ b/docs/design/add-in-color.md
@@ -1,3 +1,9 @@
+---
+title: Color guidelines for Office Add-ins
+description: ''
+ms.date: 06/27/2018
+---
+
 # Color
 Color is often used to emphasize brand and reinforce visual hierarchy. It helps identify an interface as well as guide customers through an experience. Inside Office, color is used for the same goals but it is applied purposefully and minimally. At no point does it overwhelm customer content. Even when each Office app is branded with its own dominant color, it is used sparingly.
 

--- a/docs/design/add-in-icons.md
+++ b/docs/design/add-in-icons.md
@@ -1,3 +1,9 @@
+---
+title: Icon guidelines for Office Add-ins
+description: ''
+ms.date: 06/27/2018
+---
+
 # Icons
 Icons are the visual representation of a behavior or concept. They are often used to add meaning to controls and commands. Visuals, either realistic or symbolic, enable the user to navigate the UI the same way signs help users navigate their environment. They should be simple, clear, and contain only the necessary details to enable customers to quickly parse what action will occur when they choose a control.
 

--- a/docs/design/add-in-layout.md
+++ b/docs/design/add-in-layout.md
@@ -1,3 +1,9 @@
+---
+title: Layout guidelines for Office Add-ins
+description: ''
+ms.date: 06/27/2018
+---
+
 # Layout
 Each HTML container embedded in Office will have a layout. These layouts are the main screens of your add-in. In them you will create experiences that enable customers to initiate actions, modify settings, view, scroll, or navigate content. Design your add-in with a consistent layouts across screens to guarantee continuity of experience. If you have an existing website that your customers are familiar with using, consider reusing layouts from your existing web pages. Adapt them to fit harmoniously within Office HTML containers.
 

--- a/docs/design/add-in-typography.md
+++ b/docs/design/add-in-typography.md
@@ -1,3 +1,9 @@
+---
+title: Typography guidelines for Office Add-ins
+description: ''
+ms.date: 06/27/2018
+---
+
 # Typography
 
 Segoe is the standard typeface for Office. Use it in your add-in to align with Office task panes, dialog boxes, and content objects. Office UI Fabric gives you access to Segoe. It provides a full type ramp of Segoe with many variations - across font weight and size - in convenient CSS classes. Not all Office UI Fabric sizes and weights will look great in an Office Add-in. To fit harmoniously or avoid conflicts, consider using a subset of the Fabric type ramp. Here's a list of Fabric's base classes that we recommend for use in Office Add-ins.

--- a/docs/design/authentication-patterns.md
+++ b/docs/design/authentication-patterns.md
@@ -1,3 +1,9 @@
+---
+title: Authentication design guidelines for Office Add-ins
+description: ''
+ms.date: 11/02/2018
+---
+
 # Authentication patterns
 
 Add-ins may require users to sign-in or sign-up in order to access features and functionality. Input boxes for username and password or buttons that start third party credential flows are common interface controls in authentication experiences. A simple and efficient authentication experience is an important first step to getting users started with your add-in.

--- a/docs/design/branding-patterns.md
+++ b/docs/design/branding-patterns.md
@@ -1,3 +1,9 @@
+---
+title: Branding patterns design guidelines for Office Add-ins
+description: ''
+ms.date: 06/26/2018
+---
+
 # Branding patterns
 
 These patterns provide brand visibilty and context to your add-in users. 

--- a/docs/design/design-toolkits.md
+++ b/docs/design/design-toolkits.md
@@ -1,4 +1,10 @@
-#Design toolkits
+---
+title: Design toolkits for Office Add-ins
+description: ''
+ms.date: 06/27/2018
+---
+
+# Design toolkits
 
 We've included our toolkit to help you get started. You can find all of our available patterns here with brief descriptions, layout recommendations, and a sample add-in.
 

--- a/docs/design/first-run-experience-patterns.md
+++ b/docs/design/first-run-experience-patterns.md
@@ -1,3 +1,9 @@
+---
+title: First-run experience patterns for Office Add-ins
+description: ''
+ms.date: 06/26/2018
+---
+
 # First-run experience patterns
 
 A First-run Experience (FRE) is a user's introduction to your add-in. An FRE is presented when a user opens an add-in for the first time and provides them with insight into the functions, features, and/or benefits of the add-in. This experience helps shape the user's impression of an add-in and can strongly influence their likelihood to come back to and continue using your add-in..

--- a/docs/design/navigation-patterns.md
+++ b/docs/design/navigation-patterns.md
@@ -1,3 +1,9 @@
+---
+title: Navigation patterns for Office Add-ins
+description: ''
+ms.date: 06/26/2018
+---
+
 # Navigation patterns
 
 The main features of an add-in are accessed through specific command types and limited screen area. It is important that navigation is intuitive, provides context, and allows the user to move easily throughout the add-in.

--- a/docs/design/using-motion-office-addins.md
+++ b/docs/design/using-motion-office-addins.md
@@ -1,3 +1,9 @@
+---
+title: Using motion in Office Add-ins
+description: ''
+ms.date: 03/23/2018
+---
+
 # Using motion in Office Add-ins
 
 When you design an Office Add-in, you can use motion to enhance the user experience. UI elements, controls, and components often have interactive behaviors that require transitions, motion, or animation. Common characteristics of motion across UI elements define the animation aspects of a design language. 

--- a/docs/design/ux-design-pattern-templates.md
+++ b/docs/design/ux-design-pattern-templates.md
@@ -1,3 +1,9 @@
+---
+title: UX design patterns for Office Add-ins
+description: ''
+ms.date: 06/27/2018
+---
+
 # UX design patterns for Office Add-ins
 
 Designing the user experience for Office Add-ins should provide a compelling experience for Office users and extend the overall Office experience by fitting seamlessly within the default Office UI.  

--- a/docs/design/voice-guidelines.md
+++ b/docs/design/voice-guidelines.md
@@ -1,3 +1,9 @@
+---
+title: Voice guidelines for Office Add-ins
+description: ''
+ms.date: 06/27/2018
+---
+
 # Voice guidelines
 
 As you design your Office Add-ins, consider the voice that you use in your UI text and elements. Strive to match the voice and tone of the Office UI, which is conversational, engaging, and accessible to users. 

--- a/docs/excel/excel-add-ins-conditional-formatting.md
+++ b/docs/excel/excel-add-ins-conditional-formatting.md
@@ -1,3 +1,9 @@
+---
+title: Apply conditional formatting to ranges with the Excel JavaScript API
+description: ''
+ms.date: 10/22/2018
+---
+
 # Apply conditional formatting to Excel ranges
 
 The Excel JavaScript Library provides APIs to apply conditional formatting to data ranges in your worksheets. This functionality makes large sets of data easy to visually parse. The formatting also dynamically updates based on changes within the range. 

--- a/docs/reference/javascript-api-for-office.md
+++ b/docs/reference/javascript-api-for-office.md
@@ -1,3 +1,9 @@
+---
+title: JavaScript API for Office
+description: ''
+ms.date: 10/09/2018
+---
+
 # JavaScript API for Office
 
 The JavaScript API for Office enables you to create web applications that interact with the object models in Office host applications. Your application will reference the office.js library, which is a script loader. The office.js library loads the object models that are applicable to the Office application that is running the add-in. You can use the following JavaScript object models:

--- a/docs/reference/manifest/action.md
+++ b/docs/reference/manifest/action.md
@@ -1,5 +1,5 @@
 ---
-title: Action element - Office Add-ins manifest
+title: Action element in the manifest file
 description: ''
 ms.date: 11/14/2018
 ---

--- a/docs/reference/manifest/action.md
+++ b/docs/reference/manifest/action.md
@@ -1,3 +1,9 @@
+---
+title: Action element - Office Add-ins manifest
+description: ''
+ms.date: 11/14/2018
+---
+
 # Action element
 
 Specifies the action to perform when the user selects a  [Button](control.md#button-control) or [Menu](control.md#menu-dropdown-button-controls) controls.

--- a/docs/reference/manifest/allformfactors.md
+++ b/docs/reference/manifest/allformfactors.md
@@ -1,3 +1,9 @@
+---
+title: AllFormFactors element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # AllFormFactors element
 
 Specifies the settings for an add-in for all form factors. Currently, the only feature using **AllFormFactors** is custom functions. **AllFormFactors** is a required element when using custom functions.

--- a/docs/reference/manifest/allformfactors.md
+++ b/docs/reference/manifest/allformfactors.md
@@ -1,5 +1,5 @@
 ---
-title: AllFormFactors element - Office Add-ins manifest
+title: AllFormFactors element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/allowsnapshot.md
+++ b/docs/reference/manifest/allowsnapshot.md
@@ -1,5 +1,5 @@
 ---
-title: AllowSnapshot element - Office Add-ins manifest
+title: AllowSnapshot element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/allowsnapshot.md
+++ b/docs/reference/manifest/allowsnapshot.md
@@ -1,3 +1,9 @@
+---
+title: AllowSnapshot element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # AllowSnapshot element
 
 Specifies whether a snapshot image of your content add-in is saved with the host document.

--- a/docs/reference/manifest/alternateid.md
+++ b/docs/reference/manifest/alternateid.md
@@ -1,5 +1,5 @@
 ---
-title: AlternateId element - Office Add-ins manifest
+title: AlternateId element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/alternateid.md
+++ b/docs/reference/manifest/alternateid.md
@@ -1,3 +1,9 @@
+---
+title: AlternateId element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # AlternateId element
 
 Specifies the alternate ID for your Office Add-in as issued by the Office Store.

--- a/docs/reference/manifest/appdomain.md
+++ b/docs/reference/manifest/appdomain.md
@@ -1,5 +1,5 @@
 ---
-title: AppDomain element - Office Add-ins manifest
+title: AppDomain element in the manifest file
 description: ''
 ms.date: 12/13/2018
 ---

--- a/docs/reference/manifest/appdomain.md
+++ b/docs/reference/manifest/appdomain.md
@@ -1,3 +1,9 @@
+---
+title: AppDomain element - Office Add-ins manifest
+description: ''
+ms.date: 12/13/2018
+---
+
 # AppDomain element
 
 Specifies an additional domain that will be used to load pages in the add-in window.

--- a/docs/reference/manifest/appdomains.md
+++ b/docs/reference/manifest/appdomains.md
@@ -1,3 +1,9 @@
+---
+title: AppDomains element - Office Add-ins manifest
+description: ''
+ms.date: 12/13/2018
+---
+
 # AppDomains element
 
 Lists any domains in addition to the domain specified in the SourceLocation element that your Office Add-in will use to load pages. For each additional domain, specify an AppDomain element.

--- a/docs/reference/manifest/appdomains.md
+++ b/docs/reference/manifest/appdomains.md
@@ -1,5 +1,5 @@
 ---
-title: AppDomains element - Office Add-ins manifest
+title: AppDomains element in the manifest file
 description: ''
 ms.date: 12/13/2018
 ---

--- a/docs/reference/manifest/citationtext.md
+++ b/docs/reference/manifest/citationtext.md
@@ -1,3 +1,9 @@
+---
+title: CitationText element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # CitationText element
 
 Specifies the citation boilerplate text for this dictionary.

--- a/docs/reference/manifest/citationtext.md
+++ b/docs/reference/manifest/citationtext.md
@@ -1,5 +1,5 @@
 ---
-title: CitationText element - Office Add-ins manifest
+title: CitationText element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/control.md
+++ b/docs/reference/manifest/control.md
@@ -1,5 +1,5 @@
 ---
-title: Control element - Office Add-ins manifest
+title: Control element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/control.md
+++ b/docs/reference/manifest/control.md
@@ -1,3 +1,9 @@
+---
+title: Control element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # Control element
 
 Defines a JavaScript function that executes an action or launches a task pane. A **Control** element can be either a button or a menu option. At least one **Control** must be included in a [Group](group.md) element.

--- a/docs/reference/manifest/customfunctionssourcelocation.md
+++ b/docs/reference/manifest/customfunctionssourcelocation.md
@@ -1,3 +1,9 @@
+---
+title: SourceLocation element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # SourceLocation element
 
 Defines the location of a resource needed by the Script or Page elements used by custom functions in Excel.

--- a/docs/reference/manifest/customfunctionssourcelocation.md
+++ b/docs/reference/manifest/customfunctionssourcelocation.md
@@ -1,5 +1,5 @@
 ---
-title: SourceLocation element - Office Add-ins manifest
+title: SourceLocation element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/customtab.md
+++ b/docs/reference/manifest/customtab.md
@@ -1,5 +1,5 @@
 ---
-title: CustomTab element - Office Add-ins manifest
+title: CustomTab element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/customtab.md
+++ b/docs/reference/manifest/customtab.md
@@ -1,3 +1,9 @@
+---
+title: CustomTab element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # CustomTab element
 
 On the ribbon, you specify which tab and group for their add-in commands. This can either be on the default tab (either  **Home**,  **Message**, or  **Meeting**), or on a custom tab defined by the add-in.

--- a/docs/reference/manifest/defaultlocale.md
+++ b/docs/reference/manifest/defaultlocale.md
@@ -1,3 +1,9 @@
+---
+title: DefaultLocale element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # DefaultLocale element
 
 Specifies the default culture name of the locale used by strings in your add-in.

--- a/docs/reference/manifest/defaultlocale.md
+++ b/docs/reference/manifest/defaultlocale.md
@@ -1,5 +1,5 @@
 ---
-title: DefaultLocale element - Office Add-ins manifest
+title: DefaultLocale element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/defaultsettings.md
+++ b/docs/reference/manifest/defaultsettings.md
@@ -1,3 +1,9 @@
+---
+title: DefaultSettings element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # DefaultSettings element
 
 Specifies the default source location and other default settings for your content or task pane add-in.

--- a/docs/reference/manifest/defaultsettings.md
+++ b/docs/reference/manifest/defaultsettings.md
@@ -1,5 +1,5 @@
 ---
-title: DefaultSettings element - Office Add-ins manifest
+title: DefaultSettings element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/description.md
+++ b/docs/reference/manifest/description.md
@@ -1,5 +1,5 @@
 ---
-title: Description element - Office Add-ins manifest
+title: Description element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/description.md
+++ b/docs/reference/manifest/description.md
@@ -1,3 +1,9 @@
+---
+title: Description element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # Description element
 
 Specifies the description of your Office Add-in as a string no longer than 250 characters.

--- a/docs/reference/manifest/desktopformfactor.md
+++ b/docs/reference/manifest/desktopformfactor.md
@@ -1,3 +1,9 @@
+---
+title: DesktopFormFactor element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # DesktopFormFactor element
 
 Specifies the settings for an add-in for the desktop form factor. The desktop form factor includes Office for Windows, Office for Mac, and Office Online. It contains all the add-in information for the desktop form factor except for the  **Resources** node.

--- a/docs/reference/manifest/desktopformfactor.md
+++ b/docs/reference/manifest/desktopformfactor.md
@@ -1,5 +1,5 @@
 ---
-title: DesktopFormFactor element - Office Add-ins manifest
+title: DesktopFormFactor element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/desktopsettings.md
+++ b/docs/reference/manifest/desktopsettings.md
@@ -1,5 +1,5 @@
 ---
-title: DesktopSettings element - Office Add-ins manifest
+title: DesktopSettings element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/desktopsettings.md
+++ b/docs/reference/manifest/desktopsettings.md
@@ -1,3 +1,9 @@
+---
+title: DesktopSettings element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # DesktopSettings element
 
 Specifies source location and control settings that apply when your mail add-in is used on a desktop computer.

--- a/docs/reference/manifest/dictionary.md
+++ b/docs/reference/manifest/dictionary.md
@@ -1,3 +1,9 @@
+---
+title: Dictionary element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # Dictionary element
 Defines settings for a task pane add-in that implements additional dictionary support.
 

--- a/docs/reference/manifest/dictionary.md
+++ b/docs/reference/manifest/dictionary.md
@@ -1,5 +1,5 @@
 ---
-title: Dictionary element - Office Add-ins manifest
+title: Dictionary element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/dictionaryhomepage.md
+++ b/docs/reference/manifest/dictionaryhomepage.md
@@ -1,5 +1,5 @@
 ---
-title: DictionaryHomePage element - Office Add-ins manifest
+title: DictionaryHomePage element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/dictionaryhomepage.md
+++ b/docs/reference/manifest/dictionaryhomepage.md
@@ -1,3 +1,9 @@
+---
+title: DictionaryHomePage element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # DictionaryHomePage element
 
 Specifies the URL of the home page for the dictionary.

--- a/docs/reference/manifest/dictionaryname.md
+++ b/docs/reference/manifest/dictionaryname.md
@@ -1,3 +1,9 @@
+---
+title: DictionaryName element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # DictionaryName element
 
 Specifies the name of this dictionary.

--- a/docs/reference/manifest/dictionaryname.md
+++ b/docs/reference/manifest/dictionaryname.md
@@ -1,5 +1,5 @@
 ---
-title: DictionaryName element - Office Add-ins manifest
+title: DictionaryName element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/disableentityhighlighting.md
+++ b/docs/reference/manifest/disableentityhighlighting.md
@@ -1,3 +1,9 @@
+---
+title: DisableEntityHighlighting element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # DisableEntityHighlighting element
 
 Specifies whether entity highlighting should be turned off for your mail add-in.

--- a/docs/reference/manifest/disableentityhighlighting.md
+++ b/docs/reference/manifest/disableentityhighlighting.md
@@ -1,5 +1,5 @@
 ---
-title: DisableEntityHighlighting element - Office Add-ins manifest
+title: DisableEntityHighlighting element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/displayname.md
+++ b/docs/reference/manifest/displayname.md
@@ -1,3 +1,9 @@
+---
+title: DisplayName element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # DisplayName element
 
 Specifies the name for your Office Add-in as a string up to 125 characters long.

--- a/docs/reference/manifest/displayname.md
+++ b/docs/reference/manifest/displayname.md
@@ -1,5 +1,5 @@
 ---
-title: DisplayName element - Office Add-ins manifest
+title: DisplayName element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/event.md
+++ b/docs/reference/manifest/event.md
@@ -1,5 +1,5 @@
 ---
-title: Event element - Office Add-ins manifest
+title: Event element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/event.md
+++ b/docs/reference/manifest/event.md
@@ -1,3 +1,9 @@
+---
+title: Event element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # Event element
 
 Defines an event handler in an add-in.

--- a/docs/reference/manifest/extensionpoint.md
+++ b/docs/reference/manifest/extensionpoint.md
@@ -1,5 +1,5 @@
 ---
-title: ExtensionPoint element - Office Add-ins manifest
+title: ExtensionPoint element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/extensionpoint.md
+++ b/docs/reference/manifest/extensionpoint.md
@@ -1,3 +1,9 @@
+---
+title: ExtensionPoint element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # ExtensionPoint element
 
  Defines where an add-in exposes functionality in the Office UI. The **ExtensionPoint** element is a child element of [AllFormFactors](allformfactors.md), [DesktopFormFactor](desktopformfactor.md) or [MobileFormFactor](mobileformfactor.md). 

--- a/docs/reference/manifest/form.md
+++ b/docs/reference/manifest/form.md
@@ -1,3 +1,9 @@
+---
+title: Form element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # Form element
 
 UX settings for the forms that your mail add-in will use when running on a particular device (desktop, tablet, or phone).

--- a/docs/reference/manifest/form.md
+++ b/docs/reference/manifest/form.md
@@ -1,5 +1,5 @@
 ---
-title: Form element - Office Add-ins manifest
+title: Form element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/formsettings.md
+++ b/docs/reference/manifest/formsettings.md
@@ -1,3 +1,9 @@
+---
+title: FormSettings element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # FormSettings element
 
 Specifies source location and control settings for your mail add-in.

--- a/docs/reference/manifest/formsettings.md
+++ b/docs/reference/manifest/formsettings.md
@@ -1,5 +1,5 @@
 ---
-title: FormSettings element - Office Add-ins manifest
+title: FormSettings element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/functionfile.md
+++ b/docs/reference/manifest/functionfile.md
@@ -1,3 +1,9 @@
+---
+title: FunctionFile element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # FunctionFile element
 
 Specifies the source code file for operations that an add-in exposes through add-in commands that execute a JavaScript function instead of displaying UI. The  **FunctionFile** element is a child element of [DesktopFormFactor](desktopformfactor.md) or [MobileFormFactor](mobileformfactor.md). The **resid** attribute of the **FunctionFile** element is set to the value of the **id** attribute of a **Url** element in the **Resources** element that contains the URL to an HTML file that contains or loads all  the JavaScript functions used by UI-less add-in command buttons, as defined by the [Control element](control.md).

--- a/docs/reference/manifest/functionfile.md
+++ b/docs/reference/manifest/functionfile.md
@@ -1,5 +1,5 @@
 ---
-title: FunctionFile element - Office Add-ins manifest
+title: FunctionFile element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/getstarted.md
+++ b/docs/reference/manifest/getstarted.md
@@ -1,3 +1,9 @@
+---
+title: GetStarted element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # GetStarted element
 
 Provides information used by the callout that appears when the add-in is installed in Word, Excel, PowerPoint, and OneNote hosts. The **GetStarted** element is a child element of [DesktopFormFactor](desktopformfactor.md).

--- a/docs/reference/manifest/getstarted.md
+++ b/docs/reference/manifest/getstarted.md
@@ -1,5 +1,5 @@
 ---
-title: GetStarted element - Office Add-ins manifest
+title: GetStarted element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/group.md
+++ b/docs/reference/manifest/group.md
@@ -1,3 +1,9 @@
+---
+title: Group element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # Group element
 
 Defines a group of UI controls in a tab.  On custom tabs, the add-in can create up to 10 groups. Each group is limited to 6 controls, regardless of which tab it appears on. Add-ins are limited to one custom tab.

--- a/docs/reference/manifest/group.md
+++ b/docs/reference/manifest/group.md
@@ -1,5 +1,5 @@
 ---
-title: Group element - Office Add-ins manifest
+title: Group element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/highresolutioniconurl.md
+++ b/docs/reference/manifest/highresolutioniconurl.md
@@ -1,3 +1,9 @@
+---
+title: HighResolutionIconUrl element - Office Add-ins manifest
+description: ''
+ms.date: 12/04/2018
+---
+
 # HighResolutionIconUrl element
 
 Specifies the URL of the image that is used to represent your Office Add-in in the insertion UX and Office Store on high DPI screens.

--- a/docs/reference/manifest/highresolutioniconurl.md
+++ b/docs/reference/manifest/highresolutioniconurl.md
@@ -1,5 +1,5 @@
 ---
-title: HighResolutionIconUrl element - Office Add-ins manifest
+title: HighResolutionIconUrl element in the manifest file
 description: ''
 ms.date: 12/04/2018
 ---

--- a/docs/reference/manifest/host.md
+++ b/docs/reference/manifest/host.md
@@ -1,3 +1,9 @@
+---
+title: Host element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # Host element
 
 Specifies an individual Office application type where the add-in should activate.

--- a/docs/reference/manifest/host.md
+++ b/docs/reference/manifest/host.md
@@ -1,5 +1,5 @@
 ---
-title: Host element - Office Add-ins manifest
+title: Host element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/hosts.md
+++ b/docs/reference/manifest/hosts.md
@@ -1,3 +1,9 @@
+---
+title: Hosts element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # Hosts element
 
 Specifies the Office client application where the Office Add-in will activate. Contains a collection of **Host** elements and their settings. 

--- a/docs/reference/manifest/hosts.md
+++ b/docs/reference/manifest/hosts.md
@@ -1,5 +1,5 @@
 ---
-title: Hosts element - Office Add-ins manifest
+title: Hosts element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/icon.md
+++ b/docs/reference/manifest/icon.md
@@ -1,3 +1,9 @@
+---
+title: Icon element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # Icon element
 
 Defines **Image** elements for [Button](control.md#button-control) or [Menu](control.md#menu-dropdown-button-controls) controls.

--- a/docs/reference/manifest/icon.md
+++ b/docs/reference/manifest/icon.md
@@ -1,5 +1,5 @@
 ---
-title: Icon element - Office Add-ins manifest
+title: Icon element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/iconurl.md
+++ b/docs/reference/manifest/iconurl.md
@@ -1,5 +1,5 @@
 ---
-title: IconUrl element - Office Add-ins manifest
+title: IconUrl element in the manifest file
 description: ''
 ms.date: 12/04/2018
 ---

--- a/docs/reference/manifest/iconurl.md
+++ b/docs/reference/manifest/iconurl.md
@@ -1,3 +1,9 @@
+---
+title: IconUrl element - Office Add-ins manifest
+description: ''
+ms.date: 12/04/2018
+---
+
 # IconUrl element
 
 Specifies the URL of the image that is used to represent your Office Add-in in the insertion UX and Office Store.

--- a/docs/reference/manifest/id.md
+++ b/docs/reference/manifest/id.md
@@ -1,3 +1,9 @@
+---
+title: Id element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # Id element
 
 Specifies the unique ID of your Office Add-in as a GUID.

--- a/docs/reference/manifest/id.md
+++ b/docs/reference/manifest/id.md
@@ -1,5 +1,5 @@
 ---
-title: Id element - Office Add-ins manifest
+title: Id element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/metadata.md
+++ b/docs/reference/manifest/metadata.md
@@ -1,5 +1,5 @@
 ---
-title: Metadata element - Office Add-ins manifest
+title: Metadata element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/metadata.md
+++ b/docs/reference/manifest/metadata.md
@@ -1,3 +1,9 @@
+---
+title: Metadata element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # Metadata element
 
 Defines the metadata settings used by a custom function in Excel.

--- a/docs/reference/manifest/method.md
+++ b/docs/reference/manifest/method.md
@@ -1,3 +1,9 @@
+---
+title: Method element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # Method element
 
 Specifies an individual method from the JavaScript API for Office that your Office Add-in requires in order to activate.

--- a/docs/reference/manifest/method.md
+++ b/docs/reference/manifest/method.md
@@ -1,5 +1,5 @@
 ---
-title: Method element - Office Add-ins manifest
+title: Method element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/methods.md
+++ b/docs/reference/manifest/methods.md
@@ -1,5 +1,5 @@
 ---
-title: Methods element - Office Add-ins manifest
+title: Methods element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/methods.md
+++ b/docs/reference/manifest/methods.md
@@ -1,3 +1,9 @@
+---
+title: Methods element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # Methods element
 
 Specifies the list of JavaScript API for Office methods that your Office Add-in requires in order to activate.

--- a/docs/reference/manifest/mobileformfactor.md
+++ b/docs/reference/manifest/mobileformfactor.md
@@ -1,3 +1,9 @@
+---
+title: MobileFormFactor element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # MobileFormFactor element
 
 Specifies the settings for an add-in for the mobile form factor. It contains all the add-in information for the mobile form factor except for the **Resources** node.

--- a/docs/reference/manifest/mobileformfactor.md
+++ b/docs/reference/manifest/mobileformfactor.md
@@ -1,5 +1,5 @@
 ---
-title: MobileFormFactor element - Office Add-ins manifest
+title: MobileFormFactor element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/namespace.md
+++ b/docs/reference/manifest/namespace.md
@@ -1,5 +1,5 @@
 ---
-title: Namespace element - Office Add-ins manifest
+title: Namespace element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/namespace.md
+++ b/docs/reference/manifest/namespace.md
@@ -1,3 +1,9 @@
+---
+title: Namespace element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # Namespace element
 
 Defines the namespace used by a custom function in Excel.

--- a/docs/reference/manifest/officeapp.md
+++ b/docs/reference/manifest/officeapp.md
@@ -1,3 +1,9 @@
+---
+title: OfficeApp element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # OfficeApp element
 
 The root element in the manifest of an Office Add-in.

--- a/docs/reference/manifest/officeapp.md
+++ b/docs/reference/manifest/officeapp.md
@@ -1,5 +1,5 @@
 ---
-title: OfficeApp element - Office Add-ins manifest
+title: OfficeApp element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/officemenu.md
+++ b/docs/reference/manifest/officemenu.md
@@ -1,5 +1,5 @@
 ---
-title: OfficeMenu element - Office Add-ins manifest
+title: OfficeMenu element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/officemenu.md
+++ b/docs/reference/manifest/officemenu.md
@@ -1,3 +1,9 @@
+---
+title: OfficeMenu element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # OfficeMenu element
 
 Defines a collection of controls to be added to the Office context menu. Applies to Word, Excel, PowerPoint, and OneNote add-ins.

--- a/docs/reference/manifest/officetab.md
+++ b/docs/reference/manifest/officetab.md
@@ -1,3 +1,9 @@
+---
+title: OfficeTab element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # OfficeTab element
 
 Defines the ribbon tab on which your add-in command appears. This can either be the default tab (either  **Home**,  **Message**, or  **Meeting**), or a custom tab defined by the add-in. This element is required.

--- a/docs/reference/manifest/officetab.md
+++ b/docs/reference/manifest/officetab.md
@@ -1,5 +1,5 @@
 ---
-title: OfficeTab element - Office Add-ins manifest
+title: OfficeTab element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/override.md
+++ b/docs/reference/manifest/override.md
@@ -1,3 +1,9 @@
+---
+title: Override element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # Override element
 
 Provides a way to specify the value of a setting for an additional locale.

--- a/docs/reference/manifest/override.md
+++ b/docs/reference/manifest/override.md
@@ -1,5 +1,5 @@
 ---
-title: Override element - Office Add-ins manifest
+title: Override element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/page.md
+++ b/docs/reference/manifest/page.md
@@ -1,3 +1,9 @@
+---
+title: Page element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # Page element
 
 Defines HTML page settings used by a custom function in Excel.

--- a/docs/reference/manifest/page.md
+++ b/docs/reference/manifest/page.md
@@ -1,5 +1,5 @@
 ---
-title: Page element - Office Add-ins manifest
+title: Page element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/permissions.md
+++ b/docs/reference/manifest/permissions.md
@@ -1,3 +1,9 @@
+---
+title: Permissions element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # Permissions element
 
 Specifies the level of API access for your Office Add-in; you should request permissions based on the principle of least privilege.

--- a/docs/reference/manifest/permissions.md
+++ b/docs/reference/manifest/permissions.md
@@ -1,5 +1,5 @@
 ---
-title: Permissions element - Office Add-ins manifest
+title: Permissions element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/phonesettings.md
+++ b/docs/reference/manifest/phonesettings.md
@@ -1,5 +1,5 @@
 ---
-title: PhoneSettings element - Office Add-ins manifest
+title: PhoneSettings element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/phonesettings.md
+++ b/docs/reference/manifest/phonesettings.md
@@ -1,3 +1,9 @@
+---
+title: PhoneSettings element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # PhoneSettings element
 
 Specifies source location and control settings that apply when your mail add-in is used on a phone.

--- a/docs/reference/manifest/providername.md
+++ b/docs/reference/manifest/providername.md
@@ -1,5 +1,5 @@
 ---
-title: ProviderName element - Office Add-ins manifest
+title: ProviderName element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/providername.md
+++ b/docs/reference/manifest/providername.md
@@ -1,3 +1,9 @@
+---
+title: ProviderName element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # ProviderName element
 
 Specifies the name of the individual or company that developed this Office Add-in as a string of no more than 125 characters.

--- a/docs/reference/manifest/queryuri.md
+++ b/docs/reference/manifest/queryuri.md
@@ -1,3 +1,9 @@
+---
+title: QueryUri element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # QueryUri element
 
 Specifies the URL of the endpoint for the dictionary query service.

--- a/docs/reference/manifest/queryuri.md
+++ b/docs/reference/manifest/queryuri.md
@@ -1,5 +1,5 @@
 ---
-title: QueryUri element - Office Add-ins manifest
+title: QueryUri element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/requestedheight.md
+++ b/docs/reference/manifest/requestedheight.md
@@ -1,5 +1,5 @@
 ---
-title: RequestedHeight element - Office Add-ins manifest
+title: RequestedHeight element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/requestedheight.md
+++ b/docs/reference/manifest/requestedheight.md
@@ -1,3 +1,9 @@
+---
+title: RequestedHeight element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # RequestedHeight element
 
 Specifies the initial height (in pixels) of a content add-in or mail add-in. 

--- a/docs/reference/manifest/requestedwidth.md
+++ b/docs/reference/manifest/requestedwidth.md
@@ -1,5 +1,5 @@
 ---
-title: RequestedWidth element - Office Add-ins manifest
+title: RequestedWidth element in the manifest file
 description: ''
 ms.date: 11/13/2018
 ---

--- a/docs/reference/manifest/requestedwidth.md
+++ b/docs/reference/manifest/requestedwidth.md
@@ -1,3 +1,9 @@
+---
+title: RequestedWidth element - Office Add-ins manifest
+description: ''
+ms.date: 11/13/2018
+---
+
 # RequestedWidth element
 
 Specifies the initial width of a content add-in in pixels, which can be between 32 and 1000.

--- a/docs/reference/manifest/requirements.md
+++ b/docs/reference/manifest/requirements.md
@@ -1,5 +1,5 @@
 ---
-title: Requirements element - Office Add-ins manifest
+title: Requirements element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/requirements.md
+++ b/docs/reference/manifest/requirements.md
@@ -1,3 +1,9 @@
+---
+title: Requirements element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # Requirements element
 
 Specifies the minimum set of JavaScript API for Office requirements ([requirement sets](https://docs.microsoft.com/office/dev/add-ins/develop/office-versions-and-requirement-sets#specify-office-hosts-and-requirement-sets) and/or methods) that your Office Add-in needs to activate.

--- a/docs/reference/manifest/resources.md
+++ b/docs/reference/manifest/resources.md
@@ -1,5 +1,5 @@
 ---
-title: Resources element - Office Add-ins manifest
+title: Resources element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/resources.md
+++ b/docs/reference/manifest/resources.md
@@ -1,3 +1,9 @@
+---
+title: Resources element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # Resources element
 
 Contains icons, strings, and URLs for the [VersionOverrides](versionoverrides.md) node. A manifest element specifies a resource by using the **id** of the resource. This helps to keep the size of the manifest manageable, especially when resources have versions for different locales. An **id** must be unique within the manifest and can have a maximum of 32 characters.

--- a/docs/reference/manifest/rule.md
+++ b/docs/reference/manifest/rule.md
@@ -1,5 +1,5 @@
 ---
-title: Rule element - Office Add-ins manifest
+title: Rule element in the manifest file
 description: ''
 ms.date: 11/30/2018
 ---

--- a/docs/reference/manifest/rule.md
+++ b/docs/reference/manifest/rule.md
@@ -1,3 +1,9 @@
+---
+title: Rule element - Office Add-ins manifest
+description: ''
+ms.date: 11/30/2018
+---
+
 # Rule element
 
 Specifies the activation rule(s) that should be evaluated for this contextual mail add-in.

--- a/docs/reference/manifest/scopes.md
+++ b/docs/reference/manifest/scopes.md
@@ -1,3 +1,9 @@
+---
+title: Scopes element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # Scopes element
 
 Contains permissions to Microsoft Graph that the add-in needs. The Office Store uses the Scopes element to create a consent dialog box. When users install the add-in from the Store, they are prompted to grant the add-in the specified permissions to the user's Microsoft Graph data.

--- a/docs/reference/manifest/scopes.md
+++ b/docs/reference/manifest/scopes.md
@@ -1,5 +1,5 @@
 ---
-title: Scopes element - Office Add-ins manifest
+title: Scopes element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/script.md
+++ b/docs/reference/manifest/script.md
@@ -1,3 +1,9 @@
+---
+title: Script element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # Script element
 
 Defines script settings used by a custom function in Excel.

--- a/docs/reference/manifest/script.md
+++ b/docs/reference/manifest/script.md
@@ -1,5 +1,5 @@
 ---
-title: Script element - Office Add-ins manifest
+title: Script element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/set.md
+++ b/docs/reference/manifest/set.md
@@ -1,3 +1,9 @@
+---
+title: Set element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # Set element
 
 Specifies a requirement set from the JavaScript API for Office that your Office Add-in requires to activate.

--- a/docs/reference/manifest/set.md
+++ b/docs/reference/manifest/set.md
@@ -1,5 +1,5 @@
 ---
-title: Set element - Office Add-ins manifest
+title: Set element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/sets.md
+++ b/docs/reference/manifest/sets.md
@@ -1,5 +1,5 @@
 ---
-title: Sets element - Office Add-ins manifest
+title: Sets element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/sets.md
+++ b/docs/reference/manifest/sets.md
@@ -1,3 +1,9 @@
+---
+title: Sets element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # Sets element
 
 Specifies the minimum subset of the JavaScript API for Office that your Office Add-in requires in order to activate.

--- a/docs/reference/manifest/sourcelocation.md
+++ b/docs/reference/manifest/sourcelocation.md
@@ -1,5 +1,5 @@
 ---
-title: SourceLocation element - Office Add-ins manifest
+title: SourceLocation element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/sourcelocation.md
+++ b/docs/reference/manifest/sourcelocation.md
@@ -1,3 +1,9 @@
+---
+title: SourceLocation element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # SourceLocation element
 
 Specifies the source file location(s) for your Office Add-in as a URL between 1 and 2018 characters long. The source location must be an HTTPS address, not a file path.

--- a/docs/reference/manifest/supertip.md
+++ b/docs/reference/manifest/supertip.md
@@ -1,5 +1,5 @@
 ---
-title: Supertip element - Office Add-ins manifest
+title: Supertip element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/supertip.md
+++ b/docs/reference/manifest/supertip.md
@@ -1,3 +1,9 @@
+---
+title: Supertip element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # Supertip
 
 Defines a rich tooltip (both Title and Description). It is used by both [Button](control.md#button-control) or [Menu](control.md#menu-dropdown-button-controls)  controls.

--- a/docs/reference/manifest/supportssharedfolders.md
+++ b/docs/reference/manifest/supportssharedfolders.md
@@ -1,5 +1,5 @@
 ---
-title: SupportsSharedFolders element - Office Add-ins manifest
+title: SupportsSharedFolders element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/supportssharedfolders.md
+++ b/docs/reference/manifest/supportssharedfolders.md
@@ -1,3 +1,9 @@
+---
+title: SupportsSharedFolders element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # SupportsSharedFolders element
 
 Defines whether the Outlook add-in is available in delegate scenarios. The **SupportsSharedFolders** element is a child element of [DesktopFormFactor](desktopformfactor.md). It is set to *false* by default.

--- a/docs/reference/manifest/supporturl.md
+++ b/docs/reference/manifest/supporturl.md
@@ -1,3 +1,9 @@
+---
+title: SupportUrl element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # SupportUrl element
 
 Specifies the URL of a page that provides support information for your add-in.

--- a/docs/reference/manifest/supporturl.md
+++ b/docs/reference/manifest/supporturl.md
@@ -1,5 +1,5 @@
 ---
-title: SupportUrl element - Office Add-ins manifest
+title: SupportUrl element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/tabletsettings.md
+++ b/docs/reference/manifest/tabletsettings.md
@@ -1,5 +1,5 @@
 ---
-title: TabletSettings element - Office Add-ins manifest
+title: TabletSettings element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/tabletsettings.md
+++ b/docs/reference/manifest/tabletsettings.md
@@ -1,3 +1,9 @@
+---
+title: TabletSettings element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # TabletSettings element
 
 Specifies control settings that apply when your mail add-in is used on a tablet.

--- a/docs/reference/manifest/targetdialect.md
+++ b/docs/reference/manifest/targetdialect.md
@@ -1,5 +1,5 @@
 ---
-title: TargetDialect element - Office Add-ins manifest
+title: TargetDialect element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/targetdialect.md
+++ b/docs/reference/manifest/targetdialect.md
@@ -1,3 +1,9 @@
+---
+title: TargetDialect element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # TargetDialect element
 
 Defines a regional language supported by this dictionary, represented as a culture name string.

--- a/docs/reference/manifest/targetdialects.md
+++ b/docs/reference/manifest/targetdialects.md
@@ -1,3 +1,9 @@
+---
+title: TargetDialects element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # TargetDialects element
 
 Defines the regional language or languages supported by this dictionary.

--- a/docs/reference/manifest/targetdialects.md
+++ b/docs/reference/manifest/targetdialects.md
@@ -1,5 +1,5 @@
 ---
-title: TargetDialects element - Office Add-ins manifest
+title: TargetDialects element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/version.md
+++ b/docs/reference/manifest/version.md
@@ -1,5 +1,5 @@
 ---
-title: Version element - Office Add-ins manifest
+title: Version element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/version.md
+++ b/docs/reference/manifest/version.md
@@ -1,3 +1,9 @@
+---
+title: Version element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # Version element
 
 Specifies the version of your Office Add-in.

--- a/docs/reference/manifest/versionoverrides.md
+++ b/docs/reference/manifest/versionoverrides.md
@@ -1,3 +1,9 @@
+---
+title: VersionOverrides element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # VersionOverrides element
 
 The root element that contains information for the add-in commands implemented by the add-in. **VersionOverrides** is a child element of the [OfficeApp](./officeapp.md) element in the manifest. This element is supported in manifest schema v1.1 and later but is defined in the VersionOverrides v1.0 or v1.1 schema.

--- a/docs/reference/manifest/versionoverrides.md
+++ b/docs/reference/manifest/versionoverrides.md
@@ -1,5 +1,5 @@
 ---
-title: VersionOverrides element - Office Add-ins manifest
+title: VersionOverrides element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/webapplicationinfo.md
+++ b/docs/reference/manifest/webapplicationinfo.md
@@ -1,3 +1,9 @@
+---
+title: WebApplicationInfo element - Office Add-ins manifest
+description: ''
+ms.date: 10/09/2018
+---
+
 # WebApplicationInfo element
 
 Supports single sign-on (SSO) in Office Add-ins. This element contains information for the add-in as both:
@@ -6,7 +12,7 @@ Supports single sign-on (SSO) in Office Add-ins. This element contains informati
 - An OAuth 2.0 *client* that might need permissions to Microsoft Graph.
 
 > [!NOTE]
-> The single sign-on API is currently supported in preview for Word, Excel, Outlook, and PowerPoint. For more information about where the single sign-on API is currently supported, see [IdentityAPI requirement sets](https://docs.microsoft.com/office/dev/add-ins/reference/requirement-sets/identity-api-requirement-sets?view=office-js). If you are working with an Outlook add-in, be sure to enable Modern Authentication for the Office 365 tenancy. To learn how to do this, see [Exchange Online: How to enable your tenant for modern authentication](https://social.technet.microsoft.com/wiki/contents/articles/32711.exchange-online-how-to-enable-your-tenant-for-modern-authentication.aspx).
+> The single sign-on API is currently supported in preview for Word, Excel, Outlook, and PowerPoint. For more information about where the single sign-on API is currently supported, seeï¿½[IdentityAPI requirement sets](https://docs.microsoft.com/office/dev/add-ins/reference/requirement-sets/identity-api-requirement-sets?view=office-js). If you are working with an Outlook add-in, be sure to enable Modern Authentication for the Office 365 tenancy. To learn how to do this, seeï¿½[Exchange Online: How to enable your tenant for modern authentication](https://social.technet.microsoft.com/wiki/contents/articles/32711.exchange-online-how-to-enable-your-tenant-for-modern-authentication.aspx).
 
 **WebApplicationInfo** is a child element of the [VersionOverrides](versionoverrides.md) element in the manifest.  
 

--- a/docs/reference/manifest/webapplicationinfo.md
+++ b/docs/reference/manifest/webapplicationinfo.md
@@ -1,5 +1,5 @@
 ---
-title: WebApplicationInfo element - Office Add-ins manifest
+title: WebApplicationInfo element in the manifest file
 description: ''
 ms.date: 10/09/2018
 ---

--- a/docs/reference/manifest/webapplicationinfo.md
+++ b/docs/reference/manifest/webapplicationinfo.md
@@ -12,7 +12,7 @@ Supports single sign-on (SSO) in Office Add-ins. This element contains informati
 - An OAuth 2.0 *client* that might need permissions to Microsoft Graph.
 
 > [!NOTE]
-> The single sign-on API is currently supported in preview for Word, Excel, Outlook, and PowerPoint. For more information about where the single sign-on API is currently supported, see�[IdentityAPI requirement sets](https://docs.microsoft.com/office/dev/add-ins/reference/requirement-sets/identity-api-requirement-sets?view=office-js). If you are working with an Outlook add-in, be sure to enable Modern Authentication for the Office 365 tenancy. To learn how to do this, see�[Exchange Online: How to enable your tenant for modern authentication](https://social.technet.microsoft.com/wiki/contents/articles/32711.exchange-online-how-to-enable-your-tenant-for-modern-authentication.aspx).
+> The single sign-on API is currently supported in preview for Word, Excel, Outlook, and PowerPoint. For more information about where the single sign-on API is currently supported, see [IdentityAPI requirement sets](https://docs.microsoft.com/office/dev/add-ins/reference/requirement-sets/identity-api-requirement-sets?view=office-js). If you are working with an Outlook add-in, be sure to enable Modern Authentication for the Office 365 tenancy. To learn how to do this, see [Exchange Online: How to enable your tenant for modern authentication](https://social.technet.microsoft.com/wiki/contents/articles/32711.exchange-online-how-to-enable-your-tenant-for-modern-authentication.aspx).
 
 **WebApplicationInfo** is a child element of the [VersionOverrides](versionoverrides.md) element in the manifest.  
 

--- a/docs/reference/objectmodel/preview-requirement-set/office.context.mailbox.diagnostics.md
+++ b/docs/reference/objectmodel/preview-requirement-set/office.context.mailbox.diagnostics.md
@@ -1,7 +1,12 @@
+---
+title: Office.context.mailbox.diagnostics
+description: ''
+ms.date: 10/11/2018
+---
 
 # diagnostics
 
-### [Office](Office.md)[.context](Office.context.md)[.mailbox](Office.context.mailbox.md). diagnostics
+### [Office](Office.md)[.context](Office.context.md)[.mailbox](Office.context.mailbox.md).diagnostics
 
 Provides diagnostic information to an Outlook add-in.
 

--- a/docs/reference/objectmodel/preview-requirement-set/office.context.mailbox.diagnostics.md
+++ b/docs/reference/objectmodel/preview-requirement-set/office.context.mailbox.diagnostics.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context.mailbox.diagnostics
+title: Office.context.mailbox.diagnostics - preview requirement set
 description: ''
 ms.date: 10/11/2018
 ---

--- a/docs/reference/objectmodel/preview-requirement-set/office.context.mailbox.item.md
+++ b/docs/reference/objectmodel/preview-requirement-set/office.context.mailbox.item.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context.mailbox.item
+title: Office.context.mailbox.item - preview requirement set
 description: ''
 ms.date: 12/18/2018
 ---

--- a/docs/reference/objectmodel/preview-requirement-set/office.context.mailbox.item.md
+++ b/docs/reference/objectmodel/preview-requirement-set/office.context.mailbox.item.md
@@ -1,3 +1,8 @@
+---
+title: Office.context.mailbox.item
+description: ''
+ms.date: 12/18/2018
+---
 
 # item
 

--- a/docs/reference/objectmodel/preview-requirement-set/office.context.mailbox.md
+++ b/docs/reference/objectmodel/preview-requirement-set/office.context.mailbox.md
@@ -1,7 +1,12 @@
+---
+title: Office.context.mailbox
+description: ''
+ms.date: 10/31/2018
+---
 
 # mailbox
 
-### [Office](Office.md)[.context](Office.context.md). mailbox
+### [Office](Office.md)[.context](Office.context.md).mailbox
 
 Provides access to the Outlook add-in object model for Microsoft Outlook and Microsoft Outlook on the web.
 

--- a/docs/reference/objectmodel/preview-requirement-set/office.context.mailbox.md
+++ b/docs/reference/objectmodel/preview-requirement-set/office.context.mailbox.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context.mailbox
+title: Office.context.mailbox - preview requirement set
 description: ''
 ms.date: 10/31/2018
 ---

--- a/docs/reference/objectmodel/preview-requirement-set/office.context.mailbox.userProfile.md
+++ b/docs/reference/objectmodel/preview-requirement-set/office.context.mailbox.userProfile.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context.mailbox.userProfile
+title: Office.context.mailbox.userProfile - preview requirement set
 description: ''
 ms.date: 10/31/2018
 ---

--- a/docs/reference/objectmodel/preview-requirement-set/office.context.mailbox.userProfile.md
+++ b/docs/reference/objectmodel/preview-requirement-set/office.context.mailbox.userProfile.md
@@ -1,7 +1,12 @@
+---
+title: Office.context.mailbox.userProfile
+description: ''
+ms.date: 10/31/2018
+---
 
 # userProfile
 
-### [Office](Office.md)[.context](Office.context.md)[.mailbox](Office.context.mailbox.md). userProfile
+### [Office](Office.md)[.context](Office.context.md)[.mailbox](Office.context.mailbox.md).userProfile
 
 ##### Requirements
 

--- a/docs/reference/objectmodel/preview-requirement-set/office.context.md
+++ b/docs/reference/objectmodel/preview-requirement-set/office.context.md
@@ -1,3 +1,8 @@
+---
+title: Office.context
+description: ''
+ms.date: 10/11/2018
+---
 
 # context
 

--- a/docs/reference/objectmodel/preview-requirement-set/office.context.md
+++ b/docs/reference/objectmodel/preview-requirement-set/office.context.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context
+title: Office.context - preview requirement set
 description: ''
 ms.date: 10/11/2018
 ---

--- a/docs/reference/objectmodel/preview-requirement-set/office.md
+++ b/docs/reference/objectmodel/preview-requirement-set/office.md
@@ -1,5 +1,5 @@
 ---
-title: Office namespace
+title: Office namespace - preview requirement set
 description: ''
 ms.date: 11/08/2018
 ---

--- a/docs/reference/objectmodel/preview-requirement-set/office.md
+++ b/docs/reference/objectmodel/preview-requirement-set/office.md
@@ -1,4 +1,8 @@
- 
+---
+title: Office namespace
+description: ''
+ms.date: 11/08/2018
+---
 
 # Office
 

--- a/docs/reference/objectmodel/preview-requirement-set/outlook-requirement-set-preview.md
+++ b/docs/reference/objectmodel/preview-requirement-set/outlook-requirement-set-preview.md
@@ -1,3 +1,9 @@
+---
+title: Outlook add-in API Preview requirement set
+description: ''
+ms.date: 10/31/2018
+---
+
 # Outlook add-in API Preview requirement set
 
 The Outlook add-in API subset of the JavaScript API for Office includes objects, methods, properties, and events that you can use in an Outlook add-in.

--- a/docs/reference/objectmodel/requirement-set-1.1/office.context.mailbox.diagnostics.md
+++ b/docs/reference/objectmodel/requirement-set-1.1/office.context.mailbox.diagnostics.md
@@ -1,7 +1,12 @@
+---
+title: Office.context.mailbox.diagnostics
+description: ''
+ms.date: 10/11/2018
+---
 
 # diagnostics
 
-### [Office](Office.md)[.context](Office.context.md)[.mailbox](Office.context.mailbox.md). diagnostics
+### [Office](Office.md)[.context](Office.context.md)[.mailbox](Office.context.mailbox.md).diagnostics
 
 Provides diagnostic information to an Outlook add-in.
 

--- a/docs/reference/objectmodel/requirement-set-1.1/office.context.mailbox.diagnostics.md
+++ b/docs/reference/objectmodel/requirement-set-1.1/office.context.mailbox.diagnostics.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context.mailbox.diagnostics
+title: Office.context.mailbox.diagnostics - requirement set 1.1
 description: ''
 ms.date: 10/11/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.1/office.context.mailbox.item.md
+++ b/docs/reference/objectmodel/requirement-set-1.1/office.context.mailbox.item.md
@@ -1,3 +1,8 @@
+---
+title: Office.context.mailbox.item
+description: ''
+ms.date: 12/18/2018
+---
 
 # item
 

--- a/docs/reference/objectmodel/requirement-set-1.1/office.context.mailbox.item.md
+++ b/docs/reference/objectmodel/requirement-set-1.1/office.context.mailbox.item.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context.mailbox.item
+title: Office.context.mailbox.item - requirement set 1.1
 description: ''
 ms.date: 12/18/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.1/office.context.mailbox.md
+++ b/docs/reference/objectmodel/requirement-set-1.1/office.context.mailbox.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context.mailbox
+title: Office.context.mailbox - requirement set 1.1
 description: ''
 ms.date: 10/31/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.1/office.context.mailbox.md
+++ b/docs/reference/objectmodel/requirement-set-1.1/office.context.mailbox.md
@@ -1,7 +1,12 @@
+---
+title: Office.context.mailbox
+description: ''
+ms.date: 10/31/2018
+---
 
 # mailbox
 
-### [Office](Office.md)[.context](Office.context.md). mailbox
+### [Office](Office.md)[.context](Office.context.md).mailbox
 
 Provides access to the Outlook add-in object model for Microsoft Outlook and Microsoft Outlook on the web.
 

--- a/docs/reference/objectmodel/requirement-set-1.1/office.context.mailbox.userProfile.md
+++ b/docs/reference/objectmodel/requirement-set-1.1/office.context.mailbox.userProfile.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context.mailbox.userProfile
+title: Office.context.mailbox.userProfile - requirement set 1.1
 description: ''
 ms.date: 10/31/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.1/office.context.mailbox.userProfile.md
+++ b/docs/reference/objectmodel/requirement-set-1.1/office.context.mailbox.userProfile.md
@@ -1,7 +1,12 @@
+---
+title: Office.context.mailbox.userProfile
+description: ''
+ms.date: 10/31/2018
+---
 
 # userProfile
 
-### [Office](Office.md)[.context](Office.context.md)[.mailbox](Office.context.mailbox.md). userProfile
+### [Office](Office.md)[.context](Office.context.md)[.mailbox](Office.context.mailbox.md).userProfile
 
 ##### Requirements
 

--- a/docs/reference/objectmodel/requirement-set-1.1/office.context.md
+++ b/docs/reference/objectmodel/requirement-set-1.1/office.context.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context
+title: Office.context - requirement set 1.1
 description: ''
 ms.date: 10/11/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.1/office.context.md
+++ b/docs/reference/objectmodel/requirement-set-1.1/office.context.md
@@ -1,7 +1,12 @@
+---
+title: Office.context
+description: ''
+ms.date: 10/11/2018
+---
 
 # context
 
-### [Office](Office.md). context
+### [Office](Office.md).context
 
 The Office.context namespace provides shared interfaces that are used by add-ins in all of the Office apps. This listing documents only those interfaces that are used by Outlook add-ins. For a full listing of the Office.context namespace, see the [Office.context reference in the Shared API](/javascript/api/office/office.context).
 

--- a/docs/reference/objectmodel/requirement-set-1.1/office.md
+++ b/docs/reference/objectmodel/requirement-set-1.1/office.md
@@ -1,4 +1,8 @@
- 
+---
+title: Office namespace
+description: ''
+ms.date: 11/08/2018
+---
 
 # Office
 

--- a/docs/reference/objectmodel/requirement-set-1.1/office.md
+++ b/docs/reference/objectmodel/requirement-set-1.1/office.md
@@ -1,5 +1,5 @@
 ---
-title: Office namespace
+title: Office namespace - requirement set 1.1
 description: ''
 ms.date: 11/08/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.1/outlook-requirement-set-1.1.md
+++ b/docs/reference/objectmodel/requirement-set-1.1/outlook-requirement-set-1.1.md
@@ -1,3 +1,9 @@
+---
+title: Outlook add-in API requirement set 1.1
+description: ''
+ms.date: 10/11/2018
+---
+
 # Outlook add-in API requirement set 1.1
 
 The Outlook add-in API subset of the JavaScript API for Office includes objects, methods, properties, and events that you can use in an Outlook add-in.

--- a/docs/reference/objectmodel/requirement-set-1.2/office.context.mailbox.diagnostics.md
+++ b/docs/reference/objectmodel/requirement-set-1.2/office.context.mailbox.diagnostics.md
@@ -1,7 +1,12 @@
+---
+title: Office.context.mailbox.diagnostics
+description: ''
+ms.date: 10/11/2018
+---
 
 # diagnostics
 
-### [Office](Office.md)[.context](Office.context.md)[.mailbox](Office.context.mailbox.md). diagnostics
+### [Office](Office.md)[.context](Office.context.md)[.mailbox](Office.context.mailbox.md).diagnostics
 
 Provides diagnostic information to an Outlook add-in.
 

--- a/docs/reference/objectmodel/requirement-set-1.2/office.context.mailbox.diagnostics.md
+++ b/docs/reference/objectmodel/requirement-set-1.2/office.context.mailbox.diagnostics.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context.mailbox.diagnostics
+title: Office.context.mailbox.diagnostics - requirement set 1.2
 description: ''
 ms.date: 10/11/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.2/office.context.mailbox.item.md
+++ b/docs/reference/objectmodel/requirement-set-1.2/office.context.mailbox.item.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context.mailbox.item
+title: Office.context.mailbox.item - requirement set 1.2
 description: ''
 ms.date: 12/18/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.2/office.context.mailbox.item.md
+++ b/docs/reference/objectmodel/requirement-set-1.2/office.context.mailbox.item.md
@@ -1,3 +1,8 @@
+---
+title: Office.context.mailbox.item
+description: ''
+ms.date: 12/18/2018
+---
 
 # item
 

--- a/docs/reference/objectmodel/requirement-set-1.2/office.context.mailbox.md
+++ b/docs/reference/objectmodel/requirement-set-1.2/office.context.mailbox.md
@@ -1,7 +1,12 @@
+---
+title: Office.context.mailbox
+description: ''
+ms.date: 10/31/2018
+---
 
 # mailbox
 
-### [Office](Office.md)[.context](Office.context.md). mailbox
+### [Office](Office.md)[.context](Office.context.md).mailbox
 
 Provides access to the Outlook add-in object model for Microsoft Outlook and Microsoft Outlook on the web.
 

--- a/docs/reference/objectmodel/requirement-set-1.2/office.context.mailbox.md
+++ b/docs/reference/objectmodel/requirement-set-1.2/office.context.mailbox.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context.mailbox
+title: Office.context.mailbox - requirement set 1.2
 description: ''
 ms.date: 10/31/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.2/office.context.mailbox.userProfile.md
+++ b/docs/reference/objectmodel/requirement-set-1.2/office.context.mailbox.userProfile.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context.mailbox.userProfile
+title: Office.context.mailbox.userProfile - requirement set 1.2
 description: ''
 ms.date: 10/31/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.2/office.context.mailbox.userProfile.md
+++ b/docs/reference/objectmodel/requirement-set-1.2/office.context.mailbox.userProfile.md
@@ -1,7 +1,12 @@
+---
+title: Office.context.mailbox.userProfile
+description: ''
+ms.date: 10/31/2018
+---
 
 # userProfile
 
-### [Office](Office.md)[.context](Office.context.md)[.mailbox](Office.context.mailbox.md). userProfile
+### [Office](Office.md)[.context](Office.context.md)[.mailbox](Office.context.mailbox.md).userProfile
 
 ##### Requirements
 

--- a/docs/reference/objectmodel/requirement-set-1.2/office.context.md
+++ b/docs/reference/objectmodel/requirement-set-1.2/office.context.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context
+title: Office.context - requirement set 1.2
 description: ''
 ms.date: 10/11/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.2/office.context.md
+++ b/docs/reference/objectmodel/requirement-set-1.2/office.context.md
@@ -1,7 +1,12 @@
+---
+title: Office.context
+description: ''
+ms.date: 10/11/2018
+---
 
 # context
 
-### [Office](Office.md). context
+### [Office](Office.md).context
 
 The Office.context namespace provides shared interfaces that are used by add-ins in all of the Office apps. This listing documents only those interfaces that are used by Outlook add-ins. For a full listing of the Office.context namespace, see the [Office.context reference in the Shared API](/javascript/api/office/office.context).
 

--- a/docs/reference/objectmodel/requirement-set-1.2/office.md
+++ b/docs/reference/objectmodel/requirement-set-1.2/office.md
@@ -1,5 +1,5 @@
 ---
-title: Office namespace
+title: Office namespace - requirement set 1.2
 description: ''
 ms.date: 11/08/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.2/office.md
+++ b/docs/reference/objectmodel/requirement-set-1.2/office.md
@@ -1,4 +1,8 @@
- 
+---
+title: Office namespace
+description: ''
+ms.date: 11/08/2018
+---
 
 # Office
 

--- a/docs/reference/objectmodel/requirement-set-1.2/outlook-requirement-set-1.2.md
+++ b/docs/reference/objectmodel/requirement-set-1.2/outlook-requirement-set-1.2.md
@@ -1,3 +1,9 @@
+---
+title: Outlook add-in API requirement set 1.2
+description: ''
+ms.date: 10/11/2018
+---
+
 # Outlook add-in API requirement set 1.2
 
 The Outlook add-in API subset of the JavaScript API for Office includes objects, methods, properties, and events that you can use in an Outlook add-in.

--- a/docs/reference/objectmodel/requirement-set-1.3/office.context.mailbox.diagnostics.md
+++ b/docs/reference/objectmodel/requirement-set-1.3/office.context.mailbox.diagnostics.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context.mailbox.diagnostics
+title: Office.context.mailbox.diagnostics - requirement set 1.3
 description: ''
 ms.date: 10/11/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.3/office.context.mailbox.diagnostics.md
+++ b/docs/reference/objectmodel/requirement-set-1.3/office.context.mailbox.diagnostics.md
@@ -1,7 +1,12 @@
+---
+title: Office.context.mailbox.diagnostics
+description: ''
+ms.date: 10/11/2018
+---
 
 # diagnostics
 
-### [Office](Office.md)[.context](Office.context.md)[.mailbox](Office.context.mailbox.md). diagnostics
+### [Office](Office.md)[.context](Office.context.md)[.mailbox](Office.context.mailbox.md).diagnostics
 
 Provides diagnostic information to an Outlook add-in.
 

--- a/docs/reference/objectmodel/requirement-set-1.3/office.context.mailbox.item.md
+++ b/docs/reference/objectmodel/requirement-set-1.3/office.context.mailbox.item.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context.mailbox.item
+title: Office.context.mailbox.item - requirement set 1.3
 description: ''
 ms.date: 12/18/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.3/office.context.mailbox.item.md
+++ b/docs/reference/objectmodel/requirement-set-1.3/office.context.mailbox.item.md
@@ -1,3 +1,8 @@
+---
+title: Office.context.mailbox.item
+description: ''
+ms.date: 12/18/2018
+---
 
 # item
 

--- a/docs/reference/objectmodel/requirement-set-1.3/office.context.mailbox.md
+++ b/docs/reference/objectmodel/requirement-set-1.3/office.context.mailbox.md
@@ -1,7 +1,12 @@
+---
+title: Office.context.mailbox
+description: ''
+ms.date: 10/31/2018
+---
 
 # mailbox
 
-### [Office](Office.md)[.context](Office.context.md). mailbox
+### [Office](Office.md)[.context](Office.context.md).mailbox
 
 Provides access to the Outlook add-in object model for Microsoft Outlook and Microsoft Outlook on the web.
 

--- a/docs/reference/objectmodel/requirement-set-1.3/office.context.mailbox.md
+++ b/docs/reference/objectmodel/requirement-set-1.3/office.context.mailbox.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context.mailbox
+title: Office.context.mailbox - requirement set 1.3
 description: ''
 ms.date: 10/31/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.3/office.context.mailbox.userProfile.md
+++ b/docs/reference/objectmodel/requirement-set-1.3/office.context.mailbox.userProfile.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context.mailbox.userProfile
+title: Office.context.mailbox.userProfile - requirement set 1.3
 description: ''
 ms.date: 10/31/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.3/office.context.mailbox.userProfile.md
+++ b/docs/reference/objectmodel/requirement-set-1.3/office.context.mailbox.userProfile.md
@@ -1,7 +1,12 @@
+---
+title: Office.context.mailbox.userProfile
+description: ''
+ms.date: 10/31/2018
+---
 
 # userProfile
 
-### [Office](Office.md)[.context](Office.context.md)[.mailbox](Office.context.mailbox.md). userProfile
+### [Office](Office.md)[.context](Office.context.md)[.mailbox](Office.context.mailbox.md).userProfile
 
 ##### Requirements
 

--- a/docs/reference/objectmodel/requirement-set-1.3/office.context.md
+++ b/docs/reference/objectmodel/requirement-set-1.3/office.context.md
@@ -1,3 +1,8 @@
+---
+title: Office.context
+description: ''
+ms.date: 10/11/2018
+---
 
 # context
 

--- a/docs/reference/objectmodel/requirement-set-1.3/office.context.md
+++ b/docs/reference/objectmodel/requirement-set-1.3/office.context.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context
+title: Office.context - requirement set 1.3
 description: ''
 ms.date: 10/11/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.3/office.md
+++ b/docs/reference/objectmodel/requirement-set-1.3/office.md
@@ -1,5 +1,5 @@
 ---
-title: Office namespace
+title: Office namespace - requirement set 1.3
 description: ''
 ms.date: 11/08/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.3/office.md
+++ b/docs/reference/objectmodel/requirement-set-1.3/office.md
@@ -1,4 +1,8 @@
- 
+---
+title: Office namespace
+description: ''
+ms.date: 11/08/2018
+---
 
 # Office
 

--- a/docs/reference/objectmodel/requirement-set-1.3/outlook-requirement-set-1.3.md
+++ b/docs/reference/objectmodel/requirement-set-1.3/outlook-requirement-set-1.3.md
@@ -1,3 +1,9 @@
+---
+title: Outlook add-in API requirement set 1.3
+description: ''
+ms.date: 10/11/2018
+---
+
 # Outlook add-in API requirement set 1.3
 
 The Outlook add-in API subset of the JavaScript API for Office includes objects, methods, properties, and events that you can use in an Outlook add-in.

--- a/docs/reference/objectmodel/requirement-set-1.4/office.context.mailbox.diagnostics.md
+++ b/docs/reference/objectmodel/requirement-set-1.4/office.context.mailbox.diagnostics.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context.mailbox.diagnostics
+title: Office.context.mailbox.diagnostics - requirement set 1.4
 description: ''
 ms.date: 10/11/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.4/office.context.mailbox.diagnostics.md
+++ b/docs/reference/objectmodel/requirement-set-1.4/office.context.mailbox.diagnostics.md
@@ -1,7 +1,12 @@
+---
+title: Office.context.mailbox.diagnostics
+description: ''
+ms.date: 10/11/2018
+---
 
 # diagnostics
 
-### [Office](Office.md)[.context](Office.context.md)[.mailbox](Office.context.mailbox.md). diagnostics
+### [Office](Office.md)[.context](Office.context.md)[.mailbox](Office.context.mailbox.md).diagnostics
 
 Provides diagnostic information to an Outlook add-in.
 

--- a/docs/reference/objectmodel/requirement-set-1.4/office.context.mailbox.item.md
+++ b/docs/reference/objectmodel/requirement-set-1.4/office.context.mailbox.item.md
@@ -1,3 +1,8 @@
+---
+title: Office.context.mailbox.item
+description: ''
+ms.date: 12/18/2018
+---
 
 # item
 

--- a/docs/reference/objectmodel/requirement-set-1.4/office.context.mailbox.item.md
+++ b/docs/reference/objectmodel/requirement-set-1.4/office.context.mailbox.item.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context.mailbox.item
+title: Office.context.mailbox.item - requirement set 1.4
 description: ''
 ms.date: 12/18/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.4/office.context.mailbox.md
+++ b/docs/reference/objectmodel/requirement-set-1.4/office.context.mailbox.md
@@ -1,7 +1,12 @@
+---
+title: Office.context.mailbox
+description: ''
+ms.date: 10/31/2018
+---
 
 # mailbox
 
-### [Office](Office.md)[.context](Office.context.md). mailbox
+### [Office](Office.md)[.context](Office.context.md).mailbox
 
 Provides access to the Outlook add-in object model for Microsoft Outlook and Microsoft Outlook on the web.
 

--- a/docs/reference/objectmodel/requirement-set-1.4/office.context.mailbox.md
+++ b/docs/reference/objectmodel/requirement-set-1.4/office.context.mailbox.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context.mailbox
+title: Office.context.mailbox - requirement set 1.4
 description: ''
 ms.date: 10/31/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.4/office.context.mailbox.userProfile.md
+++ b/docs/reference/objectmodel/requirement-set-1.4/office.context.mailbox.userProfile.md
@@ -1,7 +1,12 @@
+---
+title: Office.context.mailbox.userProfile
+description: ''
+ms.date: 10/31/2018
+---
 
 # userProfile
 
-### [Office](Office.md)[.context](Office.context.md)[.mailbox](Office.context.mailbox.md). userProfile
+### [Office](Office.md)[.context](Office.context.md)[.mailbox](Office.context.mailbox.md).userProfile
 
 ##### Requirements
 

--- a/docs/reference/objectmodel/requirement-set-1.4/office.context.mailbox.userProfile.md
+++ b/docs/reference/objectmodel/requirement-set-1.4/office.context.mailbox.userProfile.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context.mailbox.userProfile
+title: Office.context.mailbox.userProfile - requirement set 1.4
 description: ''
 ms.date: 10/31/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.4/office.context.md
+++ b/docs/reference/objectmodel/requirement-set-1.4/office.context.md
@@ -1,3 +1,8 @@
+---
+title: Office.context
+description: ''
+ms.date: 10/11/2018
+---
 
 # context
 

--- a/docs/reference/objectmodel/requirement-set-1.4/office.context.md
+++ b/docs/reference/objectmodel/requirement-set-1.4/office.context.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context
+title: Office.context - requirement set 1.4
 description: ''
 ms.date: 10/11/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.4/office.md
+++ b/docs/reference/objectmodel/requirement-set-1.4/office.md
@@ -1,5 +1,5 @@
 ---
-title: Office namespace
+title: Office namespace - requirement set 1.4
 description: ''
 ms.date: 11/08/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.4/office.md
+++ b/docs/reference/objectmodel/requirement-set-1.4/office.md
@@ -1,4 +1,8 @@
- 
+---
+title: Office namespace
+description: ''
+ms.date: 11/08/2018
+---
 
 # Office
 

--- a/docs/reference/objectmodel/requirement-set-1.4/outlook-requirement-set-1.4.md
+++ b/docs/reference/objectmodel/requirement-set-1.4/outlook-requirement-set-1.4.md
@@ -1,3 +1,9 @@
+---
+title: Outlook add-in API requirement set 1.4
+description: ''
+ms.date: 10/11/2018
+---
+
 # Outlook add-in API requirement set 1.4
 
 The Outlook add-in API subset of the JavaScript API for Office includes objects, methods, properties, and events that you can use in an Outlook add-in.

--- a/docs/reference/objectmodel/requirement-set-1.5/office.context.mailbox.diagnostics.md
+++ b/docs/reference/objectmodel/requirement-set-1.5/office.context.mailbox.diagnostics.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context.mailbox.diagnostics
+title: Office.context.mailbox.diagnostics - requirement set 1.5
 description: ''
 ms.date: 10/11/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.5/office.context.mailbox.diagnostics.md
+++ b/docs/reference/objectmodel/requirement-set-1.5/office.context.mailbox.diagnostics.md
@@ -1,6 +1,12 @@
+---
+title: Office.context.mailbox.diagnostics
+description: ''
+ms.date: 10/11/2018
+---
+
 # diagnostics
 
-### [Office](Office.md)[.context](Office.context.md)[.mailbox](Office.context.mailbox.md). diagnostics
+### [Office](Office.md)[.context](Office.context.md)[.mailbox](Office.context.mailbox.md).diagnostics
 
 Provides diagnostic information to an Outlook add-in.
 

--- a/docs/reference/objectmodel/requirement-set-1.5/office.context.mailbox.item.md
+++ b/docs/reference/objectmodel/requirement-set-1.5/office.context.mailbox.item.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context.mailbox.item
+title: Office.context.mailbox.item - requirement set 1.5
 description: ''
 ms.date: 12/18/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.5/office.context.mailbox.item.md
+++ b/docs/reference/objectmodel/requirement-set-1.5/office.context.mailbox.item.md
@@ -1,3 +1,8 @@
+---
+title: Office.context.mailbox.item
+description: ''
+ms.date: 12/18/2018
+---
 
 # item
 

--- a/docs/reference/objectmodel/requirement-set-1.5/office.context.mailbox.md
+++ b/docs/reference/objectmodel/requirement-set-1.5/office.context.mailbox.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context.mailbox
+title: Office.context.mailbox - requirement set 1.5
 description: ''
 ms.date: 10/31/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.5/office.context.mailbox.md
+++ b/docs/reference/objectmodel/requirement-set-1.5/office.context.mailbox.md
@@ -1,7 +1,12 @@
+---
+title: Office.context.mailbox
+description: ''
+ms.date: 10/31/2018
+---
 
 # mailbox
 
-### [Office](Office.md)[.context](Office.context.md). mailbox
+### [Office](Office.md)[.context](Office.context.md).mailbox
 
 Provides access to the Outlook add-in object model for Microsoft Outlook and Microsoft Outlook on the web.
 

--- a/docs/reference/objectmodel/requirement-set-1.5/office.context.mailbox.userProfile.md
+++ b/docs/reference/objectmodel/requirement-set-1.5/office.context.mailbox.userProfile.md
@@ -1,6 +1,12 @@
+---
+title: Office.context.mailbox.userProfile
+description: ''
+ms.date: 10/31/2018
+---
+
 # userProfile
 
-### [Office](Office.md)[.context](Office.context.md)[.mailbox](Office.context.mailbox.md). userProfile
+### [Office](Office.md)[.context](Office.context.md)[.mailbox](Office.context.mailbox.md).userProfile
 
 ##### Requirements
 

--- a/docs/reference/objectmodel/requirement-set-1.5/office.context.mailbox.userProfile.md
+++ b/docs/reference/objectmodel/requirement-set-1.5/office.context.mailbox.userProfile.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context.mailbox.userProfile
+title: Office.context.mailbox.userProfile - requirement set 1.5
 description: ''
 ms.date: 10/31/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.5/office.context.md
+++ b/docs/reference/objectmodel/requirement-set-1.5/office.context.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context
+title: Office.context - requirement set 1.5
 description: ''
 ms.date: 10/11/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.5/office.context.md
+++ b/docs/reference/objectmodel/requirement-set-1.5/office.context.md
@@ -1,3 +1,9 @@
+---
+title: Office.context
+description: ''
+ms.date: 10/11/2018
+---
+
 # context
 
 ### [Office](Office.md).context

--- a/docs/reference/objectmodel/requirement-set-1.5/office.md
+++ b/docs/reference/objectmodel/requirement-set-1.5/office.md
@@ -1,3 +1,9 @@
+---
+title: Office namespace
+description: ''
+ms.date: 11/08/2018
+---
+
 # Office
 
 The Office namespace provides shared interfaces that are used by add-ins in all of the Office apps. This listing documents only those interfaces that are used by Outlook add-ins. For a full listing of the Office namespace, see the [Shared API](/javascript/api/office).

--- a/docs/reference/objectmodel/requirement-set-1.5/office.md
+++ b/docs/reference/objectmodel/requirement-set-1.5/office.md
@@ -1,5 +1,5 @@
 ---
-title: Office namespace
+title: Office namespace - requirement set 1.5
 description: ''
 ms.date: 11/08/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.5/outlook-requirement-set-1.5.md
+++ b/docs/reference/objectmodel/requirement-set-1.5/outlook-requirement-set-1.5.md
@@ -1,3 +1,9 @@
+---
+title: Outlook add-in API requirement set 1.5
+description: ''
+ms.date: 11/14/2018
+---
+
 # Outlook add-in API requirement set 1.5
 
 The Outlook add-in API subset of the JavaScript API for Office includes objects, methods, properties, and events that you can use in an Outlook add-in.

--- a/docs/reference/objectmodel/requirement-set-1.6/office.context.mailbox.diagnostics.md
+++ b/docs/reference/objectmodel/requirement-set-1.6/office.context.mailbox.diagnostics.md
@@ -1,7 +1,12 @@
+---
+title: Office.context.mailbox.diagnostics
+description: ''
+ms.date: 10/11/2018
+---
 
 # diagnostics
 
-### [Office](Office.md)[.context](Office.context.md)[.mailbox](Office.context.mailbox.md). diagnostics
+### [Office](Office.md)[.context](Office.context.md)[.mailbox](Office.context.mailbox.md).diagnostics
 
 Provides diagnostic information to an Outlook add-in.
 

--- a/docs/reference/objectmodel/requirement-set-1.6/office.context.mailbox.diagnostics.md
+++ b/docs/reference/objectmodel/requirement-set-1.6/office.context.mailbox.diagnostics.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context.mailbox.diagnostics
+title: Office.context.mailbox.diagnostics - requirement set 1.6
 description: ''
 ms.date: 10/11/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.6/office.context.mailbox.item.md
+++ b/docs/reference/objectmodel/requirement-set-1.6/office.context.mailbox.item.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context.mailbox.item
+title: Office.context.mailbox.item - requirement set 1.6
 description: ''
 ms.date: 12/18/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.6/office.context.mailbox.item.md
+++ b/docs/reference/objectmodel/requirement-set-1.6/office.context.mailbox.item.md
@@ -1,3 +1,8 @@
+---
+title: Office.context.mailbox.item
+description: ''
+ms.date: 12/18/2018
+---
 
 # item
 

--- a/docs/reference/objectmodel/requirement-set-1.6/office.context.mailbox.md
+++ b/docs/reference/objectmodel/requirement-set-1.6/office.context.mailbox.md
@@ -1,7 +1,12 @@
+---
+title: Office.context.mailbox
+description: ''
+ms.date: 10/31/2018
+---
 
 # mailbox
 
-### [Office](Office.md)[.context](Office.context.md). mailbox
+### [Office](Office.md)[.context](Office.context.md).mailbox
 
 Provides access to the Outlook add-in object model for Microsoft Outlook and Microsoft Outlook on the web.
 

--- a/docs/reference/objectmodel/requirement-set-1.6/office.context.mailbox.md
+++ b/docs/reference/objectmodel/requirement-set-1.6/office.context.mailbox.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context.mailbox
+title: Office.context.mailbox - requirement set 1.6
 description: ''
 ms.date: 10/31/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.6/office.context.mailbox.userprofile.md
+++ b/docs/reference/objectmodel/requirement-set-1.6/office.context.mailbox.userprofile.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context.mailbox.userProfile
+title: Office.context.mailbox.userProfile - requirement set 1.6
 description: ''
 ms.date: 10/31/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.6/office.context.mailbox.userprofile.md
+++ b/docs/reference/objectmodel/requirement-set-1.6/office.context.mailbox.userprofile.md
@@ -1,7 +1,12 @@
+---
+title: Office.context.mailbox.userProfile
+description: ''
+ms.date: 10/31/2018
+---
 
 # userProfile
 
-### [Office](Office.md)[.context](Office.context.md)[.mailbox](Office.context.mailbox.md). userProfile
+### [Office](Office.md)[.context](Office.context.md)[.mailbox](Office.context.mailbox.md).userProfile
 
 ##### Requirements
 

--- a/docs/reference/objectmodel/requirement-set-1.6/office.context.md
+++ b/docs/reference/objectmodel/requirement-set-1.6/office.context.md
@@ -1,3 +1,8 @@
+---
+title: Office.context
+description: ''
+ms.date: 10/11/2018
+---
 
 # context
 

--- a/docs/reference/objectmodel/requirement-set-1.6/office.context.md
+++ b/docs/reference/objectmodel/requirement-set-1.6/office.context.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context
+title: Office.context - requirement set 1.6
 description: ''
 ms.date: 10/11/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.6/office.md
+++ b/docs/reference/objectmodel/requirement-set-1.6/office.md
@@ -1,5 +1,5 @@
 ---
-title: Office namespace
+title: Office namespace - requirement set 1.6
 description: ''
 ms.date: 11/08/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.6/office.md
+++ b/docs/reference/objectmodel/requirement-set-1.6/office.md
@@ -1,4 +1,8 @@
- 
+---
+title: Office namespace
+description: ''
+ms.date: 11/08/2018
+---
 
 # Office
 

--- a/docs/reference/objectmodel/requirement-set-1.6/outlook-requirement-set-1.6.md
+++ b/docs/reference/objectmodel/requirement-set-1.6/outlook-requirement-set-1.6.md
@@ -1,3 +1,9 @@
+---
+title: Outlook add-in API requirement set 1.6
+description: ''
+ms.date: 10/11/2018
+---
+
 # Outlook add-in API requirement set 1.6
 
 The Outlook add-in API subset of the JavaScript API for Office includes objects, methods, properties, and events that you can use in an Outlook add-in.

--- a/docs/reference/objectmodel/requirement-set-1.7/office.context.mailbox.diagnostics.md
+++ b/docs/reference/objectmodel/requirement-set-1.7/office.context.mailbox.diagnostics.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context.mailbox.diagnostics
+title: Office.context.mailbox.diagnostics - requirement set 1.7
 description: ''
 ms.date: 10/11/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.7/office.context.mailbox.diagnostics.md
+++ b/docs/reference/objectmodel/requirement-set-1.7/office.context.mailbox.diagnostics.md
@@ -1,7 +1,12 @@
+---
+title: Office.context.mailbox.diagnostics
+description: ''
+ms.date: 10/11/2018
+---
 
 # diagnostics
 
-### [Office](Office.md)[.context](Office.context.md)[.mailbox](Office.context.mailbox.md). diagnostics
+### [Office](Office.md)[.context](Office.context.md)[.mailbox](Office.context.mailbox.md).diagnostics
 
 Provides diagnostic information to an Outlook add-in.
 

--- a/docs/reference/objectmodel/requirement-set-1.7/office.context.mailbox.item.md
+++ b/docs/reference/objectmodel/requirement-set-1.7/office.context.mailbox.item.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context.mailbox.item
+title: Office.context.mailbox.item - requirement set 1.7
 description: ''
 ms.date: 12/18/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.7/office.context.mailbox.item.md
+++ b/docs/reference/objectmodel/requirement-set-1.7/office.context.mailbox.item.md
@@ -1,3 +1,8 @@
+---
+title: Office.context.mailbox.item
+description: ''
+ms.date: 12/18/2018
+---
 
 # item
 

--- a/docs/reference/objectmodel/requirement-set-1.7/office.context.mailbox.md
+++ b/docs/reference/objectmodel/requirement-set-1.7/office.context.mailbox.md
@@ -1,7 +1,12 @@
+---
+title: Office.context.mailbox
+description: ''
+ms.date: 10/31/2018
+---
 
 # mailbox
 
-### [Office](Office.md)[.context](Office.context.md). mailbox
+### [Office](Office.md)[.context](Office.context.md).mailbox
 
 Provides access to the Outlook add-in object model for Microsoft Outlook and Microsoft Outlook on the web.
 

--- a/docs/reference/objectmodel/requirement-set-1.7/office.context.mailbox.md
+++ b/docs/reference/objectmodel/requirement-set-1.7/office.context.mailbox.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context.mailbox
+title: Office.context.mailbox - requirement set 1.7
 description: ''
 ms.date: 10/31/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.7/office.context.mailbox.userProfile.md
+++ b/docs/reference/objectmodel/requirement-set-1.7/office.context.mailbox.userProfile.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context.mailbox.userProfile
+title: Office.context.mailbox.userProfile - requirement set 1.7
 description: ''
 ms.date: 10/31/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.7/office.context.mailbox.userProfile.md
+++ b/docs/reference/objectmodel/requirement-set-1.7/office.context.mailbox.userProfile.md
@@ -1,7 +1,12 @@
+---
+title: Office.context.mailbox.userProfile
+description: ''
+ms.date: 10/31/2018
+---
 
 # userProfile
 
-### [Office](Office.md)[.context](Office.context.md)[.mailbox](Office.context.mailbox.md). userProfile
+### [Office](Office.md)[.context](Office.context.md)[.mailbox](Office.context.mailbox.md).userProfile
 
 ##### Requirements
 

--- a/docs/reference/objectmodel/requirement-set-1.7/office.context.md
+++ b/docs/reference/objectmodel/requirement-set-1.7/office.context.md
@@ -1,3 +1,8 @@
+---
+title: Office.context
+description: ''
+ms.date: 10/11/2018
+---
 
 # context
 

--- a/docs/reference/objectmodel/requirement-set-1.7/office.context.md
+++ b/docs/reference/objectmodel/requirement-set-1.7/office.context.md
@@ -1,5 +1,5 @@
 ---
-title: Office.context
+title: Office.context - requirement set 1.7
 description: ''
 ms.date: 10/11/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.7/office.md
+++ b/docs/reference/objectmodel/requirement-set-1.7/office.md
@@ -1,5 +1,5 @@
 ---
-title: Office namespace
+title: Office namespace - requirement set 1.7
 description: ''
 ms.date: 11/08/2018
 ---

--- a/docs/reference/objectmodel/requirement-set-1.7/office.md
+++ b/docs/reference/objectmodel/requirement-set-1.7/office.md
@@ -1,4 +1,8 @@
- 
+---
+title: Office namespace
+description: ''
+ms.date: 11/08/2018
+---
 
 # Office
 

--- a/docs/reference/objectmodel/requirement-set-1.7/outlook-requirement-set-1.7.md
+++ b/docs/reference/objectmodel/requirement-set-1.7/outlook-requirement-set-1.7.md
@@ -1,3 +1,9 @@
+---
+title: Outlook add-in API requirement set 1.7
+description: ''
+ms.date: 10/09/2018
+---
+
 # Outlook add-in API requirement set 1.7
 
 The Outlook add-in API subset of the JavaScript API for Office includes objects, methods, properties and events that you can use in an Outlook add-in.

--- a/docs/reference/openspec.md
+++ b/docs/reference/openspec.md
@@ -1,3 +1,9 @@
+---
+title: API open specifications for the Office JavaScript API
+description: ''
+ms.date: 10/09/2018
+---
+
 # API open specifications
 
 The Office JavaScript API open specifications provide information about new JavaScript APIs that are being designed for Excel, Word, and other host applications. You can review the open specifications in [branches](https://github.com/OfficeDev/office-js-docs/branches/all) of the **OfficeDev/office-js-docs** GitHub repository to learn about APIs that are planned for future releases and can provide feedback about the planned API features and design by logging issues in the GitHub repository.

--- a/docs/reference/overview/excel-add-ins-reference-overview.md
+++ b/docs/reference/overview/excel-add-ins-reference-overview.md
@@ -1,3 +1,9 @@
+---
+title: Excel JavaScript API overview
+description: ''
+ms.date: 11/01/2018
+---
+
 # Excel JavaScript API overview
 
 You can use the Excel JavaScript API to build add-ins for Excel 2016 or later. The following list shows the high-level Excel objects that are available in the API. Each object page link contains a description of the properties, events, and methods that are available on the object. Explore the links from the menu to learn more.

--- a/docs/reference/overview/onenote-add-ins-javascript-reference.md
+++ b/docs/reference/overview/onenote-add-ins-javascript-reference.md
@@ -1,3 +1,9 @@
+---
+title: OneNote JavaScript API overview
+description: ''
+ms.date: 10/09/2018
+---
+
 # OneNote JavaScript API overview
 
 Applies to: OneNote Online

--- a/docs/reference/overview/visio-javascript-reference-overview.md
+++ b/docs/reference/overview/visio-javascript-reference-overview.md
@@ -1,3 +1,9 @@
+---
+title: Visio JavaScript API overview
+description: ''
+ms.date: 10/11/2018
+---
+
 # Visio JavaScript API overview
 
 You can use the Visio JavaScript APIs to embed Visio diagrams in SharePoint Online. An embedded Visio diagram is a diagram that is stored in a SharePoint document library and displayed on a SharePoint page. To embed a Visio diagram, display it in an HTML `<iframe>` element. Then you can use Visio JavaScript APIs to programmatically work with the embedded diagram.

--- a/docs/reference/overview/word-add-ins-reference-overview.md
+++ b/docs/reference/overview/word-add-ins-reference-overview.md
@@ -1,3 +1,9 @@
+---
+title: Word JavaScript API overview
+description: ''
+ms.date: 10/09/2018
+---
+
 # Word JavaScript API overview
 
 Word provides a rich set of APIs that you can use to create add-ins that interact with document content and metadata. Use these APIs to create compelling experiences that integrate with and extend Word. You can import and export content, assemble new documents from different data sources, and integrate with document workflows to create custom document solutions.

--- a/docs/reference/requirement-sets/add-in-commands-requirement-sets.md
+++ b/docs/reference/requirement-sets/add-in-commands-requirement-sets.md
@@ -1,3 +1,9 @@
+---
+title: Add-in commands requirement sets
+description: ''
+ms.date: 11/21/2018
+---
+
 # Add-in commands requirement sets
 
 Requirement sets are named groups of API members. Office Add-ins use requirement sets specified in the manifest or use a runtime check to determine whether an Office host supports APIs that an add-in needs. For more information, see [Office versions and requirement sets](https://docs.microsoft.com/office/dev/add-ins/develop/office-versions-and-requirement-sets).

--- a/docs/reference/requirement-sets/dialog-api-requirement-sets.md
+++ b/docs/reference/requirement-sets/dialog-api-requirement-sets.md
@@ -1,3 +1,9 @@
+---
+title: Dialog API requirement sets
+description: ''
+ms.date: 10/09/2018
+---
+
 # Dialog API requirement sets
 
 Requirement sets are named groups of API members. Office Add-ins use requirement sets specified in the manifest or use a runtime check to determine whether an Office host supports APIs that an add-in needs. For more information, see [Office versions and requirement sets](https://docs.microsoft.com/office/dev/add-ins/develop/office-versions-and-requirement-sets).

--- a/docs/reference/requirement-sets/excel-api-requirement-sets.md
+++ b/docs/reference/requirement-sets/excel-api-requirement-sets.md
@@ -1,3 +1,9 @@
+---
+title: Excel JavaScript API requirement sets
+description: ''
+ms.date: 10/09/2018
+---
+
 # Excel JavaScript API requirement sets
 
 Requirement sets are named groups of API members. Office Add-ins use requirement sets specified in the manifest or use a runtime check to determine whether an Office host supports APIs that an add-in needs. For more information, see [Office versions and requirement sets](https://docs.microsoft.com/office/dev/add-ins/develop/office-versions-and-requirement-sets).

--- a/docs/reference/requirement-sets/identity-api-requirement-sets.md
+++ b/docs/reference/requirement-sets/identity-api-requirement-sets.md
@@ -1,3 +1,9 @@
+---
+title: Identity API requirement sets
+description: ''
+ms.date: 10/09/2018
+---
+
 # Identity API requirement sets
 
 Requirement sets are named groups of API members. Office Add-ins use requirement sets specified in the manifest or use a runtime check to determine whether an Office host supports APIs that an add-in needs. For more information, see [Office versions and requirement sets](https://docs.microsoft.com/office/dev/add-ins/develop/office-versions-and-requirement-sets).

--- a/docs/reference/requirement-sets/office-add-in-requirement-sets.md
+++ b/docs/reference/requirement-sets/office-add-in-requirement-sets.md
@@ -1,3 +1,9 @@
+---
+title: Office common API requirement sets
+description: ''
+ms.date: 11/20/2018
+---
+
 # Office common API requirement sets
 
 Requirement sets are named groups of API members. Office Add-ins use requirement sets specified in the manifest or use a runtime check to determine whether an Office host supports APIs that an add-in needs. For more information, see [Office versions and requirement sets](https://docs.microsoft.com/office/dev/add-ins/develop/office-versions-and-requirement-sets).

--- a/docs/reference/requirement-sets/onenote-api-requirement-sets.md
+++ b/docs/reference/requirement-sets/onenote-api-requirement-sets.md
@@ -1,3 +1,9 @@
+---
+title: OneNote JavaScript API requirement sets
+description: ''
+ms.date: 10/09/2018
+---
+
 # OneNote JavaScript API requirement sets
 
 Requirement sets are named groups of API members. Office Add-ins use requirement sets specified in the manifest or use a runtime check to determine whether an Office host supports APIs that an add-in needs. For more information, see [Office versions and requirement sets](https://docs.microsoft.com/office/dev/add-ins/develop/office-versions-and-requirement-sets).

--- a/docs/reference/requirement-sets/outlook-api-requirement-sets.md
+++ b/docs/reference/requirement-sets/outlook-api-requirement-sets.md
@@ -1,3 +1,9 @@
+---
+title: Outlook JavaScript API requirement sets
+description: ''
+ms.date: 12/04/2018
+---
+
 # Outlook JavaScript API requirement sets
 
 Outlook add-ins declare what API versions they require by using the [Requirements](/office/dev/add-ins/reference/manifest/requirements) element in their [manifest](https://docs.microsoft.com/office/dev/add-ins/develop/add-in-manifests). Outlook add-ins always include a [Set](/office/dev/add-ins/reference/manifest/set) element with a `Name` attribute set to `Mailbox` and a `MinVersion` attribute set to the minimum API requirement set that supports the add-in's scenarios.

--- a/docs/reference/requirement-sets/word-api-requirement-sets.md
+++ b/docs/reference/requirement-sets/word-api-requirement-sets.md
@@ -1,3 +1,9 @@
+---
+title: Word JavaScript API requirement sets
+description: ''
+ms.date: 11/14/2018
+---
+
 # Word JavaScript API requirement sets
 
 Requirement sets are named groups of API members. Office Add-ins use requirement sets specified in the manifest or use a runtime check to determine whether an Office host supports APIs that an add-in needs. For more information, see [Office versions and requirement sets](https://docs.microsoft.com/office/dev/add-ins/develop/office-versions-and-requirement-sets).


### PR DESCRIPTION
150+ files in the doc set were missing the metadata section at the top of the file. This PR fixes that issue.