### PR TITLE
Changed info regarding LearnMoreUrl element

### DIFF
--- a/docs/reference/manifest/getstarted.md
+++ b/docs/reference/manifest/getstarted.md
@@ -15,7 +15,7 @@ Provides information used by the callout that appears when the add-in is install
 |:------------------------------|:--------:|:---------------------------------------------------|
 | [Title](#title)               | Yes      | Defines where an add-in exposes functionality.     |
 | [Description](#description)   | Yes      | A URL to a file that contains JavaScript functions.|
-| [LearnMoreUrl](#learnmoreurl) | No       | A URL to a page that explains the add-in in detail.   |
+| [LearnMoreUrl](#learnmoreurl) | Yes       | A URL to a page that explains the add-in in detail.   |
 
 ### Title 
 


### PR DESCRIPTION
LearnMoreUrl is required in GetStarted element, when user doesn't provide it, the add-in will not successfully sideload into Excel, and also 'npm run validate' will return XML Schema Violation:
![image](https://user-images.githubusercontent.com/25266191/66319559-997de980-e91d-11e9-9403-48946bff46fa.png)
