### PR TITLE
[Admin] (typo) - Remove obsolete note from Resources article.

### DIFF
--- a/docs/reference/manifest/rule.md
+++ b/docs/reference/manifest/rule.md
@@ -1,7 +1,7 @@
 ---
 title: Rule element in the manifest file
 description: ''
-ms.date: 11/30/2018
+ms.date: 12/27/2018
 ---
 
 # Rule element

--- a/docs/resources/resources-links-help.md
+++ b/docs/resources/resources-links-help.md
@@ -8,9 +8,6 @@ ms.date: 04/12/2018
 
 These resources provide additional information and support for developing Office Add-ins.
 
-> [!IMPORTANT]
-> This article is not monitored for support requests. Please use one of these resources for support rather than posting comments on this article. 
-
 |**Resource type**                    | **Guidance**                                                
 |----------------------------|---------------------------------
 |**Office JavaScript API questions** | Post API questions to [Stack Overflow](https://stackoverflow.com/questions/tagged/office-js) using the `office-js` tag, and also include the `outlook-web-addins` tag if your question relates to Outlook add-ins. Please note that Stack Overflow has guidelines such as requiring a descriptive title, a complete and concise problem statement, and sufficient details to reproduce your issue. Feature requests or overly broad questions are off-topic; new users should visit the [Stack Overflow Help Center](https://stackoverflow.com/help/how-to-ask) for more details.


### PR DESCRIPTION
Quite a while back, a config setting was added to docfx.json to disable the OPS "Feedback " feature for the Resources article; this PR removes the (now unnecessary) note that advised folks not to add comments on that article. This PR also updates the ms.date value for a manifest reference article that was updated back in December 2018.