### PR TITLE
[Excel] (Custom functions) Function ids can only use A-Z

### DIFF
--- a/docs/excel/custom-functions-naming.md
+++ b/docs/excel/custom-functions-naming.md
@@ -10,7 +10,7 @@ A custom function is identified by an **id** and **name** property in the JSON m
 
 Function names and function IDs share some common requirements:
 
-- Function ids may only use characters A to Z, 0 - 9, underscore, and period.
+- Function ids may only use characters A to Z, numbers zero through nine, underscores, and periods.
 
 - Function names may use any Unicode alphanumeric character, underscore, and period.
 

--- a/docs/excel/custom-functions-naming.md
+++ b/docs/excel/custom-functions-naming.md
@@ -10,7 +10,7 @@ A custom function is identified by an **id** and **name** property in the JSON m
 
 Function names and function IDs share some common requirements:
 
-- Function ids may only use characters A to Z, numbers zero through nine, underscores, and periods.
+- Function ids may only use characters A through Z, numbers zero through nine, underscores, and periods.
 
 - Function names may use any Unicode alphanumeric character, underscore, and period.
 

--- a/docs/excel/custom-functions-naming.md
+++ b/docs/excel/custom-functions-naming.md
@@ -12,7 +12,7 @@ Function names and function IDs share some common requirements:
 
 - Function ids may only use characters A through Z, numbers zero through nine, underscores, and periods.
 
-- Function names may use any Unicode alphanumeric character, underscore, and period.
+- Function names may use any Unicode alphabetic characters, underscores, and periods.
 
 - They must start with a letter and have a minimum limit of three characters.
 

--- a/docs/excel/custom-functions-naming.md
+++ b/docs/excel/custom-functions-naming.md
@@ -10,7 +10,9 @@ A custom function is identified by an **id** and **name** property in the JSON m
 
 Function names and function IDs share some common requirements:
 
-- They must only use alphanumeric characters (including Unicode), the numbers zero through nine, underscores, and periods.
+- Function ids may only use characters A to Z, 0 - 9, underscore, and period.
+
+- Function names may use any Unicode alphanumeric character, underscore, and period.
 
 - They must start with a letter and have a minimum limit of three characters.
 


### PR DESCRIPTION
Function ids can only use A to Z whereas function names can use any Unicode alphabetic character.