### PR TITLE
[Outlook] (manifest) - Update the `Action` element article.

### DIFF
--- a/docs/reference/manifest/action.md
+++ b/docs/reference/manifest/action.md
@@ -135,7 +135,7 @@ The following examples show two different actions that use the **Title** element
 Optional element when **xsi:type** is "ShowTaskpane". The containing [VersionOverrides](versionoverrides.md) elements must have an `xsi:type` attribute value of `VersionOverridesV1_1`. Include this element with a value of `true` to support task pane pinning. The user will be able to "pin" the task pane, causing it to stay open when changing the selection. For more information, see [Implement a pinnable task pane in Outlook](https://docs.microsoft.com/outlook/add-ins/pinnable-taskpane).
 
 > [!NOTE]
-> SupportsPinning currently only supported by Outlook 2016 for Windows (build 7628.1000 or later).
+> SupportsPinning is currently only supported by Outlook 2016 for Windows (build 7628.1000 or later) and Outlook 2016 for Mac (build 16.13.503 and later).
 
 ```xml
 <Action xsi:type="ShowTaskpane">

--- a/docs/reference/manifest/action.md
+++ b/docs/reference/manifest/action.md
@@ -135,7 +135,7 @@ The following examples show two different actions that use the **Title** element
 Optional element when **xsi:type** is "ShowTaskpane". The containing [VersionOverrides](versionoverrides.md) elements must have an `xsi:type` attribute value of `VersionOverridesV1_1`. Include this element with a value of `true` to support task pane pinning. The user will be able to "pin" the task pane, causing it to stay open when changing the selection. For more information, see [Implement a pinnable task pane in Outlook](https://docs.microsoft.com/outlook/add-ins/pinnable-taskpane).
 
 > [!NOTE]
-> SupportsPinning is currently only supported by Outlook 2016 for Windows (build 7628.1000 or later) and Outlook 2016 for Mac (build 16.13.503 and later).
+> SupportsPinning is currently only supported by Outlook 2016 for Windows (build 7628.1000 or later) and Outlook 2016 for Mac (build 16.13.503 or later).
 
 ```xml
 <Action xsi:type="ShowTaskpane">

--- a/docs/reference/objectmodel/requirement-set-1.7/office.context.mailbox.userProfile.md
+++ b/docs/reference/objectmodel/requirement-set-1.7/office.context.mailbox.userProfile.md
@@ -31,7 +31,7 @@ localization_priority: Normal
 ####  accountType :String
 
 > [!NOTE]
-> This member is currently only supported by Outlook 2016 for Mac (build 16.9.1212 and later).
+> This member is currently only supported by Outlook 2016 for Mac (build 16.9.1212 or later).
 
 Gets the account type of the user associated with the mailbox. The possible values are listed in the following table.
 

--- a/docs/reference/objectmodel/requirement-set-1.7/office.context.mailbox.userProfile.md
+++ b/docs/reference/objectmodel/requirement-set-1.7/office.context.mailbox.userProfile.md
@@ -31,7 +31,7 @@ localization_priority: Normal
 ####  accountType :String
 
 > [!NOTE]
-> This member is currently only supported in Outlook 2016 for Mac, build 16.9.1212 and greater.
+> This member is currently only supported by Outlook 2016 for Mac (build 16.9.1212 and later).
 
 Gets the account type of the user associated with the mailbox. The possible values are listed in the following table.
 


### PR DESCRIPTION
Addresses #679. 

Update `Action` element article to indicate that the `SupportsPinning` child element is now also supported by Outlook 2016 for Mac. Also update wording of support info in another article (for consistency).