### PR TITLE
[excel] (Requirement Sets) Removing support for Image Coercion for Excel on the Web

### DIFF
--- a/docs/overview/office-add-in-availability.md
+++ b/docs/overview/office-add-in-availability.md
@@ -1,7 +1,7 @@
 ---
 title: Office Add-in host and platform availability
 description: Supported requirement sets for Excel, OneNote, Outlook, PowerPoint, Project, and Word.
-ms.date: 07/26/2019
+ms.date: 08/13/2019
 localization_priority: Priority
 ---
 
@@ -38,9 +38,7 @@ To work as expected, your Office Add-in might depend on a specific Office host, 
         - <a href="/office/dev/add-ins/reference/requirement-sets/excel-api-1-7-requirement-set">ExcelApi 1.7</a><br>
         - <a href="/office/dev/add-ins/reference/requirement-sets/excel-api-1-8-requirement-set">ExcelApi 1.8</a><br>
         - <a href="/office/dev/add-ins/reference/requirement-sets/excel-api-1-9-requirement-set">ExcelApi 1.9</a><br>
-        - <a href="/office/dev/add-ins/reference/requirement-sets/dialog-api-requirement-sets">DialogApi 1.1</a><br>
-        - <a href="/office/dev/add-ins/reference/requirement-sets/image-coercion-requirement-sets#imagecoercion-11">ImageCoercion 1.1</a><br>
-        - <a href="/office/dev/add-ins/reference/requirement-sets/image-coercion-requirement-sets#imagecoercion-12">ImageCoercion 1.2</a></td>
+        - <a href="/office/dev/add-ins/reference/requirement-sets/dialog-api-requirement-sets">DialogApi 1.1</a></td>
     <td>
         - BindingEvents<br>
         - CompressedFile<br>

--- a/docs/reference/requirement-sets/image-coercion-requirement-sets.md
+++ b/docs/reference/requirement-sets/image-coercion-requirement-sets.md
@@ -10,8 +10,6 @@ localization_priority: Normal
 
 Requirement sets are named groups of API members. Office Add-ins use requirement sets specified in the manifest or use a runtime check to determine whether an Office host supports APIs that an add-in needs. For more information, see [Office versions and requirement sets](/office/dev/add-ins/develop/office-versions-and-requirement-sets).
 
-Office Add-ins run across multiple versions of Office. The following table lists the Image Coercion requirement sets, the Office host applications that support that requirement set, and the build or version numbers for the Office application.
-
 ## ImageCoercion 1.1
 
 ImageCoercion 1.1 enables conversion to an image (`Office.CoercionType.Image`) when writing data using the [`Document.setSelectedDataAsync`](/javascript/api/office/office.document#setselecteddataasync-data--options--callback-) method. The following hosts are supported:

--- a/docs/reference/requirement-sets/image-coercion-requirement-sets.md
+++ b/docs/reference/requirement-sets/image-coercion-requirement-sets.md
@@ -1,7 +1,7 @@
 ---
 title: Image Coercion requirement sets
 description: Support for Image Coercion requirement sets with Office Add-ins across Excel, PowerPoint, and Word.
-ms.date: 07/11/2019
+ms.date: 08/13/2019
 ms.prod: non-product-specific
 localization_priority: Normal
 ---
@@ -18,7 +18,6 @@ ImageCoercion 1.1 enables conversion to an image (`Office.CoercionType.Image`) w
 
 - Excel 2013 and later on Windows
 - Excel 2016 and later on Mac
-- Excel on the web
 - Excel on iPad
 - OneNote on the web
 - PowerPoint 2013 and later on Windows
@@ -36,7 +35,6 @@ ImageCoercion 1.2 enables conversion to SVG format (`Office.CoercionType.XmlSvg`
 
 - Excel on Windows (connected to an Office 365 subscription)
 - Excel on Mac (connected to an Office 365 subscription)
-- Excel on the web
 - PowerPoint on Windows (connected to an Office 365 subscription)
 - PowerPoint on Mac (connected to an Office 365 subscription)
 - PowerPoint on the web


### PR DESCRIPTION
[Internal tracking issue](https://office.visualstudio.com/OC/_workitems/edit/3537516)

Excel on the Web does not support Image Coercion. This change removes those claims.