### PR TITLE
Point Sideloading URL to the Sideloading Heading

### DIFF
--- a/docs/publish/publish.md
+++ b/docs/publish/publish.md
@@ -11,7 +11,7 @@ You can use one of several methods to deploy your Office Add-in for testing or d
 
 |**Method**|**Use...**|
 |:---------|:------------|
-|[Sideloading](../testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins.md#sideload-your-add-in)|As part of your development process, to test your add-in running on Windows, iPad, Mac, or in a browser.|
+|[Sideloading](../testing/test-debug-office-add-ins.md#sideload-an-office-add-in-for-testing)|As part of your development process, to test your add-in running on Windows, iPad, Mac, or in a browser.|
 |[Centralized Deployment](centralized-deployment.md)|In a cloud or hybrid deployment, to distribute your add-in to users in your organization by using the Office 365 admin center.|
 |[SharePoint catalog](publish-task-pane-and-content-add-ins-to-an-add-in-catalog.md)|In an on-premises environment, to distribute your add-in to users in your organization.|
 |[AppSource](/office/dev/store/submit-to-the-office-store)|To distribute your add-in publicly to users.|

--- a/docs/publish/publish.md
+++ b/docs/publish/publish.md
@@ -11,7 +11,7 @@ You can use one of several methods to deploy your Office Add-in for testing or d
 
 |**Method**|**Use...**|
 |:---------|:------------|
-|[Sideloading](../testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins.md)|As part of your development process, to test your add-in running on Windows, iPad, Mac, or in a browser.|
+|[Sideloading](../testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins.md#sideload-your-add-in)|As part of your development process, to test your add-in running on Windows, iPad, Mac, or in a browser.|
 |[Centralized Deployment](centralized-deployment.md)|In a cloud or hybrid deployment, to distribute your add-in to users in your organization by using the Office 365 admin center.|
 |[SharePoint catalog](publish-task-pane-and-content-add-ins-to-an-add-in-catalog.md)|In an on-premises environment, to distribute your add-in to users in your organization.|
 |[AppSource](/office/dev/store/submit-to-the-office-store)|To distribute your add-in publicly to users.|


### PR DESCRIPTION
Point Sideloading URL to the Sideloading Heading. When clicking the sideloading method it feels like it's going to the wrong page. 

#1281 
https://github.com/OfficeDev/office-js-docs-pr/issues/1281

I'm not familiar to how you are modifying the URLs on your end, mainly the suffix/extension `.md`, but the change that works for me externally: https://docs.microsoft.com/en-us/office/dev/add-ins/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins.md#sideload-your-add-in