### PR TITLE
[general] (Open Spec) Scoping Open Spec page to focus more on open spec

### DIFF
--- a/docs/reference/openspec/openspec.md
+++ b/docs/reference/openspec/openspec.md
@@ -1,35 +1,26 @@
 ---
 title: API open specifications for the Office JavaScript API
 description: ''
-ms.date: 05/13/2019
+ms.date: 06/10/2019
 localization_priority: Normal
 ---
 
 # API open specifications
 
-The Office JavaScript API open specifications provide information about new JavaScript APIs that are being designed for Excel, Word, and other host applications.
+The Office JavaScript API open specifications provide information about new JavaScript APIs that are being designed for Excel, Outlook, and other host applications. The open specification phase allows us to hear from the community about upcoming designs. After we've heard from the community and are ready, the APIs are moved to a public preview requirement set and can be tested. Each host's requirement set page has details about the APIs currently in preview.
 
 > [!IMPORTANT]
-> Features described in the API open specifications may be in various stages of development, such as early design or public preview, and are subject to change. When an API feature becomes generally available, the [reference documentation](/javascript/api/overview/office) will be updated.
+> Features described in the API open specifications are subject to change and may be removed from the development cycle.
 
-## Open specifications
+## Current open specifications
 
-The open specification phase allows us to hear from the community about upcoming designs. Currently, we have no APIs in the public open specification phase. We will update this page with new designs as they become available.
+Currently, we have no APIs in the public open specification phase. We will update this page with new designs as they become available.
 
-## Preview APIs
+## See also
 
-After the open specification process, new Office JavaScript enter the preview phase. To use preview APIs, your add-in must reference the **beta** library on the CDN (https://appsforoffice.microsoft.com/lib/beta/hosted/office.js) and you may also need to join the Office Insider program to get a recent Office build.
-
-Feedback is still welcome for preview APIs. The design is not necessarily finalized at this step and we want to ensure that when the APIs are released they are of high quality. Please report any issues you encounter or thoughts or have through GitHub. Each page has a reporting link at the end of the page.
-
-### New Excel JavaScript APIs
-
-Join us in reviewing our design for new Excel JavaScript APIs. The latest updates can be found in the [Excel JavaScript API requirement sets page](../requirement-sets/excel-api-requirement-sets.md#excel-javascript-preview-apis).
-
-**See the [Excel JavaScript preview APIs](/javascript/api/excel) to learn more and provide your feedback.**
-
-### New Word JavaScript APIs
-
-Join us in reviewing our design for new Word JavaScript APIs. The latest updates can be found in the [Word JavaScript API requirement sets page](../requirement-sets/word-api-requirement-sets.md#word-javascript-preview-apis).
-
-**See the [Word JavaScript preview APIs](/javascript/api/word) to learn more and provide your feedback.**
+- [Excel preview API reference](/javascript/api/excel)
+- [Excel JavaScript API preview requirement set](../requirement-sets/excel-api-requirement-sets.md#excel-javascript-preview-apis)
+- [Outlook preview API reference](/javascript/api/outlook)
+- [Outlook JavaScript API preview requirement set](..//objectmodel/preview-requirement-set/outlook-requirement-set-preview.md)
+- [Word preview API reference](/javascript/api/word)
+- [Word JavaScript API preview requirement set](../requirement-sets/word-api-requirement-sets.md#word-javascript-preview-apis)

--- a/docs/reference/overview/excel-add-ins-reference-overview.md
+++ b/docs/reference/overview/excel-add-ins-reference-overview.md
@@ -1,7 +1,7 @@
 ---
 title: Excel JavaScript API overview
 description: ''
-ms.date: 05/13/2019
+ms.date: 06/10/2019
 ms.prod: excel
 localization_priority: Priority
 ---
@@ -15,37 +15,33 @@ Some of the core Excel objects are listed below for convenience:
 - [Workbook](/javascript/api/excel/excel.workbook): The top-level object that contains related workbook objects such as worksheets, tables, ranges, etc. It also can be used to list related references.
 
 - [Worksheet](/javascript/api/excel/excel.worksheet): Represents a worksheet in a workbook.
-    - [WorksheetCollection](/javascript/api/excel/excel.worksheetcollection): A collection of the **Worksheet** objects in a workbook.
-    - [WorksheetProtection](/javascript/api/excel/excel.worksheetprotection): Represents the protection of a **Worksheet** object.
+  - [WorksheetCollection](/javascript/api/excel/excel.worksheetcollection): A collection of the **Worksheet** objects in a workbook.
+  - [WorksheetProtection](/javascript/api/excel/excel.worksheetprotection): Represents the protection of a **Worksheet** object.
 
 - [Range](/javascript/api/excel/excel.range): Represents a cell, a row, a column, or a selection of cells containing one or more contiguous blocks of cells.
-    - [ConditionalFormat](/javascript/api/excel/excel.conditionalformat): An object defining a rule and a format applied to the range when the rule's condition is met.
-	- [DataValidation](/javascript/api/excel/excel.datavalidation): An object that restricts user input to a range based on a variety of criteria.
-    - [RangeSort](/javascript/api/excel/excel.rangesort): Represents a object that manages sorting operations on a range.
+  - [ConditionalFormat](/javascript/api/excel/excel.conditionalformat): An object defining a rule and a format applied to the range when the rule's condition is met.
+  - [DataValidation](/javascript/api/excel/excel.datavalidation): An object that restricts user input to a range based on a variety of criteria.
+  - [RangeSort](/javascript/api/excel/excel.rangesort): Represents a object that manages sorting operations on a range.
 
 - [Table](/javascript/api/excel/excel.table): Represents a collection of organized cells designed to make management of the data easy.
-    - [TableCollection](/javascript/api/excel/excel.tablecollection): A collection of tables in a workbook or worksheet.
-    - [TableColumnCollection](/javascript/api/excel/excel.tablecolumncollection): A collection of all the columns in a table.
-    - [TableRowCollection](/javascript/api/excel/excel.tablerowcollection): A collection of all the rows in a table.
-    - [TableSort](/javascript/api/excel/excel.tablesort): Represents an object that manages sorting operations on a table.
+  - [TableCollection](/javascript/api/excel/excel.tablecollection): A collection of tables in a workbook or worksheet.
+  - [TableColumnCollection](/javascript/api/excel/excel.tablecolumncollection): A collection of all the columns in a table.
+  - [TableRowCollection](/javascript/api/excel/excel.tablerowcollection): A collection of all the rows in a table.
+  - [TableSort](/javascript/api/excel/excel.tablesort): Represents an object that manages sorting operations on a table.
 
 - [Chart](/javascript/api/excel/excel.chart): Represents a chart object in a worksheet, which is a visual representation of underlying data.
-    - [ChartCollection](/javascript/api/excel/excel.chartcollection): A collection of charts in a worksheet.
-	
+  - [ChartCollection](/javascript/api/excel/excel.chartcollection): A collection of charts in a worksheet.
+
 - [PivotTable](/javascript/api/excel/excel.pivottable): Represents an Excel PivotTable, which is a hierarchical grouping and presentation of data.
-    - [PivotTableCollection](/javascript/api/excel/excel.pivottablecollection): A collection of PivotTables in a worksheet.
+  - [PivotTableCollection](/javascript/api/excel/excel.pivottablecollection): A collection of PivotTables in a worksheet.
 
 - [Filter](/javascript/api/excel/excel.filter): Represents an object that manages the filtering of a table's column.
 
 - [NamedItem](/javascript/api/excel/excel.nameditem): Represents a defined name for a range of cells or a value.
-    - [NamedItemCollection](/javascript/api/excel/excel.nameditemcollection): A collection of the **NamedItem** objects in a workbook.
+  - [NamedItemCollection](/javascript/api/excel/excel.nameditemcollection): A collection of the **NamedItem** objects in a workbook.
 
 - [Binding](/javascript/api/excel/excel.binding): An abstract class that represents a binding to a section of the workbook.
-    - [BindingCollection](/javascript/api/excel/excel.bindingcollection): A collection of the **Binding** objects in a workbook.
-
-## Excel JavaScript API open specifications
-
-As we design and develop new APIs for Excel add-ins, we'll make them available for your feedback on our [Open API specifications](../openspec/openspec.md) page. Find out what new features are in the pipeline for the Excel JavaScript APIs, and provide your input on our design specifications.
+  - [BindingCollection](/javascript/api/excel/excel.bindingcollection): A collection of the **Binding** objects in a workbook.
 
 ## Excel JavaScript API requirement sets
 
@@ -60,3 +56,4 @@ For detailed information about the Excel JavaScript API, see the [Excel JavaScri
 - [Excel add-ins overview](/office/dev/add-ins/excel/excel-add-ins-overview)
 - [Office Add-ins platform overview](/office/dev/add-ins/overview/office-add-ins)
 - [Excel add-in samples on GitHub](https://github.com/OfficeDev?utf8=%E2%9C%93&q=Excel)
+- [Open API specifications](../openspec/openspec.md)

--- a/docs/reference/overview/excel-add-ins-reference-overview.md
+++ b/docs/reference/overview/excel-add-ins-reference-overview.md
@@ -56,4 +56,4 @@ For detailed information about the Excel JavaScript API, see the [Excel JavaScri
 - [Excel add-ins overview](/office/dev/add-ins/excel/excel-add-ins-overview)
 - [Office Add-ins platform overview](/office/dev/add-ins/overview/office-add-ins)
 - [Excel add-in samples on GitHub](https://github.com/OfficeDev?utf8=%E2%9C%93&q=Excel)
-- [Open API specifications](../openspec/openspec.md)
+- [API open specifications](../openspec/openspec.md)

--- a/docs/reference/overview/word-add-ins-reference-overview.md
+++ b/docs/reference/overview/word-add-ins-reference-overview.md
@@ -130,4 +130,4 @@ For detailed information about the Word JavaScript API, see the [Word JavaScript
 - [Word add-ins overview](/office/dev/add-ins/word/word-add-ins-programming-overview)
 - [Office Add-ins platform overview](/office/dev/add-ins/overview/office-add-ins)
 - [Word add-in samples on GitHub](https://github.com/OfficeDev?utf8=%E2%9C%93&q=Word)
-- [Open API specifications](../openspec/openspec.md)
+- [API open specifications](../openspec/openspec.md)

--- a/docs/reference/overview/word-add-ins-reference-overview.md
+++ b/docs/reference/overview/word-add-ins-reference-overview.md
@@ -1,7 +1,7 @@
 ---
 title: Word JavaScript API overview
 description: ''
-ms.date: 05/13/2019
+ms.date: 06/10/2019
 ms.prod: word
 localization_priority: Priority
 ---
@@ -23,8 +23,8 @@ The Word JavaScript API is loaded by Office.js. The Word JavaScript API changes 
 
 You can reference Office.js from the following locations:
 
-* https://appsforoffice.microsoft.com/lib/1/hosted/office.js - use this resource for production add-ins.
-* https://appsforoffice.microsoft.com/lib/beta/hosted/office.js - use this resource when you're trying out preview features.
+- https://appsforoffice.microsoft.com/lib/1/hosted/office.js - use this resource for production add-ins.
+- https://appsforoffice.microsoft.com/lib/beta/hosted/office.js - use this resource when you're trying out preview features.
 
 If you're using [Visual Studio](https://www.visualstudio.com/products/free-developer-offers-vs), you can download the [Office Developer Tools](https://www.visualstudio.com/features/office-tools-vs.aspx) to get project templates that include Office.js.  You can also use [nuget to get Office.js](https://www.nuget.org/packages/Microsoft.Office.js/).
 
@@ -95,7 +95,6 @@ The Word proxy objects have methods for accessing and updating the object model.
 
 The following example shows how the command queue works. When **context.sync()** is called, the command to load the body text is executed in Word. Then, the command to insert text into the body in Word occurs. The results are then returned to the body proxy object. The value of the **body.text** property in the Word JavaScript API is the value of the Word document body <u>before</u> the text was inserted into Word document.
 
-
 ```js
 // Run a batch operation against the Word JavaScript API.
 Word.run(function (context) {
@@ -118,10 +117,6 @@ Word.run(function (context) {
 })
 ```
 
-## Word JavaScript API open specifications
-
-As we design and develop new APIs for Word add-ins, we'll make them available for your feedback on our [Open API specifications](../openspec/openspec.md) page. Find out what new features are in the pipeline for the Word JavaScript APIs and provide your input on our design specifications.
-
 ## Word JavaScript API requirement sets
 
 Requirement sets are named groups of API members. Office Add-ins use requirement sets specified in the manifest or use a runtime check to determine whether an Office host supports APIs that an add-in needs. For detailed information about Word JavaScript API requirement sets, see the [Word JavaScript API requirement sets](../requirement-sets/word-api-requirement-sets.md) article.
@@ -132,6 +127,7 @@ For detailed information about the Word JavaScript API, see the [Word JavaScript
 
 ## See also
 
-* [Word add-ins overview](/office/dev/add-ins/word/word-add-ins-programming-overview)
-* [Office Add-ins platform overview](/office/dev/add-ins/overview/office-add-ins)
-* [Word add-in samples on GitHub](https://github.com/OfficeDev?utf8=%E2%9C%93&q=Word)
+- [Word add-ins overview](/office/dev/add-ins/word/word-add-ins-programming-overview)
+- [Office Add-ins platform overview](/office/dev/add-ins/overview/office-add-ins)
+- [Word add-in samples on GitHub](https://github.com/OfficeDev?utf8=%E2%9C%93&q=Word)
+- [Open API specifications](../openspec/openspec.md)


### PR DESCRIPTION
We received feedback that the Open Spec page gave a misleading impression about preview APIs. To help distinguish the two for our users, we're making this page explicitly about open specifications. The surrounding text has been changed to also clarify the process and journey. 

I also cleaned up the markdown of a couple files I was in.