### PR TITLE
[typo] Fixing Excel page title casing

### DIFF
--- a/docs/excel/excel-add-ins-charts.md
+++ b/docs/excel/excel-add-ins-charts.md
@@ -1,7 +1,7 @@
 ---
 title: Work with charts using the Excel JavaScript API
 description: ''
-ms.date: 03/19/2019
+ms.date: 07/17/2019
 localization_priority: Priority
 ---
 

--- a/docs/excel/excel-add-ins-charts.md
+++ b/docs/excel/excel-add-ins-charts.md
@@ -1,11 +1,11 @@
 ---
-title: Work with Charts using the Excel JavaScript API
+title: Work with charts using the Excel JavaScript API
 description: ''
 ms.date: 03/19/2019
 localization_priority: Priority
 ---
 
-# Work with Charts using the Excel JavaScript API
+# Work with charts using the Excel JavaScript API
 
 This article provides code samples that show how to perform common tasks with charts using the Excel JavaScript API.
 For the complete list of properties and methods that the **Chart** and **ChartCollection** objects support, see [Chart Object (JavaScript API for Excel)](/javascript/api/excel/excel.chart) and [Chart Collection Object (JavaScript API for Excel)](/javascript/api/excel/excel.chartcollection).

--- a/docs/excel/excel-add-ins-shapes.md
+++ b/docs/excel/excel-add-ins-shapes.md
@@ -7,7 +7,7 @@ localization_priority: Normal
 
 # Work with shapes using the Excel JavaScript API
 
-Excel defines shapes as any object that sits on the drawing layer of Excel. That means anything outside of a cell is a shape. This article describes how to use geometric shapes, lines, and images in conjunction with the [Shape](/javascript/api/excel/excel.shape) and [ShapeCollection](/javascript/api/excel/excel.shapecollection) APIs. [Charts](/javascript/api/excel/excel.chart) are covered in their own article, [Work with charts using the Excel JavaScript API](excel-add-ins-charts.md)).
+Excel defines shapes as any object that sits on the drawing layer of Excel. That means anything outside of a cell is a shape. This article describes how to use geometric shapes, lines, and images in conjunction with the [Shape](/javascript/api/excel/excel.shape) and [ShapeCollection](/javascript/api/excel/excel.shapecollection) APIs. [Charts](/javascript/api/excel/excel.chart) are covered in their own article, [Work with charts using the Excel JavaScript API](excel-add-ins-charts.md).
 
 ## Create shapes
 

--- a/docs/excel/excel-add-ins-shapes.md
+++ b/docs/excel/excel-add-ins-shapes.md
@@ -1,13 +1,13 @@
 ---
-title: Work with Shapes using the Excel JavaScript API
+title: Work with shapes using the Excel JavaScript API
 description: ''
 ms.date: 04/30/2019
 localization_priority: Normal
 ---
 
-# Work with Shapes using the Excel JavaScript API
+# Work with shapes using the Excel JavaScript API
 
-Excel defines shapes as any object that sits on the drawing layer of Excel. That means anything outside of a cell is a shape. This article describes how to use geometric shapes, lines, and images in conjunction with the [Shape]/javascript/api/excel/excel.shape) and [ShapeCollection](/javascript/api/excel/excel.shapecollection) APIs. [Charts](/javascript/api/excel/excel.chart) are covered in their own article, [Work with Charts using the Excel JavaScript API]](excel-add-ins-charts.md)).
+Excel defines shapes as any object that sits on the drawing layer of Excel. That means anything outside of a cell is a shape. This article describes how to use geometric shapes, lines, and images in conjunction with the [Shape]/javascript/api/excel/excel.shape) and [ShapeCollection](/javascript/api/excel/excel.shapecollection) APIs. [Charts](/javascript/api/excel/excel.chart) are covered in their own article, [Work with charts using the Excel JavaScript API]](excel-add-ins-charts.md)).
 
 ## Create shapes
 
@@ -247,4 +247,4 @@ Excel.run(function (context) {
 ## See also
 
 - [Fundamental programming concepts with the Excel JavaScript API](../reference/overview/excel-add-ins-reference-overview.md)
-- [Work with Charts using the Excel JavaScript API](excel-add-ins-charts.md)
+- [Work with charts using the Excel JavaScript API](excel-add-ins-charts.md)

--- a/docs/excel/excel-add-ins-shapes.md
+++ b/docs/excel/excel-add-ins-shapes.md
@@ -1,7 +1,7 @@
 ---
 title: Work with shapes using the Excel JavaScript API
 description: ''
-ms.date: 04/30/2019
+ms.date: 07/19/2019
 localization_priority: Normal
 ---
 

--- a/docs/excel/excel-add-ins-shapes.md
+++ b/docs/excel/excel-add-ins-shapes.md
@@ -7,7 +7,7 @@ localization_priority: Normal
 
 # Work with shapes using the Excel JavaScript API
 
-Excel defines shapes as any object that sits on the drawing layer of Excel. That means anything outside of a cell is a shape. This article describes how to use geometric shapes, lines, and images in conjunction with the [Shape]/javascript/api/excel/excel.shape) and [ShapeCollection](/javascript/api/excel/excel.shapecollection) APIs. [Charts](/javascript/api/excel/excel.chart) are covered in their own article, [Work with charts using the Excel JavaScript API]](excel-add-ins-charts.md)).
+Excel defines shapes as any object that sits on the drawing layer of Excel. That means anything outside of a cell is a shape. This article describes how to use geometric shapes, lines, and images in conjunction with the [Shape](/javascript/api/excel/excel.shape) and [ShapeCollection](/javascript/api/excel/excel.shapecollection) APIs. [Charts](/javascript/api/excel/excel.chart) are covered in their own article, [Work with charts using the Excel JavaScript API](excel-add-ins-charts.md)).
 
 ## Create shapes
 


### PR DESCRIPTION
Making the [Chart](https://docs.microsoft.com/en-us/office/dev/add-ins/excel/excel-add-ins-charts?view=office-js) and [Shape](https://docs.microsoft.com/en-us/office/dev/add-ins/excel/excel-add-ins-shapes?view=office-js) article titles match the casing of the [Table](https://docs.microsoft.com/en-us/office/dev/add-ins/excel/excel-add-ins-tables?view=office-js) and [Worksheet](https://docs.microsoft.com/en-us/office/dev/add-ins/excel/excel-add-ins-worksheets?view=office-js) articles.