### PR TITLE
[common API] (Requirement Set) Updating requirement set syntax (part 2 of 2)

### DIFF
--- a/docs/develop/specify-office-hosts-and-api-requirements.md
+++ b/docs/develop/specify-office-hosts-and-api-requirements.md
@@ -1,7 +1,7 @@
 ---
 title: Specify Office hosts and API requirements
 description: ''
-ms.date: 07/01/2019
+ms.date: 07/18/2019
 localization_priority: Priority
 ---
 
@@ -161,7 +161,7 @@ The **isSetSupported** method and the requirement sets for these hosts are avail
 The following code example shows how an add-in can provide different functionality for different Office hosts that might support different requirement sets or API members.
 
 ```js
-if (Office.context.requirements.isSetSupported('WordApi', 1.1))
+if (Office.context.requirements.isSetSupported('WordApi', '1.1'))
 {
     // Run code that provides additional functionality using the Word JavaScript API when the add-in runs in Word 2016 or later.
 }

--- a/docs/excel/excel-add-ins-advanced-concepts.md
+++ b/docs/excel/excel-add-ins-advanced-concepts.md
@@ -1,7 +1,7 @@
 ---
 title: Advanced programming concepts with the Excel JavaScript API
 description: ''
-ms.date: 06/20/2019
+ms.date: 07/17/2019
 localization_priority: Priority
 ---
 

--- a/docs/excel/excel-add-ins-tables.md
+++ b/docs/excel/excel-add-ins-tables.md
@@ -1,7 +1,7 @@
 ---
 title: Work with tables using the Excel JavaScript API
 description: ''
-ms.date: 04/30/2019
+ms.date: 07/18/2019
 localization_priority: Priority
 ---
 
@@ -71,7 +71,7 @@ Excel.run(function (context) {
         ["1/31/2017", "BEST FOR YOU ORGANICS COMPANY", "Groceries", "$97"]
     ]);
 
-    if (Office.context.requirements.isSetSupported("ExcelApi", 1.2)) {
+    if (Office.context.requirements.isSetSupported("ExcelApi", "1.2")) {
         sheet.getUsedRange().format.autofitColumns();
         sheet.getUsedRange().format.autofitRows();
     }
@@ -111,7 +111,7 @@ Excel.run(function (context) {
         ["Monday"]
     ]);
 
-    if (Office.context.requirements.isSetSupported("ExcelApi", 1.2)) {
+    if (Office.context.requirements.isSetSupported("ExcelApi", "1.2")) {
         sheet.getUsedRange().format.autofitColumns();
         sheet.getUsedRange().format.autofitRows();
     }
@@ -144,7 +144,7 @@ Excel.run(function (context) {
         ['=IF(OR((TEXT([DATE], "dddd") = "Saturday"), (TEXT([DATE], "dddd") = "Sunday")), "Weekend", "Weekday")']
     ]);
 
-    if (Office.context.requirements.isSetSupported("ExcelApi", 1.2)) {
+    if (Office.context.requirements.isSetSupported("ExcelApi", "1.2")) {
         sheet.getUsedRange().format.autofitColumns();
         sheet.getUsedRange().format.autofitRows();
     }
@@ -172,7 +172,7 @@ Excel.run(function (context) {
         .then(function () {
             expensesTable.columns.items[0].name = "Purchase date";
 
-            if (Office.context.requirements.isSetSupported("ExcelApi", 1.2)) {
+            if (Office.context.requirements.isSetSupported("ExcelApi", "1.2")) {
                 sheet.getUsedRange().format.autofitColumns();
                 sheet.getUsedRange().format.autofitRows();
             }
@@ -419,7 +419,7 @@ Excel.run(function (context) {
     var range = sheet.getRange("A1:E7");
     range.values = values;
 
-    if (Office.context.requirements.isSetSupported("ExcelApi", 1.2)) {
+    if (Office.context.requirements.isSetSupported("ExcelApi", "1.2")) {
         sheet.getUsedRange().format.autofitColumns();
         sheet.getUsedRange().format.autofitRows();
     }
@@ -474,7 +474,7 @@ Excel.run(function (context) {
 
     expensesTable.rows.add(null, newData);
 
-    if (Office.context.requirements.isSetSupported("ExcelApi", 1.2)) {
+    if (Office.context.requirements.isSetSupported("ExcelApi", "1.2")) {
         sheet.getUsedRange().format.autofitColumns();
         sheet.getUsedRange().format.autofitRows();
     }

--- a/docs/reference/requirement-sets/onenote-api-requirement-sets.md
+++ b/docs/reference/requirement-sets/onenote-api-requirement-sets.md
@@ -1,7 +1,7 @@
 ---
 title: OneNote JavaScript API requirement sets
 description: ''
-ms.date: 06/20/2019
+ms.date: 07/17/2019
 ms.prod: onenote
 localization_priority: Normal
 ---

--- a/docs/reference/requirement-sets/outlook-api-requirement-sets.md
+++ b/docs/reference/requirement-sets/outlook-api-requirement-sets.md
@@ -1,7 +1,7 @@
 ---
 title: Outlook JavaScript API requirement sets
 description: ''
-ms.date: 06/20/2019
+ms.date: 07/17/2019
 ms.prod: outlook
 localization_priority: Priority
 ---

--- a/docs/tutorials/excel-tutorial.md
+++ b/docs/tutorials/excel-tutorial.md
@@ -1,7 +1,7 @@
 ---
 title: Excel add-in tutorial
 description: In this tutorial, you'll build an Excel add-in that creates, populates, filters, and sorts a table, creates a chart, freezes a table header, protects a worksheet, and opens a dialog.
-ms.date: 06/20/2019
+ms.date: 07/17/2019
 ms.prod: excel
 ms.topic: tutorial
 #Customer intent: As a developer, I want to build a Excel add-in that can interact with content in a Excel document.

--- a/docs/tutorials/word-tutorial.md
+++ b/docs/tutorials/word-tutorial.md
@@ -1,7 +1,7 @@
 ---
 title: Word add-in tutorial
 description: In this tutorial, you'll build a Word add-in that inserts (and replaces) text ranges, paragraphs, images, HTML, tables, and content controls. You'll also learn how to format text and how to insert (and replace) content in content controls.
-ms.date: 06/20/2019
+ms.date: 07/17/2019
 ms.prod: word
 ms.topic: tutorial
 #Customer intent: As a developer, I want to build a Word add-in that can interact with content in a Word document.


### PR DESCRIPTION
This PR updates `ms.date` for articles that were updated in #1187 and also makes the requirement set number parameter in the `isSetSupported` call a string (by adding quotation marks around the parameter value) in a few more places.