### PR TITLE
[Excel](custom functions): Fix to runtime link

### DIFF
--- a/docs/excel/custom-functions-overview.md
+++ b/docs/excel/custom-functions-overview.md
@@ -66,7 +66,7 @@ function add(first, second){
 Note that the **functions.html** file, which governs the loading of the custom functions runtime, must link to the current CDN for custom functions. Projects prepared with the current version of the Yo Office generator reference the correct CDN. If you are retrofitting a previous custom function project from March 2019 or earlier, you need to copy in the code below to the **functions.html** page.
 
 ```HTML
-<script src="https://appsforoffice.microsoft.com/lib/beta/hosted/custom-functions-runtime.js" type="text/javascript"></script>
+<script src="https://appsforoffice.microsoft.com/lib/1.1/hosted/custom-functions-runtime.js" type="text/javascript"></script>
 ```
 
 ### Manifest file


### PR DESCRIPTION
Just a quick fix to which link is the custom function runtime link.