### PR TITLE
[Outlook] (manifest) Update notes on SupportsSharedFolders element

### DIFF
--- a/docs/reference/manifest/desktopformfactor.md
+++ b/docs/reference/manifest/desktopformfactor.md
@@ -1,7 +1,7 @@
 ---
 title: DesktopFormFactor element in the manifest file
 description: ''
-ms.date: 10/09/2018
+ms.date: 03/01/2019
 localization_priority: Normal
 ---
 
@@ -18,7 +18,7 @@ Each DesktopFormFactor definition contains the  **FunctionFile** element and one
 | [ExtensionPoint](extensionpoint.md)   | Yes      | Defines where an add-in exposes functionality. |
 | [FunctionFile](functionfile.md)       | Yes      | A URL to a file that contains JavaScript functions.|
 | [GetStarted](getstarted.md)           | No       | Defines the callout that appears when installing the add-in in Word, Excel, or PowerPoint hosts. |
-| [SupportsSharedFolders](supportssharedfolders.md) | No | Defines whether the Outlook add-in is available in delegate scenarios and is set to *false* by default.<br><br>**Important**: This element is only available in the Outlook add-ins Preview requirement set against Exchange Online. Add-ins that use this element cannot be published to AppSource or deployed via centralized deployment. |
+| [SupportsSharedFolders](supportssharedfolders.md) | No | Defines whether the Outlook add-in is available in delegate scenarios and is set to *false* by default.<br><br>**Important**: Because delegate access for Outlook add-ins is currently in preview, add-ins that use the `SupportSharedFolders` element cannot be published to AppSource or deployed via centralized deployment. |
 
 ## DesktopFormFactor example
 

--- a/docs/reference/manifest/supportssharedfolders.md
+++ b/docs/reference/manifest/supportssharedfolders.md
@@ -1,7 +1,7 @@
 ---
 title: SupportsSharedFolders element in the manifest file
 description: ''
-ms.date: 10/09/2018
+ms.date: 03/01/2019
 localization_priority: Normal
 ---
 
@@ -10,7 +10,7 @@ localization_priority: Normal
 Defines whether the Outlook add-in is available in delegate scenarios. The **SupportsSharedFolders** element is a child element of [DesktopFormFactor](desktopformfactor.md). It is set to *false* by default.
 
 > [!IMPORTANT]
-> This element is only available in the [Outlook add-ins Preview requirement set](../objectmodel/preview-requirement-set/outlook-requirement-set-preview.md) against Exchange Online. Add-ins that use this element cannot be published to AppSource or deployed via centralized deployment.
+> Delegate access for Outlook add-ins is currently in preview and only supported in clients that run against Exchange Online. Add-ins that use this element cannot be published to AppSource or deployed via centralized deployment.
 
 The following is an example of the  **SupportsSharedFolders** element.
 
@@ -18,8 +18,8 @@ The following is an example of the  **SupportsSharedFolders** element.
 <DesktopFormFactor>
   <FunctionFile resid="residDesktopFuncUrl" />
   <SupportsSharedFolders>true</SupportsSharedFolders>
-  <ExtensionPoint xsi:type="PrimaryCommandSurface">
-    <!-- information about this extension point -->
+  <ExtensionPoint xsi:type="MessageReadCommandSurface">
+    <!-- configure selected extension point -->
   </ExtensionPoint>
 
   <!-- You can define more than one ExtensionPoint element as needed -->


### PR DESCRIPTION
Based on notes in [delegate access article](https://docs.microsoft.com/en-us/outlook/add-ins/delegate-access).