### PR TITLE
[All] Rename Office Online

### DIFF
--- a/docs/overview/office-add-in-availability.md
+++ b/docs/overview/office-add-in-availability.md
@@ -324,7 +324,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     <th><a href="/office/dev/add-ins/reference/requirement-sets/office-add-in-requirement-sets"><b>Common APIs</b></a></th>
   </tr>
   <tr>
-    <td>Office on the web<br>(Outlook.com or<br>connected to Office 365 subscription)</td>
+    <td>Office on the web<br>(new)</td>
     <td> - Mail Read<br>
       - Mail Compose<br>
       - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a></td>
@@ -338,7 +338,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     <td>Not available</td>
   </tr>
   <tr>
-    <td>Office on the web<br>(Classic)</td>
+    <td>Office on the web<br>(classic)</td>
     <td> - Mail Read<br>
       - Mail Compose<br>
       - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a></td>

--- a/docs/overview/office-add-in-availability.md
+++ b/docs/overview/office-add-in-availability.md
@@ -1,7 +1,7 @@
 ---
 title: Office Add-in host and platform availability
 description: Supported requirement sets for Excel, Word, Outlook, PowerPoint, OneNote, and Project.
-ms.date: 05/23/2019
+ms.date: 06/07/2019
 localization_priority: Priority
 ---
 
@@ -22,7 +22,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     <th style="width:40%"><a href="/office/dev/add-ins/reference/requirement-sets/office-add-in-requirement-sets"><b>Common APIs</b></a></th>
   </tr>
   <tr>
-    <td>Office Online</td>
+    <td>Office for the web</td>
     <td> - TaskPane<br>
         - Content<br>
         - Custom Functions<br>
@@ -54,7 +54,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
         - TextCoercion</td>
   </tr>
   <tr>
-    <td>Office on Windows<br>(connected to Office 365)</td>
+    <td>Office for Windows<br>(with Office 365 subscription)</td>
     <td> - TaskPane<br>
         - Content<br>
         - Custom Functions<br>
@@ -86,7 +86,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
         - TextCoercion</td>
   </tr>
   <tr>
-    <td>Office 2019 on Windows<br>(one-time purchase)</td>
+    <td>Office 2019 for Windows<br>(one-time purchase)</td>
     <td>- TaskPane<br>
         - Content<br>
         - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a></td>
@@ -114,7 +114,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
         - TextCoercion</td>
   </tr>
   <tr>
-    <td>Office 2016 on Windows<br>(one-time purchase)</td>
+    <td>Office 2016 for Windows<br>(one-time purchase)</td>
     <td>- TaskPane<br>
         - Content</td>
     <td>- <a href="/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets">ExcelApi 1.1</a><br>
@@ -134,7 +134,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
         - TextCoercion</td>
   </tr>
   <tr>
-    <td>Office 2013 on Windows<br>(one-time purchase)</td>
+    <td>Office 2013 for Windows<br>(one-time purchase)</td>
     <td>
         - TaskPane<br>
         - Content</td>
@@ -155,7 +155,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
         - TextCoercion</td>
   </tr>
   <tr>
-    <td>Office for iPad<br>(connected to Office 365)</td>
+    <td>Office for iPad<br>(with Office 365 subscription)</td>
     <td>- TaskPane<br>
         - Content<br>
         - Custom Functions</td>
@@ -183,7 +183,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
         - TextCoercion</td>
   </tr>
   <tr>
-    <td>Office for Mac<br>(connected to Office 365)</td>
+    <td>Office for Mac<br>(with Office 365 subscription)</td>
     <td>- TaskPane<br>
         - Content<br>
         - Custom Functions<br>
@@ -277,7 +277,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     <th style="width:40%"><a href="/office/dev/add-ins/reference/requirement-sets/office-add-in-requirement-sets"><b>Common APIs</b></a></th>
   </tr>
   <tr>
-    <td>Office Online</td>
+    <td>Office for the web</td>
     <td>
         - Custom Functions</td>
     <td>
@@ -286,7 +286,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     </td>
   </tr>
   <tr>
-    <td>Office on Windows<br>(connected to Office 365)</td>
+    <td>Office for Windows<br>(with Office 365 subscription)</td>
     <td>
         - Custom Functions</td>
     <td>
@@ -295,7 +295,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     </td>
   </tr>
   <tr>
-    <td>Office for iPad<br>(connected to Office 365)</td>
+    <td>Office for iPad<br>(with Office 365 subscription)</td>
     <td>
         - Custom Functions</td>
     <td>
@@ -304,7 +304,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     </td>
   </tr>
   <tr>
-    <td>Office for Mac<br>(connected to Office 365)</td>
+    <td>Office for Mac<br>(with Office 365 subscription)</td>
     <td>
         - Custom Functions</td>
     <td>
@@ -324,7 +324,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     <th><a href="/office/dev/add-ins/reference/requirement-sets/office-add-in-requirement-sets"><b>Common APIs</b></a></th>
   </tr>
   <tr>
-    <td>Office Online</td>
+    <td>Office for the web</td>
     <td> - Mail Read<br>
       - Mail Compose<br>
       - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a></td>
@@ -338,7 +338,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     <td>Not available</td>
   </tr>
   <tr>
-    <td>Office on Windows<br>(connected to Office 365)</td>
+    <td>Office for Windows<br>(with Office 365 subscription)</td>
     <td> - Mail Read<br>
       - Mail Compose<br>
       - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a><br>
@@ -353,7 +353,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     <td>Not available</td>
   </tr>
   <tr>
-    <td>Office 2019 on Windows<br>(one-time purchase)</td>
+    <td>Office 2019 for Windows<br>(one-time purchase)</td>
     <td> - Mail Read<br>
       - Mail Compose<br>
       - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a><br>
@@ -368,7 +368,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     <td>Not available</td>
   </tr>
   <tr>
-    <td>Office 2016 on Windows<br>(one-time purchase)</td>
+    <td>Office 2016 for Windows<br>(one-time purchase)</td>
     <td> - Mail Read<br>
       - Mail Compose<br>
       - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a><br>
@@ -380,7 +380,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     <td>Not available</td>
   </tr>
   <tr>
-    <td>Office 2013 on Windows<br>(one-time purchase)</td>
+    <td>Office 2013 for Windows<br>(one-time purchase)</td>
     <td> - Mail Read<br>
       - Mail Compose</td>
     <td> - <a href="/office/dev/add-ins/reference/objectmodel/requirement-set-1.1/outlook-requirement-set-1.1">Mailbox 1.1</a><br>
@@ -390,7 +390,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     <td>Not available</td>
   </tr>
   <tr>
-    <td>Office for iOS<br>(connected to Office 365)</td>
+    <td>Office for iOS<br>(with Office 365 subscription)</td>
     <td> - Mail Read<br>
       - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a></td>
     <td> - <a href="/office/dev/add-ins/reference/objectmodel/requirement-set-1.1/outlook-requirement-set-1.1">Mailbox 1.1</a><br>
@@ -401,7 +401,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     <td>Not available</td>
   </tr>
   <tr>
-    <td>Office for Mac<br>(connected to Office 365)</td>
+    <td>Office for Mac<br>(with Office 365 subscription)</td>
     <td> - Mail Read<br>
       - Mail Compose<br>
       - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a></td>
@@ -441,7 +441,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     <td>Not available</td>
   </tr>
   <tr>
-    <td>Office for Android<br>(connected to Office 365)</td>
+    <td>Office for Android<br>(with Office 365 subscription)</td>
     <td> - Mail Read<br>
       - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a></td>
     <td> - <a href="/office/dev/add-ins/reference/objectmodel/requirement-set-1.1/outlook-requirement-set-1.1">Mailbox 1.1</a><br>
@@ -467,7 +467,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     <th><a href="/office/dev/add-ins/reference/requirement-sets/office-add-in-requirement-sets"><b>Common APIs</b></a></th>
   </tr>
   <tr>
-    <td>Office Online</td>
+    <td>Office for the web</td>
     <td> - TaskPane<br>
          - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a></td>
     <td> - <a href="/office/dev/add-ins/reference/requirement-sets/word-api-requirement-sets">WordApi 1.1</a><br>
@@ -493,7 +493,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
          - TextFile</td>
   </tr>
   <tr>
-    <td>Office on Windows<br>(connected to Office 365)</td>
+    <td>Office for Windows<br>(with Office 365 subscription)</td>
     <td> - TaskPane<br>
          - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a></td>
     <td> - <a href="/office/dev/add-ins/reference/requirement-sets/word-api-requirement-sets">WordApi 1.1</a><br>
@@ -521,7 +521,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     </td>
   </tr>
   <tr>
-    <td>Office 2019 on Windows<br>(one-time purchase)</td>
+    <td>Office 2019 for Windows<br>(one-time purchase)</td>
     <td> - TaskPane<br>
          - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a></td>
     <td> - <a href="/office/dev/add-ins/reference/requirement-sets/word-api-requirement-sets">WordApi 1.1</a><br>
@@ -549,7 +549,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     </td>
   </tr>
   <tr>
-    <td>Office 2016 on Windows<br>(one-time purchase)</td>
+    <td>Office 2016 for Windows<br>(one-time purchase)</td>
     <td> - TaskPane</td>
     <td> - <a href="/office/dev/add-ins/reference/requirement-sets/word-api-requirement-sets">WordApi 1.1</a><br>
          - <a href="/office/dev/add-ins/reference/requirement-sets/dialog-api-requirement-sets">DialogApi 1.1</a>*</td>
@@ -574,7 +574,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     </td>
   </tr>
   <tr>
-    <td>Office 2013 on Windows<br>(one-time purchase)</td>
+    <td>Office 2013 for Windows<br>(one-time purchase)</td>
     <td> - TaskPane</td>
     <td> - <a href="/office/dev/add-ins/reference/requirement-sets/dialog-api-requirement-sets">DialogApi 1.1</a>*</td>
     <td> - BindingEvents<br>
@@ -597,7 +597,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
          - TextFile</td>
   </tr>
   <tr>
-    <td>Office for iPad<br>(connected to Office 365)</td>
+    <td>Office for iPad<br>(with Office 365 subscription)</td>
     <td> - TaskPane</td>
     <td> - <a href="/office/dev/add-ins/reference/requirement-sets/word-api-requirement-sets">WordApi 1.1</a><br>
          - <a href="/office/dev/add-ins/reference/requirement-sets/word-api-requirement-sets">WordApi 1.2</a><br>
@@ -625,7 +625,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     </td>
   </tr>
   <tr>
-    <td>Office for Mac<br>(connected to Office 365)</td>
+    <td>Office for Mac<br>(with Office 365 subscription)</td>
     <td> - TaskPane<br>
          - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a></td>
     <td> - <a href="/office/dev/add-ins/reference/requirement-sets/word-api-requirement-sets">WordApi 1.1</a><br>
@@ -723,7 +723,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     <th><a href="/office/dev/add-ins/reference/requirement-sets/office-add-in-requirement-sets"><b>Common APIs</b></a></th>
   </tr>
   <tr>
-    <td>Office Online</td>
+    <td>Office for the web</td>
     <td> - Content<br>
          - TaskPane<br>
          - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a></td>
@@ -739,7 +739,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
          - TextCoercion</td>
   </tr>
   <tr>
-    <td>Office on Windows<br>(connected to Office 365)</td>
+    <td>Office for Windows<br>(with Office 365 subscription)</td>
     <td> - Content<br>
          - TaskPane<br>
          - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a></td>
@@ -755,7 +755,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
          - TextCoercion</td>
   </tr>
   <tr>
-    <td>Office 2019 on Windows<br>(one-time purchase)</td>
+    <td>Office 2019 for Windows<br>(one-time purchase)</td>
     <td> - Content<br>
          - TaskPane<br>
          - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a></td>
@@ -771,7 +771,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
          - TextCoercion</td>
   </tr>
   <tr>
-    <td>Office 2016 on Windows<br>(one-time purchase)</td>
+    <td>Office 2016 for Windows<br>(one-time purchase)</td>
     <td> - Content<br>
          - TaskPane</td>
     <td> - <a href="/office/dev/add-ins/reference/requirement-sets/dialog-api-requirement-sets">DialogApi 1.1</a>*</td>
@@ -786,7 +786,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
          - TextCoercion</td>
   </tr>
   <tr>
-    <td>Office 2013 on Windows<br>(one-time purchase)</td>
+    <td>Office 2013 for Windows<br>(one-time purchase)</td>
     <td> - Content<br>
          - TaskPane<br>
     </td>
@@ -802,7 +802,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
          - TextCoercion</td>
   </tr>
   <tr>
-    <td>Office for iPad<br>(connected to Office 365)</td>
+    <td>Office for iPad<br>(with Office 365 subscription)</td>
     <td> - Content<br>
          - TaskPane</td>
     <td> - <a href="/office/dev/add-ins/reference/requirement-sets/dialog-api-requirement-sets">DialogApi 1.1</a></td>
@@ -817,7 +817,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
          - ImageCoercion</td>
   </tr>
   <tr>
-    <td>Office for Mac<br>(connected to Office 365)</td>
+    <td>Office for Mac<br>(with Office 365 subscription)</td>
     <td> - Content<br>
          - TaskPane<br>
          - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a></td>
@@ -879,7 +879,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     <th><a href="/office/dev/add-ins/reference/requirement-sets/office-add-in-requirement-sets"><b>Common APIs</b></a></th>
   </tr>
   <tr>
-    <td>Office Online</td>
+    <td>Office for the web</td>
     <td> - Content<br>
          - TaskPane<br>
          - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a></td>
@@ -905,21 +905,21 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     <th><a href="/office/dev/add-ins/reference/requirement-sets/office-add-in-requirement-sets"><b>Common APIs</b></a></th>
   </tr>
   <tr>
-    <td>Office 2019 on Windows<br>(one-time purchase)</td>
+    <td>Office 2019 for Windows<br>(one-time purchase)</td>
     <td> - TaskPane</td>
     <td> - <a href="/office/dev/add-ins/reference/requirement-sets/dialog-api-requirement-sets">DialogApi 1.1</a></td>
     <td> - Selection<br>
          - TextCoercion</td>
   </tr>
   <tr>
-    <td>Office 2016 on Windows<br>(one-time purchase)</td>
+    <td>Office 2016 for Windows<br>(one-time purchase)</td>
     <td> - TaskPane</td>
     <td> - <a href="/office/dev/add-ins/reference/requirement-sets/dialog-api-requirement-sets">DialogApi 1.1</a></td>
     <td> - Selection<br>
          - TextCoercion</td>
   </tr>
   <tr>
-    <td>Office 2013 on Windows<br>(one-time purchase)</td>
+    <td>Office 2013 for Windows<br>(one-time purchase)</td>
     <td> - TaskPane</td>
     <td> - <a href="/office/dev/add-ins/reference/requirement-sets/dialog-api-requirement-sets">DialogApi 1.1</a></td>
     <td> - Selection<br>

--- a/docs/overview/office-add-in-availability.md
+++ b/docs/overview/office-add-in-availability.md
@@ -1,7 +1,7 @@
 ---
 title: Office Add-in host and platform availability
-description: Supported requirement sets for Excel, Word, Outlook, PowerPoint, OneNote, and Project.
-ms.date: 06/07/2019
+description: Supported requirement sets for Excel, OneNote, Outlook, PowerPoint, Project, and Word.
+ms.date: 06/13/2019
 localization_priority: Priority
 ---
 
@@ -22,7 +22,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     <th style="width:40%"><a href="/office/dev/add-ins/reference/requirement-sets/office-add-in-requirement-sets"><b>Common APIs</b></a></th>
   </tr>
   <tr>
-    <td>Office for the web</td>
+    <td>Office on the web</td>
     <td> - TaskPane<br>
         - Content<br>
         - Custom Functions<br>
@@ -54,7 +54,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
         - TextCoercion</td>
   </tr>
   <tr>
-    <td>Office for Windows<br>(with Office 365 subscription)</td>
+    <td>Office on Windows<br>(connected to Office 365 subscription)</td>
     <td> - TaskPane<br>
         - Content<br>
         - Custom Functions<br>
@@ -86,7 +86,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
         - TextCoercion</td>
   </tr>
   <tr>
-    <td>Office 2019 for Windows<br>(one-time purchase)</td>
+    <td>Office 2019 on Windows<br>(one-time purchase)</td>
     <td>- TaskPane<br>
         - Content<br>
         - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a></td>
@@ -114,7 +114,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
         - TextCoercion</td>
   </tr>
   <tr>
-    <td>Office 2016 for Windows<br>(one-time purchase)</td>
+    <td>Office 2016 on Windows<br>(one-time purchase)</td>
     <td>- TaskPane<br>
         - Content</td>
     <td>- <a href="/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets">ExcelApi 1.1</a><br>
@@ -134,7 +134,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
         - TextCoercion</td>
   </tr>
   <tr>
-    <td>Office 2013 for Windows<br>(one-time purchase)</td>
+    <td>Office 2013 on Windows<br>(one-time purchase)</td>
     <td>
         - TaskPane<br>
         - Content</td>
@@ -155,7 +155,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
         - TextCoercion</td>
   </tr>
   <tr>
-    <td>Office for iPad<br>(with Office 365 subscription)</td>
+    <td>Office on iPad<br>(connected to Office 365 subscription)</td>
     <td>- TaskPane<br>
         - Content<br>
         - Custom Functions</td>
@@ -183,7 +183,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
         - TextCoercion</td>
   </tr>
   <tr>
-    <td>Office for Mac<br>(with Office 365 subscription)</td>
+    <td>Office on Mac<br>(connected to Office 365 subscription)</td>
     <td>- TaskPane<br>
         - Content<br>
         - Custom Functions<br>
@@ -214,7 +214,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
         - TextCoercion</td>
   </tr>
   <tr>
-    <td>Office 2019 for Mac<br>(one-time purchase)</td>
+    <td>Office 2019 on Mac<br>(one-time purchase)</td>
     <td>- TaskPane<br>
         - Content<br>
         - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a></td>
@@ -243,7 +243,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
         - TextCoercion</td>
   </tr>
   <tr>
-    <td>Office 2016 for Mac<br>(one-time purchase)</td>
+    <td>Office 2016 on Mac<br>(one-time purchase)</td>
     <td>- TaskPane<br>
         - Content</td>
     <td>- <a href="/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets">ExcelApi 1.1</a><br>
@@ -277,7 +277,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     <th style="width:40%"><a href="/office/dev/add-ins/reference/requirement-sets/office-add-in-requirement-sets"><b>Common APIs</b></a></th>
   </tr>
   <tr>
-    <td>Office for the web</td>
+    <td>Office on the web</td>
     <td>
         - Custom Functions</td>
     <td>
@@ -286,7 +286,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     </td>
   </tr>
   <tr>
-    <td>Office for Windows<br>(with Office 365 subscription)</td>
+    <td>Office on Windows<br>(connected to Office 365 subscription)</td>
     <td>
         - Custom Functions</td>
     <td>
@@ -295,7 +295,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     </td>
   </tr>
   <tr>
-    <td>Office for iPad<br>(with Office 365 subscription)</td>
+    <td>Office on iPad<br>(connected to Office 365 subscription)</td>
     <td>
         - Custom Functions</td>
     <td>
@@ -304,7 +304,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     </td>
   </tr>
   <tr>
-    <td>Office for Mac<br>(with Office 365 subscription)</td>
+    <td>Office on Mac<br>(connected to Office 365 subscription)</td>
     <td>
         - Custom Functions</td>
     <td>
@@ -324,7 +324,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     <th><a href="/office/dev/add-ins/reference/requirement-sets/office-add-in-requirement-sets"><b>Common APIs</b></a></th>
   </tr>
   <tr>
-    <td>Office for the web</td>
+    <td>Office on the web</td>
     <td> - Mail Read<br>
       - Mail Compose<br>
       - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a></td>
@@ -338,7 +338,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     <td>Not available</td>
   </tr>
   <tr>
-    <td>Office for Windows<br>(with Office 365 subscription)</td>
+    <td>Office on Windows<br>(connected to Office 365 subscription)</td>
     <td> - Mail Read<br>
       - Mail Compose<br>
       - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a><br>
@@ -353,7 +353,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     <td>Not available</td>
   </tr>
   <tr>
-    <td>Office 2019 for Windows<br>(one-time purchase)</td>
+    <td>Office 2019 on Windows<br>(one-time purchase)</td>
     <td> - Mail Read<br>
       - Mail Compose<br>
       - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a><br>
@@ -368,7 +368,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     <td>Not available</td>
   </tr>
   <tr>
-    <td>Office 2016 for Windows<br>(one-time purchase)</td>
+    <td>Office 2016 on Windows<br>(one-time purchase)</td>
     <td> - Mail Read<br>
       - Mail Compose<br>
       - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a><br>
@@ -380,7 +380,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     <td>Not available</td>
   </tr>
   <tr>
-    <td>Office 2013 for Windows<br>(one-time purchase)</td>
+    <td>Office 2013 on Windows<br>(one-time purchase)</td>
     <td> - Mail Read<br>
       - Mail Compose</td>
     <td> - <a href="/office/dev/add-ins/reference/objectmodel/requirement-set-1.1/outlook-requirement-set-1.1">Mailbox 1.1</a><br>
@@ -390,7 +390,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     <td>Not available</td>
   </tr>
   <tr>
-    <td>Office for iOS<br>(with Office 365 subscription)</td>
+    <td>Office on iOS<br>(connected to Office 365 subscription)</td>
     <td> - Mail Read<br>
       - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a></td>
     <td> - <a href="/office/dev/add-ins/reference/objectmodel/requirement-set-1.1/outlook-requirement-set-1.1">Mailbox 1.1</a><br>
@@ -401,7 +401,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     <td>Not available</td>
   </tr>
   <tr>
-    <td>Office for Mac<br>(with Office 365 subscription)</td>
+    <td>Office on Mac<br>(connected to Office 365 subscription)</td>
     <td> - Mail Read<br>
       - Mail Compose<br>
       - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a></td>
@@ -415,7 +415,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     <td>Not available</td>
   </tr>
   <tr>
-    <td>Office 2019 for Mac<br>(one-time purchase)</td>
+    <td>Office 2019 on Mac<br>(one-time purchase)</td>
     <td> - Mail Read<br>
       - Mail Compose<br>
       - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a></td>
@@ -428,7 +428,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     <td>Not available</td>
   </tr>
   <tr>
-    <td>Office 2016 for Mac<br>(one-time purchase)</td>
+    <td>Office 2016 on Mac<br>(one-time purchase)</td>
     <td> - Mail Read<br>
       - Mail Compose<br>
       - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a></td>
@@ -441,7 +441,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     <td>Not available</td>
   </tr>
   <tr>
-    <td>Office for Android<br>(with Office 365 subscription)</td>
+    <td>Office on Android<br>(connected to Office 365 subscription)</td>
     <td> - Mail Read<br>
       - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a></td>
     <td> - <a href="/office/dev/add-ins/reference/objectmodel/requirement-set-1.1/outlook-requirement-set-1.1">Mailbox 1.1</a><br>
@@ -467,7 +467,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     <th><a href="/office/dev/add-ins/reference/requirement-sets/office-add-in-requirement-sets"><b>Common APIs</b></a></th>
   </tr>
   <tr>
-    <td>Office for the web</td>
+    <td>Office on the web</td>
     <td> - TaskPane<br>
          - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a></td>
     <td> - <a href="/office/dev/add-ins/reference/requirement-sets/word-api-requirement-sets">WordApi 1.1</a><br>
@@ -493,7 +493,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
          - TextFile</td>
   </tr>
   <tr>
-    <td>Office for Windows<br>(with Office 365 subscription)</td>
+    <td>Office on Windows<br>(connected to Office 365 subscription)</td>
     <td> - TaskPane<br>
          - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a></td>
     <td> - <a href="/office/dev/add-ins/reference/requirement-sets/word-api-requirement-sets">WordApi 1.1</a><br>
@@ -521,7 +521,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     </td>
   </tr>
   <tr>
-    <td>Office 2019 for Windows<br>(one-time purchase)</td>
+    <td>Office 2019 on Windows<br>(one-time purchase)</td>
     <td> - TaskPane<br>
          - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a></td>
     <td> - <a href="/office/dev/add-ins/reference/requirement-sets/word-api-requirement-sets">WordApi 1.1</a><br>
@@ -549,7 +549,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     </td>
   </tr>
   <tr>
-    <td>Office 2016 for Windows<br>(one-time purchase)</td>
+    <td>Office 2016 on Windows<br>(one-time purchase)</td>
     <td> - TaskPane</td>
     <td> - <a href="/office/dev/add-ins/reference/requirement-sets/word-api-requirement-sets">WordApi 1.1</a><br>
          - <a href="/office/dev/add-ins/reference/requirement-sets/dialog-api-requirement-sets">DialogApi 1.1</a>*</td>
@@ -574,7 +574,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     </td>
   </tr>
   <tr>
-    <td>Office 2013 for Windows<br>(one-time purchase)</td>
+    <td>Office 2013 on Windows<br>(one-time purchase)</td>
     <td> - TaskPane</td>
     <td> - <a href="/office/dev/add-ins/reference/requirement-sets/dialog-api-requirement-sets">DialogApi 1.1</a>*</td>
     <td> - BindingEvents<br>
@@ -597,7 +597,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
          - TextFile</td>
   </tr>
   <tr>
-    <td>Office for iPad<br>(with Office 365 subscription)</td>
+    <td>Office on iPad<br>(connected to Office 365 subscription)</td>
     <td> - TaskPane</td>
     <td> - <a href="/office/dev/add-ins/reference/requirement-sets/word-api-requirement-sets">WordApi 1.1</a><br>
          - <a href="/office/dev/add-ins/reference/requirement-sets/word-api-requirement-sets">WordApi 1.2</a><br>
@@ -625,7 +625,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     </td>
   </tr>
   <tr>
-    <td>Office for Mac<br>(with Office 365 subscription)</td>
+    <td>Office on Mac<br>(connected to Office 365 subscription)</td>
     <td> - TaskPane<br>
          - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a></td>
     <td> - <a href="/office/dev/add-ins/reference/requirement-sets/word-api-requirement-sets">WordApi 1.1</a><br>
@@ -654,7 +654,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     </td>
   </tr>
   <tr>
-    <td>Office 2019 for Mac<br>(one-time purchase)</td>
+    <td>Office 2019 on Mac<br>(one-time purchase)</td>
     <td> - TaskPane<br>
          - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a></td>
     <td> - <a href="/office/dev/add-ins/reference/requirement-sets/word-api-requirement-sets">WordApi 1.1</a><br>
@@ -683,7 +683,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     </td>
   </tr>
   <tr>
-    <td>Office 2016 for Mac<br>(one-time purchase)</td>
+    <td>Office 2016 on Mac<br>(one-time purchase)</td>
     <td> - TaskPane</td>
     <td> - <a href="/office/dev/add-ins/reference/requirement-sets/word-api-requirement-sets">WordApi 1.1</a><br>
         - <a href="/office/dev/add-ins/reference/requirement-sets/dialog-api-requirement-sets">DialogApi 1.1</a>*</td>
@@ -723,7 +723,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     <th><a href="/office/dev/add-ins/reference/requirement-sets/office-add-in-requirement-sets"><b>Common APIs</b></a></th>
   </tr>
   <tr>
-    <td>Office for the web</td>
+    <td>Office on the web</td>
     <td> - Content<br>
          - TaskPane<br>
          - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a></td>
@@ -739,7 +739,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
          - TextCoercion</td>
   </tr>
   <tr>
-    <td>Office for Windows<br>(with Office 365 subscription)</td>
+    <td>Office on Windows<br>(connected to Office 365 subscription)</td>
     <td> - Content<br>
          - TaskPane<br>
          - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a></td>
@@ -755,7 +755,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
          - TextCoercion</td>
   </tr>
   <tr>
-    <td>Office 2019 for Windows<br>(one-time purchase)</td>
+    <td>Office 2019 on Windows<br>(one-time purchase)</td>
     <td> - Content<br>
          - TaskPane<br>
          - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a></td>
@@ -771,7 +771,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
          - TextCoercion</td>
   </tr>
   <tr>
-    <td>Office 2016 for Windows<br>(one-time purchase)</td>
+    <td>Office 2016 on Windows<br>(one-time purchase)</td>
     <td> - Content<br>
          - TaskPane</td>
     <td> - <a href="/office/dev/add-ins/reference/requirement-sets/dialog-api-requirement-sets">DialogApi 1.1</a>*</td>
@@ -786,7 +786,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
          - TextCoercion</td>
   </tr>
   <tr>
-    <td>Office 2013 for Windows<br>(one-time purchase)</td>
+    <td>Office 2013 on Windows<br>(one-time purchase)</td>
     <td> - Content<br>
          - TaskPane<br>
     </td>
@@ -802,7 +802,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
          - TextCoercion</td>
   </tr>
   <tr>
-    <td>Office for iPad<br>(with Office 365 subscription)</td>
+    <td>Office on iPad<br>(connected to Office 365 subscription)</td>
     <td> - Content<br>
          - TaskPane</td>
     <td> - <a href="/office/dev/add-ins/reference/requirement-sets/dialog-api-requirement-sets">DialogApi 1.1</a></td>
@@ -817,7 +817,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
          - ImageCoercion</td>
   </tr>
   <tr>
-    <td>Office for Mac<br>(with Office 365 subscription)</td>
+    <td>Office on Mac<br>(connected to Office 365 subscription)</td>
     <td> - Content<br>
          - TaskPane<br>
          - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a></td>
@@ -833,7 +833,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
          - TextCoercion</td>
   </tr>
   <tr>
-    <td>Office 2019 for Mac<br>(one-time purchase)</td>
+    <td>Office 2019 on Mac<br>(one-time purchase)</td>
     <td> - Content<br>
          - TaskPane<br>
          - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a></td>
@@ -849,7 +849,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
          - TextCoercion</td>
   </tr>
   <tr>
-    <td>Office 2016 for Mac<br>(one-time purchase)</td>
+    <td>Office 2016 on Mac<br>(one-time purchase)</td>
     <td> - Content<br>
          - TaskPane</td>
     <td> - <a href="/office/dev/add-ins/reference/requirement-sets/dialog-api-requirement-sets">DialogApi 1.1</a>*</td>
@@ -879,7 +879,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     <th><a href="/office/dev/add-ins/reference/requirement-sets/office-add-in-requirement-sets"><b>Common APIs</b></a></th>
   </tr>
   <tr>
-    <td>Office for the web</td>
+    <td>Office on the web</td>
     <td> - Content<br>
          - TaskPane<br>
          - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a></td>
@@ -905,21 +905,21 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     <th><a href="/office/dev/add-ins/reference/requirement-sets/office-add-in-requirement-sets"><b>Common APIs</b></a></th>
   </tr>
   <tr>
-    <td>Office 2019 for Windows<br>(one-time purchase)</td>
+    <td>Office 2019 on Windows<br>(one-time purchase)</td>
     <td> - TaskPane</td>
     <td> - <a href="/office/dev/add-ins/reference/requirement-sets/dialog-api-requirement-sets">DialogApi 1.1</a></td>
     <td> - Selection<br>
          - TextCoercion</td>
   </tr>
   <tr>
-    <td>Office 2016 for Windows<br>(one-time purchase)</td>
+    <td>Office 2016 on Windows<br>(one-time purchase)</td>
     <td> - TaskPane</td>
     <td> - <a href="/office/dev/add-ins/reference/requirement-sets/dialog-api-requirement-sets">DialogApi 1.1</a></td>
     <td> - Selection<br>
          - TextCoercion</td>
   </tr>
   <tr>
-    <td>Office 2013 for Windows<br>(one-time purchase)</td>
+    <td>Office 2013 on Windows<br>(one-time purchase)</td>
     <td> - TaskPane</td>
     <td> - <a href="/office/dev/add-ins/reference/requirement-sets/dialog-api-requirement-sets">DialogApi 1.1</a></td>
     <td> - Selection<br>

--- a/docs/overview/office-add-in-availability.md
+++ b/docs/overview/office-add-in-availability.md
@@ -324,7 +324,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
     <th><a href="/office/dev/add-ins/reference/requirement-sets/office-add-in-requirement-sets"><b>Common APIs</b></a></th>
   </tr>
   <tr>
-    <td>Office on the web</td>
+    <td>Office on the web<br>(Outlook.com or<br>connected to Office 365 subscription)</td>
     <td> - Mail Read<br>
       - Mail Compose<br>
       - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a></td>
@@ -335,6 +335,19 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
       - <a href="/office/dev/add-ins/reference/objectmodel/requirement-set-1.5/outlook-requirement-set-1.5">Mailbox 1.5</a><br>
       - <a href="/office/dev/add-ins/reference/objectmodel/requirement-set-1.6/outlook-requirement-set-1.6">Mailbox 1.6</a><br>
       - <a href="/office/dev/add-ins/reference/objectmodel/requirement-set-1.7/outlook-requirement-set-1.7">Mailbox 1.7</a></td>
+    <td>Not available</td>
+  </tr>
+  <tr>
+    <td>Office on the web<br>(Classic)</td>
+    <td> - Mail Read<br>
+      - Mail Compose<br>
+      - <a href="/office/dev/add-ins/reference/requirement-sets/add-in-commands-requirement-sets">Add-in Commands</a></td>
+    <td> - <a href="/office/dev/add-ins/reference/objectmodel/requirement-set-1.1/outlook-requirement-set-1.1">Mailbox 1.1</a><br>
+      - <a href="/office/dev/add-ins/reference/objectmodel/requirement-set-1.2/outlook-requirement-set-1.2">Mailbox 1.2</a><br>
+      - <a href="/office/dev/add-ins/reference/objectmodel/requirement-set-1.3/outlook-requirement-set-1.3">Mailbox 1.3</a><br>
+      - <a href="/office/dev/add-ins/reference/objectmodel/requirement-set-1.4/outlook-requirement-set-1.4">Mailbox 1.4</a><br>
+      - <a href="/office/dev/add-ins/reference/objectmodel/requirement-set-1.5/outlook-requirement-set-1.5">Mailbox 1.5</a><br>
+      - <a href="/office/dev/add-ins/reference/objectmodel/requirement-set-1.6/outlook-requirement-set-1.6">Mailbox 1.6</a></td>
     <td>Not available</td>
   </tr>
   <tr>


### PR DESCRIPTION
After discussing with our editor, Laura, landed on the following.
-Rename "Office Online" to "Office on the web"
-Reword "connected to Office 365" to "connected to Office 365 subscription"
-Reword from "for [platform]" to "on [platform]"