### PR TITLE
[Common API] (Compressed File) Removing support notes for Compressed File on iOS

### DIFF
--- a/docs/overview/office-add-in-availability.md
+++ b/docs/overview/office-add-in-availability.md
@@ -604,6 +604,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
          - <a href="/office/dev/add-ins/reference/requirement-sets/dialog-api-requirement-sets">DialogApi 1.1</a>
 </td>
     <td> - BindingEvents<br>
+         - CompressedFile<br>
          - CustomXmlParts<br>
          - DocumentEvents<br>
          - File<br>
@@ -805,6 +806,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
          - TaskPane</td>
     <td> - <a href="/office/dev/add-ins/reference/requirement-sets/dialog-api-requirement-sets">DialogApi 1.1</a></td>
     <td> - ActiveView<br>
+         - CompressedFile<br>
          - DocumentEvents<br>
          - File<br>
          - PdfFile<br>

--- a/docs/overview/office-add-in-availability.md
+++ b/docs/overview/office-add-in-availability.md
@@ -1,7 +1,7 @@
 ---
 title: Office Add-in host and platform availability
 description: Supported requirement sets for Excel, Word, Outlook, PowerPoint, OneNote, and Project.
-ms.date: 05/01/2019
+ms.date: 05/07/2019
 localization_priority: Priority
 ---
 
@@ -170,7 +170,6 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
         - <a href="/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets">ExcelApi 1.9</a><br>
         - <a href="/office/dev/add-ins/reference/requirement-sets/dialog-api-requirement-sets">DialogApi 1.1</a></td>
     <td>- BindingEvents<br>
-        - CompressedFile<br>
         - DocumentEvents<br>
         - File<br>
         - ImageCoercion<br>
@@ -605,7 +604,6 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
          - <a href="/office/dev/add-ins/reference/requirement-sets/dialog-api-requirement-sets">DialogApi 1.1</a>
 </td>
     <td> - BindingEvents<br>
-         - CompressedFile<br>
          - CustomXmlParts<br>
          - DocumentEvents<br>
          - File<br>
@@ -806,8 +804,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     <td> - Content<br>
          - TaskPane</td>
     <td> - <a href="/office/dev/add-ins/reference/requirement-sets/dialog-api-requirement-sets">DialogApi 1.1</a></td>
-     <td> - ActiveView<br>
-         - CompressedFile<br>
+    <td> - ActiveView<br>
          - DocumentEvents<br>
          - File<br>
          - PdfFile<br>

--- a/docs/reference/requirement-sets/office-add-in-requirement-sets.md
+++ b/docs/reference/requirement-sets/office-add-in-requirement-sets.md
@@ -52,7 +52,7 @@ See [Add-in command requirement sets](add-in-commands-requirement-sets.md).
 
 |**Office hosts**|**Methods in set**|
 |:-----|:-----|
-| Excel<br>Excel Online<br>Excel for Mac<br>PowerPoint<br>PowerPoint Online<br>PowerPoint for Mac<br>Word 2013 and later<br>Word 2016 for Mac and later<br>Word Online|Supports output to Office Open XML (OOXML) format as a byte array<br>(Office.FileType.Compressed) when using the Document.getFileAsync method.|
+| Excel<br>Excel Online<br>Excel for Mac<br>PowerPoint<br>PowerPoint Online<br>PowerPoint for iPad<br>PowerPoint for Mac<br>Word 2013 and later<br>Word 2016 for Mac and later<br>Word Online<br>Word for iPad|Supports output to Office Open XML (OOXML) format as a byte array<br>(Office.FileType.Compressed) when using the Document.getFileAsync method.|
 
 ---
 

--- a/docs/reference/requirement-sets/office-add-in-requirement-sets.md
+++ b/docs/reference/requirement-sets/office-add-in-requirement-sets.md
@@ -1,7 +1,7 @@
 ---
 title: Office Common API requirement sets
 description: ''
-ms.date: 05/07/2019
+ms.date: 05/02/2019
 ms.prod: non-product-specific
 localization_priority: Priority
 ---

--- a/docs/reference/requirement-sets/office-add-in-requirement-sets.md
+++ b/docs/reference/requirement-sets/office-add-in-requirement-sets.md
@@ -1,7 +1,7 @@
 ---
 title: Office Common API requirement sets
 description: ''
-ms.date: 05/02/2019
+ms.date: 05/07/2019
 ms.prod: non-product-specific
 localization_priority: Priority
 ---
@@ -52,7 +52,7 @@ See [Add-in command requirement sets](add-in-commands-requirement-sets.md).
 
 |**Office hosts**|**Methods in set**|
 |:-----|:-----|
-| Excel<br>Excel Online<br>Excel for Mac<br>PowerPoint<br>PowerPoint Online<br>PowerPoint for iPad<br>PowerPoint for Mac<br>Word 2013 and later<br>Word 2016 for Mac and later<br>Word Online<br>Word for iPad|Supports output to Office Open XML (OOXML) format as a byte array<br>(Office.FileType.Compressed) when using the Document.getFileAsync method.|
+| Excel<br>Excel Online<br>Excel for Mac<br>PowerPoint<br>PowerPoint Online<br>PowerPoint for Mac<br>Word 2013 and later<br>Word 2016 for Mac and later<br>Word Online|Supports output to Office Open XML (OOXML) format as a byte array<br>(Office.FileType.Compressed) when using the Document.getFileAsync method.|
 
 ---
 


### PR DESCRIPTION
iOS does not support the Compressed File requirement set. There will be a corresponding PR in Definitely Typed soon.