### PR TITLE
Change OK to Add to reflect UI

### DIFF
--- a/docs/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins.md
+++ b/docs/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins.md
@@ -77,7 +77,7 @@ The following video walks you through the process of sideloading your add-in in 
 
 3. Choose **SHARED FOLDER** at the top of the **Office Add-ins** dialog box.
 
-4. Select the name of the add-in and choose **OK** to insert the add-in.
+4. Select the name of the add-in and choose **Add** to insert the add-in.
 
 ## See also
 


### PR DESCRIPTION
Hello again,
In the steps to sideload an Office add-in on Windows, the steps say to click "OK", while the UI shows "Add".

I'm using Office 365 ProPlus, version 1906, and performed the sideloading process in Excel.
If this UI element is not universal across the versions, and you'd like to keep it, feel free to close the PR.