### PR TITLE
[typo] (Office on Mac) Fix folder name in instructions

### DIFF
--- a/docs/testing/sideload-an-office-add-in-on-ipad-and-mac.md
+++ b/docs/testing/sideload-an-office-add-in-on-ipad-and-mac.md
@@ -59,9 +59,9 @@ To see how your add-in will run in Office on iOS, you can sideload your add-in's
 
 1. Open  **Terminal** and go to one of the following folders where you'll save your add-in's manifest file. If the `wef` folder doesn't exist on your computer, create it.
     
-    - For Word:  `/Users/<username>/Library/Containers/com.microsoft.Word/Data/documents/wef`    
-    - For Excel:  `/Users/<username>/Library/Containers/com.microsoft.Excel/Data/documents/wef`
-    - For PowerPoint: `/Users/<username>/Library/Containers/com.microsoft.Powerpoint/Data/documents/wef`
+    - For Word:  `/Users/<username>/Library/Containers/com.microsoft.Word/Data/Documents/wef`    
+    - For Excel:  `/Users/<username>/Library/Containers/com.microsoft.Excel/Data/Documents/wef`
+    - For PowerPoint: `/Users/<username>/Library/Containers/com.microsoft.Powerpoint/Data/Documents/wef`
     
 2. Open the folder in  **Finder** using the command `open .` (including the period or dot). Copy your add-in's manifest file to this folder.
     


### PR DESCRIPTION
Hi!

The instructions to sideload an add-in in Office on Mac tells user to go to the "documents" folder, but Office needs a (capital-letter) "Documents" folder.