### PR TITLE
[Add-ins] (Yo Office) Remove note about spaces not being permitted in project name or folder path.

### DIFF
--- a/docs/design/using-office-ui-fabric-react.md
+++ b/docs/design/using-office-ui-fabric-react.md
@@ -1,7 +1,7 @@
 ---
 title: Use Office UI Fabric React in Office Add-ins
 description: Learn how to use Office UI Fabric React in Office Add-ins.
-ms.date: 07/11/2019
+ms.date: 09/06/2019
 localization_priority: Priority
 ---
 
@@ -24,8 +24,6 @@ You'll use the Yeoman generator for Office Add-ins to create an add-in project t
 
 ### Create the project
 
-[!include[note about Yeoman generator bug](../includes/note-yeoman-generator-bug-201908.md)]
-
 Use the Yeoman generator to create a Word add-in project. Run the following command and then answer the prompts as follows:
 
 ```command&nbsp;line
@@ -34,8 +32,10 @@ yo office
 
 - **Choose a project type:** `Office Add-in Task Pane project using React framework`
 - **Choose a script type:** `TypeScript`
-- **What do you want to name your add-in?** `my-office-add-in`
+- **What do you want to name your add-in?** `My Office Add-in`
 - **Which Office client application would you like to support?** `Word`
+
+![Yeoman generator](../images/yo-office-word-react.png)
 
 After you complete the wizard, the generator creates the project and installs supporting Node components.
 
@@ -44,7 +44,7 @@ After you complete the wizard, the generator creates the project and installs su
 1. Navigate to the root folder of the project.
 
     ```command&nbsp;line
-    cd "my-office-add-in"
+    cd "My Office Add-in"
     ```
 
 2. Complete the following steps to start the local web server and sideload your add-in.

--- a/docs/includes/note-yeoman-generator-bug-201908.md
+++ b/docs/includes/note-yeoman-generator-bug-201908.md
@@ -1,2 +1,0 @@
-> [!IMPORTANT]
-> Spaces are not currently permitted in the add-in project name or anywhere in the folder path where you create your add-in project. If your add-in's project name or folder path contains spaces, the local web server won't start when you run `npm start` or `npm run start:web`. This limitation is temporary and will be eliminated when the underlying [issue](https://github.com/OfficeDev/generator-office/issues/476) is resolved in the Yeoman generator for Office Add-ins.

--- a/docs/quickstarts/excel-custom-functions-quickstart.md
+++ b/docs/quickstarts/excel-custom-functions-quickstart.md
@@ -1,5 +1,5 @@
 ---
-ms.date: 07/10/2019
+ms.date: 09/06/2019
 description: Developing custom functions in Excel quick start guide.
 title: Custom functions quick start
 ms.prod: excel
@@ -23,8 +23,6 @@ With custom functions, developers can now add new functions to Excel by defining
 ## Build your first custom functions project
 
 To start, you'll use the Yeoman generator to create the custom functions project. This will set up your project with the correct folder structure, source files, and dependencies to begin coding your custom functions.
-
-[!include[note about Yeoman generator bug](../includes/note-yeoman-generator-bug-201908.md)]
 
 1. In a folder of your choice, run the following command and then answer the prompts as follows.
 

--- a/docs/quickstarts/excel-quickstart-angular.md
+++ b/docs/quickstarts/excel-quickstart-angular.md
@@ -1,7 +1,7 @@
 ---
 title: Build an Excel task pane add-in using Angular
 description: 
-ms.date: 05/02/2019
+ms.date: 09/06/2019
 ms.prod: excel
 localization_priority: Priority
 ---
@@ -16,8 +16,6 @@ In this article, you'll walk through the process of building an Excel task pane 
 
 ## Create the add-in project
 
-[!include[note about Yeoman generator bug](../includes/note-yeoman-generator-bug-201908.md)]
-
 Use the Yeoman generator to create an Excel add-in project. Run the following command and then answer the prompts as follows:
 
 ```command&nbsp;line
@@ -26,8 +24,10 @@ yo office
 
 - **Choose a project type:** `Office Add-in Task Pane project using Angular framework`
 - **Choose a script type:** `TypeScript`
-- **What do you want to name your add-in?** `my-office-add-in`
+- **What do you want to name your add-in?** `My Office Add-in`
 - **Which Office client application would you like to support?** `Excel`
+
+![Yeoman generator](../images/yo-office-excel-angular-2.png)
 
 After you complete the wizard, the generator creates the project and installs supporting Node components.
 
@@ -45,7 +45,7 @@ The add-in project that you've created with the Yeoman generator contains sample
 1. Navigate to the root folder of the project.
 
     ```command&nbsp;line
-    cd "my-office-add-in"
+    cd "My Office Add-in"
     ```
 
 2. [!include[Start server section](../includes/quickstart-yo-start-server-excel.md)] 

--- a/docs/quickstarts/excel-quickstart-jquery.md
+++ b/docs/quickstarts/excel-quickstart-jquery.md
@@ -1,7 +1,7 @@
 ---
 title: Build your first Excel task pane add-in
 description: Learn how to build a simple Excel task pane add-in by using the Office JS API.
-ms.date: 07/17/2019
+ms.date: 09/06/2019
 ms.prod: excel
 localization_priority: Priority
 ---
@@ -22,8 +22,6 @@ In this article, you'll walk through the process of building an Excel task pane 
 
 ### Create the add-in project
 
-[!include[note about Yeoman generator bug](../includes/note-yeoman-generator-bug-201908.md)]
-
 Use the Yeoman generator to create an Excel add-in project. Run the following command and then answer the prompts as follows:
 
 ```command&nbsp;line
@@ -32,8 +30,10 @@ yo office
 
 - **Choose a project type:** `Office Add-in Task Pane project`
 - **Choose a script type:** `Javascript`
-- **What do you want to name your add-in?** `my-office-add-in`
+- **What do you want to name your add-in?** `My Office Add-in`
 - **Which Office client application would you like to support?** `Excel`
+
+![Yeoman generator](../images/yo-office-excel.png)
 
 After you complete the wizard, the generator creates the project and installs supporting Node components.
 
@@ -46,7 +46,7 @@ After you complete the wizard, the generator creates the project and installs su
 1. Navigate to the root folder of the project.
 
     ```command&nbsp;line
-    cd "my-office-add-in"
+    cd "My Office Add-in"
     ```
 
 2. [!include[Start server section](../includes/quickstart-yo-start-server-excel.md)] 

--- a/docs/quickstarts/excel-quickstart-react.md
+++ b/docs/quickstarts/excel-quickstart-react.md
@@ -1,7 +1,7 @@
 ---
 title: Build an Excel task pane add-in using React
 description: 
-ms.date: 05/02/2019
+ms.date: 09/06/2019
 ms.prod: excel
 localization_priority: Priority
 ---
@@ -16,8 +16,6 @@ In this article, you'll walk through the process of building an Excel task pane 
 
 ## Create the add-in project
 
-[!include[note about Yeoman generator bug](../includes/note-yeoman-generator-bug-201908.md)]
-
 Use the Yeoman generator to create an Excel add-in project. Run the following command and then answer the prompts as follows:
 
 ```command&nbsp;line
@@ -26,8 +24,10 @@ yo office
 
 - **Choose a project type:** `Office Add-in Task Pane project using React framework`
 - **Choose a script type:** `TypeScript`
-- **What do you want to name your add-in?** `my-office-add-in`
+- **What do you want to name your add-in?** `My Office Add-in`
 - **Which Office client application would you like to support?** `Excel`
+
+![Yeoman generator](../images/yo-office-excel-react-2.png)
 
 After you complete the wizard, the generator creates the project and installs supporting Node components.
 
@@ -45,7 +45,7 @@ The add-in project that you've created with the Yeoman generator contains sample
 1. Navigate to the root folder of the project.
 
     ```command&nbsp;line
-    cd "my-office-add-in"
+    cd "My Office Add-in"
     ```
 
 2. [!include[Start server section](../includes/quickstart-yo-start-server-excel.md)] 

--- a/docs/quickstarts/onenote-quickstart.md
+++ b/docs/quickstarts/onenote-quickstart.md
@@ -1,7 +1,7 @@
 ---
 title: Build your first OneNote task pane add-in
 description: 
-ms.date: 06/20/2019
+ms.date: 09/06/2019
 ms.prod: onenote
 localization_priority: Priority
 ---
@@ -16,8 +16,6 @@ In this article, you'll walk through the process of building a OneNote task pane
 
 ## Create the add-in project
 
-[!include[note about Yeoman generator bug](../includes/note-yeoman-generator-bug-201908.md)]
-
 Use the Yeoman generator to create a OneNote add-in project. Run the following command and then answer the prompts as follows:
 
 ```command&nbsp;line
@@ -26,8 +24,10 @@ yo office
 
 - **Choose a project type:** `Office Add-in Task Pane project`
 - **Choose a script type:** `Javascript`
-- **What do you want to name your add-in?** `my-office-add-in`
+- **What do you want to name your add-in?** `My Office Add-in`
 - **Which Office client application would you like to support?** `OneNote`
+
+![A screenshot of the prompts and answers for the Yeoman generator](../images/yo-office-onenote.png)
 
 After you complete the wizard, the generator creates the project and installs supporting Node components.
 	
@@ -71,7 +71,7 @@ try {
 1. Navigate to the root folder of the project.
 
     ```command&nbsp;line
-    cd "my-office-add-in"
+    cd "My Office Add-in"
     ```
 
 2. Start the local web server and sideload your add-in.

--- a/docs/quickstarts/powerpoint-quickstart.md
+++ b/docs/quickstarts/powerpoint-quickstart.md
@@ -1,7 +1,7 @@
 ---
 title: Build your first PowerPoint task pane add-in
 description: Learn how to build a simple PowerPoint task pane add-in by using the Office JS API.
-ms.date: 07/17/2019
+ms.date: 09/06/2019
 ms.prod: powerpoint
 localization_priority: Priority
 ---
@@ -22,8 +22,6 @@ In this article, you'll walk through the process of building a PowerPoint task p
 
 ### Create the add-in project
 
-[!include[note about Yeoman generator bug](../includes/note-yeoman-generator-bug-201908.md)]
-
 Use the Yeoman generator to create a PowerPoint add-in project. Run the following command and then answer the prompts as follows:
 
 ```command&nbsp;line
@@ -32,8 +30,10 @@ yo office
 
 - **Choose a project type:** `Office Add-in Task Pane project`
 - **Choose a script type:** `Javascript`
-- **What do you want to name your add-in?** `my-office-add-in`
+- **What do you want to name your add-in?** `My Office Add-in`
 - **Which Office client application would you like to support?** `PowerPoint`
+
+![A screenshot of the prompts and answers for the Yeoman generator](../images/yo-office-powerpoint.png)
 
 After you complete the wizard, the generator creates the project and installs supporting Node components.
 
@@ -46,7 +46,7 @@ After you complete the wizard, the generator creates the project and installs su
 1. Navigate to the root folder of the project.
 
     ```command&nbsp;line
-    cd "my-office-add-in"
+    cd "My Office Add-in"
     ```
 
 2. Complete the following steps to start the local web server and sideload your add-in.

--- a/docs/quickstarts/project-quickstart.md
+++ b/docs/quickstarts/project-quickstart.md
@@ -1,7 +1,7 @@
 ---
 title: Build your first Project task pane add-in
 description: 
-ms.date: 05/08/2019
+ms.date: 09/06/2019
 ms.prod: project
 localization_priority: Priority
 ---
@@ -18,8 +18,6 @@ In this article, you'll walk through the process of building a Project task pane
 
 ## Create the add-in
 
-[!include[note about Yeoman generator bug](../includes/note-yeoman-generator-bug-201908.md)]
-
 Use the Yeoman generator to create a Project add-in project. Run the following command and then answer the prompts as follows:
 
 ```command&nbsp;line
@@ -28,8 +26,10 @@ yo office
 
 - **Choose a project type:** `Office Add-in Task Pane project`
 - **Choose a script type:** `Javascript`
-- **What do you want to name your add-in?** `my-office-add-in`
+- **What do you want to name your add-in?** `My Office Add-in`
 - **Which Office client application would you like to support?** `Project`
+
+![A screenshot of the prompts and answers for the Yeoman generator](../images/yo-office-project.png)
 
 After you complete the wizard, the generator creates the project and installs supporting Node components.
 
@@ -89,7 +89,7 @@ Office.context.document.getSelectedTaskAsync(
 1. Navigate to the root folder of the project.
 
     ```command&nbsp;line
-    cd "my-office-add-in"
+    cd "My Office Add-in"
     ```
 
 2. Start the local web server.

--- a/docs/quickstarts/word-quickstart.md
+++ b/docs/quickstarts/word-quickstart.md
@@ -1,7 +1,7 @@
 ---
 title: Build your first Word task pane add-in
 description: Learn how to build a simple Word task pane add-in by using the Office JS API.
-ms.date: 07/17/2019
+ms.date: 09/06/2019
 ms.prod: word
 localization_priority: Priority
 ---
@@ -24,8 +24,6 @@ In this article, you'll walk through the process of building a Word task pane ad
 
 ### Create the add-in project
 
-[!include[note about Yeoman generator bug](../includes/note-yeoman-generator-bug-201908.md)]
-
 Use the Yeoman generator to create a Word add-in project. Run the following command and then answer the prompts as follows:
 
 ```command&nbsp;line
@@ -34,8 +32,10 @@ yo office
 
 - **Choose a project type:** `Office Add-in Task Pane project`
 - **Choose a script type:** `Javascript`
-- **What do you want to name your add-in?** `my-office-add-in`
+- **What do you want to name your add-in?** `My Office Add-in`
 - **Which Office client application would you like to support?** `Word`
+
+![A screenshot of the prompts and answers for the Yeoman generator](../images/yo-office-word.png)
 
 After you complete the wizard, the generator creates the project and installs supporting Node components.
 
@@ -48,7 +48,7 @@ After you complete the wizard, the generator creates the project and installs su
 1. Navigate to the root folder of the project.
 
     ```command&nbsp;line
-    cd "my-office-add-in"
+    cd "My Office Add-in"
     ```
 
 2. Complete the following steps to start the local web server and sideload your add-in.

--- a/docs/tutorials/excel-tutorial-create-custom-functions.md
+++ b/docs/tutorials/excel-tutorial-create-custom-functions.md
@@ -1,7 +1,7 @@
 ---
 title: Excel custom functions tutorial
 description: In this tutorial, you’ll create an Excel add-in that contains a custom function that can perform calculations, request web data, or stream web data.
-ms.date: 07/09/2019
+ms.date: 09/06/2019
 ms.prod: excel
 #Customer intent: As an add-in developer, I want to create custom functions in Excel to increase user productivity. 
 localization_priority: Normal
@@ -27,8 +27,6 @@ In this tutorial, you will:
 ## Create a custom functions project
 
  To start, you'll create the code project to build your custom function add-in. The [Yeoman generator for Office Add-ins](https://www.npmjs.com/package/generator-office) will set up your project with some prebuilt custom functions that you can try out. If you have already run the custom functions quick start and generated a project, continue to use that project and skip to [this step](#create-a-custom-function-that-requests-data-from-the-web) instead.
-
-[!include[note about Yeoman generator bug](../includes/note-yeoman-generator-bug-201908.md)]
 
 1. Run the following command and then answer the prompts as follows.
     


### PR DESCRIPTION
This PR reverts changes made in PR #1241 (now that the issue with spaces not being allowed in project names / folder path has been resolved).