### PR TITLE
[common] (AppDomain) Trusted domains that can make Office.js API call

### DIFF
--- a/docs/develop/add-in-manifests.md
+++ b/docs/develop/add-in-manifests.md
@@ -1,7 +1,7 @@
 ---
 title: Office Add-ins XML manifest
 description: ''
-ms.date: 06/20/2019
+ms.date: 07/03/2019
 localization_priority: Priority
 ---
 
@@ -133,9 +133,9 @@ The following XML manifest example hosts its main add-in page in the `https://ww
 </OfficeApp>
 ```
 
-## Specify domains from which you want to make Office.js API calls
+## Specify domains from which Office.js API calls are made
 
-Your add-in can make Office.js API calls from the domain mentioned in the [SourceLocation](/office/dev/add-ins/reference/manifest/sourcelocation) element of the manifest file. If you have other IFrame within your add-in that needs to access Office.js API, then add the domain of that source URL to the list specified in the [AppDomains](/office/dev/add-ins/reference/manifest/appdomains) element of the manifest file. If an IFrame whose source isn't in the `AppDomains` list attempts to make Office.js API call, then the add-in will receive permission denied error. 
+Your add-in can make Office.js API calls from the domain referenced in the [SourceLocation](/office/dev/add-ins/reference/manifest/sourcelocation) element of the manifest file. If you have other IFrames within your add-in that need to access Office.js APIs, add the domain of that source URL to the list specified in the [AppDomains](/office/dev/add-ins/reference/manifest/appdomains) element of the manifest file. If an IFrame with a source not contained in the `AppDomains` list attempts to make an Office.js API call, then the add-in will receive a [permission denied error](../reference/javascript-api-for-office-error-codes.md). 
 
 ## Manifest v1.1 XML file examples and schemas
 

--- a/docs/develop/add-in-manifests.md
+++ b/docs/develop/add-in-manifests.md
@@ -133,6 +133,10 @@ The following XML manifest example hosts its main add-in page in the `https://ww
 </OfficeApp>
 ```
 
+## Specify domains from which you want to make Office.js API calls
+
+Your add-in can make Office.js API calls from the domain mentioned in the [SourceLocation](/office/dev/add-ins/reference/manifest/sourcelocation) element of the manifest file. If you have other IFrame within your add-in that needs to access Office.js API, then add the domain of that source URL to the list specified in the [AppDomains](/office/dev/add-ins/reference/manifest/appdomains) element of the manifest file. If an IFrame whose source isn't in the `AppDomains` list attempts to make Office.js API call, then the add-in will receive permission denied error. 
+
 ## Manifest v1.1 XML file examples and schemas
 
 The following sections show examples of manifest v1.1 XML files for content, task pane, and Outlook add-ins.

--- a/docs/reference/manifest/appdomain.md
+++ b/docs/reference/manifest/appdomain.md
@@ -1,13 +1,13 @@
 ---
 title: AppDomain element in the manifest file
 description: ''
-ms.date: 05/15/2019
+ms.date: 07/03/2019
 localization_priority: Normal
 ---
 
 # AppDomain element
 
-Specifies additional domains that will be used to load pages in the add-in window. It is also be used to list trusted domains from which Office.js API calls can be made from IFrames within the add-in.
+Specifies additional domains that load pages in the add-in window. It also lists trusted domains from which Office.js API calls can be made from IFrames within the add-in.
 
 **Add-in type:** Content, Task pane, Mail
 

--- a/docs/reference/manifest/appdomain.md
+++ b/docs/reference/manifest/appdomain.md
@@ -7,7 +7,7 @@ localization_priority: Normal
 
 # AppDomain element
 
-Specifies an additional domain that will be used to load pages in the add-in window.
+Specifies additional domains that will be used to load pages in the add-in window. It is also be used to list trusted domains from which Office.js API calls can be made from IFrames within the add-in.
 
 **Add-in type:** Content, Task pane, Mail
 

--- a/docs/reference/manifest/appdomains.md
+++ b/docs/reference/manifest/appdomains.md
@@ -1,13 +1,13 @@
 ---
 title: AppDomains element in the manifest file
 description: ''
-ms.date: 12/13/2018
+ms.date: 07/03/2019
 localization_priority: Normal
 ---
 
 # AppDomains element
 
-Lists any domains in addition to the domain specified in the `SourceLocation` element that your Office Add-in will use to load pages. It is also be used to list trusted domains from which Office.js API calls can be made from IFrames within the add-in. For each additional domain, specify an AppDomain element. 
+Lists any domains in addition to the domain specified in the `SourceLocation` element that your Office Add-in will use to load pages. It also lists trusted domains from which Office.js API calls can be made from IFrames within the add-in. For each additional domain, specify an AppDomain element.
 
  **Add-in type:** Content, Task pane, Mail
 

--- a/docs/reference/manifest/appdomains.md
+++ b/docs/reference/manifest/appdomains.md
@@ -7,7 +7,7 @@ localization_priority: Normal
 
 # AppDomains element
 
-Lists any domains in addition to the domain specified in the SourceLocation element that your Office Add-in will use to load pages. For each additional domain, specify an AppDomain element.
+Lists any domains in addition to the domain specified in the `SourceLocation` element that your Office Add-in will use to load pages. It is also be used to list trusted domains from which Office.js API calls can be made from IFrames within the add-in. For each additional domain, specify an AppDomain element. 
 
  **Add-in type:** Content, Task pane, Mail
 


### PR DESCRIPTION
Clarification language to communicate the usage of AppDoamins manifest entry to add trusted domains from where Office.js API calls can be made. 