### PR TITLE
[Common API] (Requirement Sets) Increased urgency around using strings in isSetSupported

### DIFF
--- a/docs/develop/convert-javascript-to-typescript.md
+++ b/docs/develop/convert-javascript-to-typescript.md
@@ -1,7 +1,7 @@
 ---
 title: Convert an Office Add-in project in Visual Studio to TypeScript
 description: ''
-ms.date: 07/17/2019
+ms.date: 08/14/2019
 localization_priority: Priority
 ---
 
@@ -88,13 +88,7 @@ You can use the Office Add-in template in Visual Studio to create an add-in that
         ...
     ```
 
-13. In the **Home.ts** file, change **'1.1'** to **1.1** (that is, remove the quotation marks) in the following line:
-
-	```typescript
-	if (!Office.context.requirements.isSetSupported('ExcelApi', '1.1')) {
-	```
-
-14. In the **Home.ts** file, find the `displaySelectedCells` function, replace the entire function with the following code, and save the file:
+13. In the **Home.ts** file, find the `displaySelectedCells` function, replace the entire function with the following code, and save the file:
 
     ```typescript
     function displaySelectedCells() {
@@ -160,7 +154,7 @@ declare var fabric: any;
             loadSampleData();
 
             // Add a click event handler for the highlight button.
-            $('#highlight-button').click(hightlightHighestValue);
+            $('#highlight-button').click(highlightHighestValue);
         });
     };
 
@@ -184,7 +178,7 @@ declare var fabric: any;
         .catch(errorHandler);
     }
 
-    function hightlightHighestValue() {
+    function highlightHighestValue() {
         // Run a batch operation against the Excel object model
         Excel.run(function (ctx) {
             // Create a proxy object for the selected range and load its properties

--- a/docs/develop/specify-office-hosts-and-api-requirements.md
+++ b/docs/develop/specify-office-hosts-and-api-requirements.md
@@ -140,7 +140,7 @@ if (Office.context.requirements.isSetSupported(RequirementSetName, MinimumVersio
 
 ```
 
-- _RequirementSetName_ (required) is a string that represents the name of the requirement set (e.g., "**ExcelApi**", "**Mailbox**, etc.). For more information about available requirement sets, see [Office Add-in requirement sets](/office/dev/add-ins/reference/requirement-sets/office-add-in-requirement-sets).
+- _RequirementSetName_ (required) is a string that represents the name of the requirement set (e.g., "**ExcelApi**", "**Mailbox**", etc.). For more information about available requirement sets, see [Office Add-in requirement sets](/office/dev/add-ins/reference/requirement-sets/office-add-in-requirement-sets).
 - _MinimumVersion_ (optional) is a string that specifies the minimum requirement set version that the host must support in order for the code within the `if` statement to run (e.g., "**1.9**").
 
 > [!WARNING]

--- a/docs/develop/specify-office-hosts-and-api-requirements.md
+++ b/docs/develop/specify-office-hosts-and-api-requirements.md
@@ -1,7 +1,7 @@
 ---
 title: Specify Office hosts and API requirements
 description: ''
-ms.date: 07/18/2019
+ms.date: 08/14/2019
 localization_priority: Priority
 ---
 
@@ -128,24 +128,24 @@ The following code example shows an add-in that loads in all Office host applica
 
 - The  **Method** element specifies an individual method that must be supported in the Office host where your add-in runs. The **Name** attribute is required and specifies the name of the method qualified with its parent object.
 
-
 ## Use runtime checks in your JavaScript code
-
 
 You might want to provide additional functionality in your add-in if certain requirement sets are supported by the Office host. For example, you might want to use the Word JavaScript APIs in your existing add-in if your add-in runs in Word 2016. To do this, you use the [isSetSupported](/javascript/api/office/office.requirementsetsupport#issetsupported-name--minversion-) method with the name of the requirement set. **isSetSupported** determines, at runtime, whether the Office host running the add-in supports the requirement set. If the requirement set is supported, **isSetSupported** returns **true** and runs the additional code that uses the API members from that requirement set. If the Office host doesn't support the requirement set, **isSetSupported** returns **false** and the additional code won't run. The following code shows the syntax to use with **isSetSupported**.
 
-
 ```js
-if (Office.context.requirements.isSetSupported(RequirementSetName, VersionNumber))
+if (Office.context.requirements.isSetSupported(RequirementSetName, MinimumVersion))
 {
    // Code that uses API members from RequirementSetName.
 }
 
 ```
 
--  _RequirementSetName_ (required) is a string that represents the name of the requirement set. For more information about available requirement sets, see [Office Add-in requirement sets](/office/dev/add-ins/reference/requirement-sets/office-add-in-requirement-sets).
-    
--  _VersionNumber_ (optional) is the version of the requirement set.
+- _RequirementSetName_ (required) is a string that represents the name of the requirement set. For more information about available requirement sets, see [Office Add-in requirement sets](/office/dev/add-ins/reference/requirement-sets/office-add-in-requirement-sets).
+- _MinimumVersion_ (optional) is the version of the requirement set.
+
+> [!WARNING]
+> Your add-in should always use a string when specifying the requirement set version for **isSetSupported**. If you use a number, the JavaScript parser cannot tell the difference between 1.1 and 1.10.
+> The `number` overload is deprecated.
 
 Use **isSetSupported** with the **RequirementSetName** associated with the Office host as follows.
 
@@ -175,7 +175,6 @@ else
 }
 
 ```
-
 
 ## Runtime checks using methods not in a requirement set
 

--- a/docs/develop/specify-office-hosts-and-api-requirements.md
+++ b/docs/develop/specify-office-hosts-and-api-requirements.md
@@ -140,11 +140,11 @@ if (Office.context.requirements.isSetSupported(RequirementSetName, MinimumVersio
 
 ```
 
-- _RequirementSetName_ (required) is a string that represents the name of the requirement set. For more information about available requirement sets, see [Office Add-in requirement sets](/office/dev/add-ins/reference/requirement-sets/office-add-in-requirement-sets).
-- _MinimumVersion_ (optional) is the version of the requirement set.
+- _RequirementSetName_ (required) is a string that represents the name of the requirement set (e.g., "**ExcelApi**", "**Mailbox**, etc.). For more information about available requirement sets, see [Office Add-in requirement sets](/office/dev/add-ins/reference/requirement-sets/office-add-in-requirement-sets).
+- _MinimumVersion_ (optional) is a string that specifies the minimum requirement set version that the host must support in order for the code within the `if` statement to run (e.g., "**1.9**").
 
 > [!WARNING]
-> Your add-in should always use a string when specifying the requirement set version for **isSetSupported**. If you use a number, the JavaScript parser cannot tell the difference between 1.1 and 1.10.
+> When calling the **isSetSupported** method, the value of the `MinimumVersion` parameter (if specified) should be a string. This is because the JavaScript parser cannot differentiate between numeric values such as 1.1 and 1.10, where as it can for string values such as "1.1" and "1.10".
 > The `number` overload is deprecated.
 
 Use **isSetSupported** with the **RequirementSetName** associated with the Office host as follows.

--- a/docs/excel/excel-add-ins-advanced-concepts.md
+++ b/docs/excel/excel-add-ins-advanced-concepts.md
@@ -32,7 +32,7 @@ Requirement sets are named groups of API members. An Office Add-in can perform a
 The following code sample shows how to determine whether the host application where the add-in is running supports the specified API requirement set.
 
 ```js
-if (Office.context.requirements.isSetSupported('ExcelApi', '1.3') === true) {
+if (Office.context.requirements.isSetSupported('ExcelApi', '1.3')) {
   /// perform actions
 }
 else {

--- a/docs/reference/requirement-sets/outlook-api-requirement-sets.md
+++ b/docs/reference/requirement-sets/outlook-api-requirement-sets.md
@@ -1,7 +1,7 @@
 ---
 title: Outlook JavaScript API requirement sets
 description: ''
-ms.date: 08/13/2019
+ms.date: 08/14/2019
 ms.prod: outlook
 localization_priority: Priority
 ---
@@ -31,7 +31,7 @@ Setting a minimum requirement set version in the manifest controls which Outlook
 
 ## Using APIs from later requirement sets
 
-Setting a requirement set does not limit the available APIs that the add-in can use. For example, if the add-in specifies requirement set 1.1, but it is running in an Outlook client which supports 1.3, the add-in can use APIs from requirement set 1.3.
+Setting a requirement set does not limit the available APIs that the add-in can use. For example, if the add-in specifies requirement set "Mailbox 1.1", but it is running in an Outlook client which supports "Mailbox 1.3", the add-in can use APIs from requirement set "Mailbox 1.3".
 
 To use a newer API, developers can check if a particular host supports the requirement set by doing the following.
 


### PR DESCRIPTION
This is a follow-up to @sumurthy's PR (https://github.com/OfficeDev/office-js-docs-pr/pull/1174).

I want to make it clear users should use strings instead of numbers for `isSetSupported` and why.

If the text and messaging is good here, I'll update DefinitelyTyped and the ref docs.