### PR TITLE
[admin] (Discoverability) Remove open spec link from Word overview

### DIFF
--- a/docs/word/word-add-ins-programming-overview.md
+++ b/docs/word/word-add-ins-programming-overview.md
@@ -1,7 +1,7 @@
 ---
 title: Word add-ins overview
 description: ''
-ms.date: 05/08/2019
+ms.date: 06/12/2019
 localization_priority: Priority
 ---
 
@@ -70,7 +70,7 @@ Use the shared JavaScript API for Office when you need to:
 
 ## Next steps
 
-Ready to create your first Word add-in? See [Build your first Word add-in](word-add-ins.md). You can also try our interactive [Get started experience](/office/dev/add-ins/?product=Word). Use the [add-in manifest](../develop/add-in-manifests.md) to describe where your add-in is hosted, how it is displayed, and define permissions and other information.
+Ready to create your first Word add-in? See [Build your first Word add-in](word-add-ins.md). Use the [add-in manifest](../develop/add-in-manifests.md) to describe where your add-in is hosted, how it is displayed, and define permissions and other information.
 
 To learn more about how to design a world class Word add-in that creates a compelling experience for your users, see [Design guidelines](../design/add-in-design.md) and [Best practices](../concepts/add-in-development-best-practices.md).
 

--- a/docs/word/word-add-ins-programming-overview.md
+++ b/docs/word/word-add-ins-programming-overview.md
@@ -76,10 +76,6 @@ To learn more about how to design a world class Word add-in that creates a compe
 
 After you develop your add-in, you can [publish](../publish/publish.md) it to a network share, an app catalog, or AppSource.
 
-## What's coming up for Word add-ins?
-
-As we design and develop new APIs for Word add-ins, we'll make them available for your feedback on our [API open specifications](/office/dev/add-ins/reference/openspec/openspec) page. Find out what new features are in the pipeline for the Word JavaScript APIs, and provide your input on our design specifications.
-
 ## See also
 
 * [Office Add-ins platform overview](../overview/office-add-ins.md)


### PR DESCRIPTION
Aside from addressing #1075, this removes the notion that we're actively updating Word APIs. Since we have no immediate plans to add open specs for Word, we shouldn't promote it from the overview page.