### PR TITLE
[excel] (Quick Start) Adding section on trusting self-signed certificates to the vue quick start

### DIFF
--- a/docs/includes/file-get-started-excel-vue.md
+++ b/docs/includes/file-get-started-excel-vue.md
@@ -177,9 +177,14 @@ To enable HTTPS for your app, open the file **package.json** in the root folder 
     npm start
     ```
 
-2. In a web browser, navigate to `https://localhost:8080`. If your browser indicates that the site's certificate is not trusted, you will need to configure your computer to trust the certificate. 
+2. In a web browser, navigate to `https://localhost:8080`. If the page loads without any certificate errors, proceed to the next section in this article (**Try it out**). If your browser indicates that the site's certificate is not trusted, proceed to the following step.
 
-3. After your browser loads the add-in page without any certificate errors, you're ready test your add-in. 
+3. Office Web Add-ins should use HTTPS, not HTTP, even when you are developing. If your browser indicates that the site's certificate is not trusted, you will need to add the certificate as a trusted certificate. See [Adding Self-Signed Certificates as Trusted Root Certificate](https://github.com/OfficeDev/generator-office/blob/master/src/docs/ssl.md) for details.
+
+    > [!NOTE]
+    > Chrome (web browser) may continue to indicate the the site's certificate is not trusted, even after you have completed the process described in [Adding Self-Signed Certificates as Trusted Root Certificate](https://github.com/OfficeDev/generator-office/blob/master/src/docs/ssl.md). Therefore, you should use either Internet Explorer or Microsoft Edge to verify that the certificate is trusted.
+
+4. After your browser loads the add-in page without any certificate errors, you're ready test your add-in.
 
 ## Try it out
 


### PR DESCRIPTION
Giving this article a link to the [Adding Self-Signed Certificates as Trusted Root Certificate](https://github.com/OfficeDev/generator-office/blob/master/src/docs/ssl.md) article. This should match the other Excel quick starts.
This is in response to #720.