### PR TITLE
[All] (Yo Office prerequisites) Remove Git as a prerequisite for using Yo Office.

### DIFF
--- a/docs/includes/quickstart-yo-prerequisites.md
+++ b/docs/includes/quickstart-yo-prerequisites.md
@@ -1,7 +1,5 @@
 - [Node.js](https://nodejs.org) (version 8.0.0 or later)
 
-- [Git](https://git-scm.com/downloads)
-
 - The latest version of [Yeoman](https://github.com/yeoman/yo) and the [Yeoman generator for Office Add-ins](https://github.com/OfficeDev/generator-office). To install these tools globally, run the following command via the command prompt:
 
     ```command&nbsp;line


### PR DESCRIPTION
The next release of Yo Office no longer requires Git. I'll plan to merge this PR as soon as the next release of Yo Office is published (most likely Monday 6/24).