### PR TITLE
Update office.js CDN URL to all lowercase letters

### DIFF
--- a/docs/develop/referencing-the-javascript-api-for-office-library-from-its-cdn.md
+++ b/docs/develop/referencing-the-javascript-api-for-office-library-from-its-cdn.md
@@ -21,7 +21,7 @@ The [JavaScript API for Office](/office/dev/add-ins/reference/javascript-api-for
 The simplest way to reference the API is to use our CDN by adding the following `<script>` to your page's `<head>` tag:  
 
 ```html
-<script src="https://appsforoffice.microsoft.com/lib/1/hosted/Office.js" type="text/javascript"></script>
+<script src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js" type="text/javascript"></script>
 ```
 
 The  `/1/` in front of `office.js` in the CDN URL specifies the latest incremental release within version 1 of Office.js. Because the JavaScript API for Office maintains backward compatibility, the latest release will continue to support API members that were introduced earlier in version 1. If you need to upgrade an existing project, see [Update the version of your JavaScript API for Office and manifest schema files](update-your-javascript-api-for-office-and-manifest-schema-version.md). 


### PR DESCRIPTION
The CDN URL for office.js should be changed to all lowercase letters, because many of our tools and samples are referencing it that way. Furthermore, we are now prefetching the office.js using the lowercase URL in Office Online. Using uppercase O in the URL causes us to be unable to share the browser cache as the URLs are different.