### PR TITLE
[Admin] Fix typos.

### DIFF
--- a/docs/overview/explore-with-script-lab.md
+++ b/docs/overview/explore-with-script-lab.md
@@ -8,7 +8,7 @@ localization_priority: Normal
 
 # Explore Office JavaScript API using Script Lab
 
-The [Script Lab add-in](https://store.office.com/app.aspx?assetid=WA104380862), which is available free from the Office store, enables you to explore the Office JavaScript API while you're working in an Office program such as Excel or Word. Script Lab is a convenient tool to add to your development toolkit as you prototype and verify functionality you want in your add-in.
+The [Script Lab add-in](https://appsource.microsoft.com/en-us/product/office/WA104380862), which is available free from AppSource, enables you to explore the Office JavaScript API while you're working in an Office program such as Excel or Word. Script Lab is a convenient tool to add to your development toolkit as you prototype and verify functionality you want in your add-in.
 
 ## What is Script Lab?
 
@@ -57,7 +57,7 @@ Script Lab is supported for Excel, Word, and PowerPoint on the following clients
 
 ## Next steps
 
-To use Script Lab in Excel, Word, or PowerPoint, install the [Script Lab add-in](https://store.office.com/app.aspx?assetid=WA104380862) from the Office Store. 
+To use Script Lab in Excel, Word, or PowerPoint, install the [Script Lab add-in](https://appsource.microsoft.com/en-us/product/office/WA104380862) from AppSource. 
 
 You're welcome to expand the sample library in Script Lab by contributing new snippets to the [office-js-snippets](https://github.com/OfficeDev/office-js-snippets#office-js-snippets) GitHub repository.
 
@@ -65,6 +65,6 @@ When you're ready to create your first Office Add-in, try out the quick start fo
 
 ## See also
 
-- [Get Script Lab](https://store.office.com/app.aspx?assetid=WA104380862)
+- [Get Script Lab](https://appsource.microsoft.com/en-us/product/office/WA104380862)
 - [Learn more about Script Lab](https://github.com/OfficeDev/script-lab#script-lab-a-microsoft-garage-project)
 - [Sign up for the dev program](https://developer.microsoft.com/office/dev-program)

--- a/docs/overview/schemas/content/OfficeAppBasicTypesV1_0.xsd
+++ b/docs/overview/schemas/content/OfficeAppBasicTypesV1_0.xsd
@@ -374,7 +374,7 @@
 
   <xs:simpleType name="AlternateId">
     <xs:annotation>
-      <xs:documentation>Defines an alternate ID type as defined by the Office Store.</xs:documentation>
+      <xs:documentation>Defines an alternate ID type as defined by AppSource.</xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
       <xs:pattern value=".{5,12}\\WA[0-9]{9}"/>

--- a/docs/overview/schemas/content/OfficeAppManifestV1_1.xsd
+++ b/docs/overview/schemas/content/OfficeAppManifestV1_1.xsd
@@ -232,7 +232,7 @@
 
   <xs:simpleType name="AlternateId">
     <xs:annotation>
-      <xs:documentation>Defines an alternate ID type as defined by the Office Store.</xs:documentation>
+      <xs:documentation>Defines an alternate ID type as defined by AppSource.</xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
       <xs:pattern value=".{5,12}\\WA[0-9]{9}"/>
@@ -840,7 +840,7 @@
       </xs:element>
       <xs:element name="AlternateId" type="AlternateId" minOccurs="0" maxOccurs="1">
         <xs:annotation>
-          <xs:documentation>Specifies the alternate ID for the app as issued by the Office Store.</xs:documentation>
+          <xs:documentation>Specifies the alternate ID for the app as issued by AppSource.</xs:documentation>
         </xs:annotation>
       </xs:element>
       <xs:element name="Version" type="Version" minOccurs="1" maxOccurs="1">

--- a/docs/overview/schemas/mail/OfficeAppBasicTypesV1_0.xsd
+++ b/docs/overview/schemas/mail/OfficeAppBasicTypesV1_0.xsd
@@ -374,7 +374,7 @@
 
   <xs:simpleType name="AlternateId">
     <xs:annotation>
-      <xs:documentation>Defines an alternate ID type as defined by the Office Store.</xs:documentation>
+      <xs:documentation>Defines an alternate ID type as defined by AppSource.</xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
       <xs:pattern value=".{5,12}\\WA[0-9]{9}"/>

--- a/docs/overview/schemas/mail/OfficeAppManifestV1_1.xsd
+++ b/docs/overview/schemas/mail/OfficeAppManifestV1_1.xsd
@@ -232,7 +232,7 @@
 
   <xs:simpleType name="AlternateId">
     <xs:annotation>
-      <xs:documentation>Defines an alternate ID type as defined by the Office Store.</xs:documentation>
+      <xs:documentation>Defines an alternate ID type as defined by AppSource.</xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
       <xs:pattern value=".{5,12}\\WA[0-9]{9}"/>
@@ -840,7 +840,7 @@
       </xs:element>
       <xs:element name="AlternateId" type="AlternateId" minOccurs="0" maxOccurs="1">
         <xs:annotation>
-          <xs:documentation>Specifies the alternate ID for the app as issued by the Office Store.</xs:documentation>
+          <xs:documentation>Specifies the alternate ID for the app as issued by AppSource.</xs:documentation>
         </xs:annotation>
       </xs:element>
       <xs:element name="Version" type="Version" minOccurs="1" maxOccurs="1">

--- a/docs/overview/schemas/taskpane/OfficeAppBasicTypesV1_0.xsd
+++ b/docs/overview/schemas/taskpane/OfficeAppBasicTypesV1_0.xsd
@@ -374,7 +374,7 @@
 
   <xs:simpleType name="AlternateId">
     <xs:annotation>
-      <xs:documentation>Defines an alternate ID type as defined by the Office Store.</xs:documentation>
+      <xs:documentation>Defines an alternate ID type as defined by AppSource.</xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
       <xs:pattern value=".{5,12}\\WA[0-9]{9}"/>

--- a/docs/overview/schemas/taskpane/OfficeAppManifestV1_1.xsd
+++ b/docs/overview/schemas/taskpane/OfficeAppManifestV1_1.xsd
@@ -232,7 +232,7 @@
 
   <xs:simpleType name="AlternateId">
     <xs:annotation>
-      <xs:documentation>Defines an alternate ID type as defined by the Office Store.</xs:documentation>
+      <xs:documentation>Defines an alternate ID type as defined by AppSource.</xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
       <xs:pattern value=".{5,12}\\WA[0-9]{9}"/>
@@ -840,7 +840,7 @@
       </xs:element>
       <xs:element name="AlternateId" type="AlternateId" minOccurs="0" maxOccurs="1">
         <xs:annotation>
-          <xs:documentation>Specifies the alternate ID for the app as issued by the Office Store.</xs:documentation>
+          <xs:documentation>Specifies the alternate ID for the app as issued by AppSource.</xs:documentation>
         </xs:annotation>
       </xs:element>
       <xs:element name="Version" type="Version" minOccurs="1" maxOccurs="1">

--- a/docs/reference/manifest/alternateid.md
+++ b/docs/reference/manifest/alternateid.md
@@ -7,7 +7,7 @@ localization_priority: Normal
 
 # AlternateId element
 
-Specifies the alternate ID for your Office Add-in as issued by the Office Store.
+Specifies the alternate ID for your Office Add-in as issued by AppSource.
 
 **Add-in type:** Content, Task pane, Mail
 
@@ -23,5 +23,5 @@ Specifies the alternate ID for your Office Add-in as issued by the Office Store.
 
 ## Remarks
 
-You don't create this value yourself; it is assigned to your add-in when you submit it to the Office Store.
+You don't create this value yourself; it is assigned to your add-in when you submit it to AppSource.
 

--- a/docs/reference/manifest/iconurl.md
+++ b/docs/reference/manifest/iconurl.md
@@ -29,7 +29,7 @@ Specifies the URL of the image that is used to represent your Office Add-in in t
 
 ## Remarks
 
-For a mail add-in, the icon is displayed in the  **File** > **Manage add-ins** UI (Outlook) or **Settings** > **Manage add-ins** UI (Outlook on the web). For a content or task pane add-in, the icon is displayed in the **Insert** > **Add-ins** UI. For all add-in types, the icon is also used on the Office Store site, if you publish your add-in to the Office Store.
+For a mail add-in, the icon is displayed in the  **File** > **Manage add-ins** UI (Outlook) or **Settings** > **Manage add-ins** UI (Outlook on the web). For a content or task pane add-in, the icon is displayed in the **Insert** > **Add-ins** UI. For all add-in types, the icon is also used in [AppSource](https://appsource.microsoft.com), if you publish your add-in to AppSource.
 
 The image must be in one of the following file formats: GIF, JPG, PNG, EXIF, BMP, or TIFF. For content and task pane apps, the image specified must be 32 x 32 pixels. For mail apps, the recommended image resolution is 64 x 64 pixels. You should also specify an icon for use with Office host applications running on high DPI screens using the [HighResolutionIconUrl](highresolutioniconurl.md) element. For more information, see the section _Create a consistent visual identity for your app_ in [Create effective listings in AppSource and within Office](/office/dev/store/create-effective-office-store-listings#create-a-consistent-visual-identity).
 

--- a/docs/reference/manifest/scopes.md
+++ b/docs/reference/manifest/scopes.md
@@ -7,7 +7,7 @@ localization_priority: Normal
 
 # Scopes element
 
-Contains permissions to Microsoft Graph that the add-in needs. The Office Store uses the Scopes element to create a consent dialog box. When users install the add-in from the Store, they are prompted to grant the add-in the specified permissions to the user's Microsoft Graph data.
+Contains permissions to Microsoft Graph that the add-in needs. AppSource uses the Scopes element to create a consent dialog box. When users install the add-in from the Store, they are prompted to grant the add-in the specified permissions to the user's Microsoft Graph data.
 
 ## Child elements
 


### PR DESCRIPTION
Changes **Office Store** -> **AppSource** throughout the docs. Note that I've intentionally *not* updated `ms.date` in any of these articles, since none of the changes are substantive.