### PR TITLE
Metadata update for getting started docs

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -80,9 +80,9 @@
         "reference/openspec/*.md": "reference",
         "reference/requirement-sets/*.md": "reference"
       },
-      "scenarios": {
-        "quickstarts/*.md": "getting-started",
-        "tutorials/*.md": "getting-started"
+      "ms.custom": {
+        "quickstarts/*.md": "scenarios:getting-started; languages:JavaScript,TypeScript",
+        "tutorials/*.md": "scenarios:getting-started; languages:JavaScript,TypeScript"
       }
     },
     "template": [],

--- a/docs/excel/custom-functions-overview.md
+++ b/docs/excel/custom-functions-overview.md
@@ -3,7 +3,7 @@ ms.date: 09/26/2019
 description: Create custom functions in Excel using JavaScript.
 title: Create custom functions in Excel
 ms.topic: overview
-scenarios: getting-started
+ms.custom: scenarios:getting-started
 localization_priority: Priority
 ---
 

--- a/docs/excel/custom-functions-overview.md
+++ b/docs/excel/custom-functions-overview.md
@@ -2,7 +2,7 @@
 ms.date: 09/26/2019
 description: Create custom functions in Excel using JavaScript.
 title: Create custom functions in Excel
-ms.topic: overview
+ms.topic: conceptual
 ms.custom: scenarios:getting-started
 localization_priority: Priority
 ---

--- a/docs/excel/excel-add-ins-overview.md
+++ b/docs/excel/excel-add-ins-overview.md
@@ -2,7 +2,7 @@
 title: Excel add-ins overview
 description: ''
 ms.date: 07/05/2019
-ms.topic: overview
+ms.topic: conceptual
 ms.custom: scenarios:getting-started
 localization_priority: Priority
 ---

--- a/docs/excel/excel-add-ins-overview.md
+++ b/docs/excel/excel-add-ins-overview.md
@@ -3,7 +3,7 @@ title: Excel add-ins overview
 description: ''
 ms.date: 07/05/2019
 ms.topic: overview
-ms.custom: scenarios:getting-started, languages:JavaScript,TypeScript
+ms.custom: scenarios:getting-started
 localization_priority: Priority
 ---
 

--- a/docs/excel/excel-add-ins-overview.md
+++ b/docs/excel/excel-add-ins-overview.md
@@ -3,7 +3,7 @@ title: Excel add-ins overview
 description: ''
 ms.date: 07/05/2019
 ms.topic: overview
-scenarios: getting-started
+ms.custom: scenarios:getting-started, languages:JavaScript,TypeScript
 localization_priority: Priority
 ---
 

--- a/docs/onenote/onenote-add-ins-programming-overview.md
+++ b/docs/onenote/onenote-add-ins-programming-overview.md
@@ -2,8 +2,8 @@
 title: OneNote JavaScript API programming overview
 description: ''
 ms.date: 07/05/2019
-ms.topic: overview
-scenarios: getting-started
+ms.topic: conceptual
+ms.custom: scenarios: getting-started
 localization_priority: Priority
 ---
 

--- a/docs/onenote/onenote-add-ins-programming-overview.md
+++ b/docs/onenote/onenote-add-ins-programming-overview.md
@@ -3,7 +3,7 @@ title: OneNote JavaScript API programming overview
 description: ''
 ms.date: 07/05/2019
 ms.topic: conceptual
-ms.custom: scenarios: getting-started
+ms.custom: scenarios:getting-started
 localization_priority: Priority
 ---
 

--- a/docs/overview/explore-with-script-lab.md
+++ b/docs/overview/explore-with-script-lab.md
@@ -3,7 +3,7 @@ title: Explore Office JavaScript API using Script Lab
 description: Use Script Lab to explore the Office JS API and to prototype functionality.
 ms.date: 07/05/2019
 ms.topic: conceptual
-ms.custom: scenarios:getting-started
+ms.custom: scenarios:getting-started; languages:JavaScript,TypeScript
 localization_priority: Normal
 ---
 

--- a/docs/overview/explore-with-script-lab.md
+++ b/docs/overview/explore-with-script-lab.md
@@ -3,7 +3,7 @@ title: Explore Office JavaScript API using Script Lab
 description: Use Script Lab to explore the Office JS API and to prototype functionality.
 ms.date: 07/05/2019
 ms.topic: conceptual
-ms.custom: scenarios:getting-started; languages:JavaScript,TypeScript
+ms.custom: scenarios:getting-started
 localization_priority: Normal
 ---
 

--- a/docs/overview/explore-with-script-lab.md
+++ b/docs/overview/explore-with-script-lab.md
@@ -3,7 +3,7 @@ title: Explore Office JavaScript API using Script Lab
 description: Use Script Lab to explore the Office JS API and to prototype functionality.
 ms.date: 07/05/2019
 ms.topic: conceptual
-ms.custom: getting-started
+ms.custom: scenarios:getting-started
 localization_priority: Normal
 ---
 

--- a/docs/overview/explore-with-script-lab.md
+++ b/docs/overview/explore-with-script-lab.md
@@ -2,8 +2,8 @@
 title: Explore Office JavaScript API using Script Lab
 description: Use Script Lab to explore the Office JS API and to prototype functionality.
 ms.date: 07/05/2019
-ms.topic: overview
-scenarios: getting-started
+ms.topic: conceptual
+ms.custom: scenarios: getting-started
 localization_priority: Normal
 ---
 

--- a/docs/overview/explore-with-script-lab.md
+++ b/docs/overview/explore-with-script-lab.md
@@ -3,7 +3,7 @@ title: Explore Office JavaScript API using Script Lab
 description: Use Script Lab to explore the Office JS API and to prototype functionality.
 ms.date: 07/05/2019
 ms.topic: conceptual
-ms.custom: scenarios: getting-started
+ms.custom: getting-started
 localization_priority: Normal
 ---
 

--- a/docs/overview/office-add-ins.md
+++ b/docs/overview/office-add-ins.md
@@ -3,7 +3,7 @@ title: Office Add-ins platform overview | Microsoft Docs
 description:  Use familiar web technologies such as HTML, CSS, and JavaScript to extend and interact with Word, Excel, PowerPoint, OneNote, Project, and Outlook.
 ms.date: 07/05/2019
 ms.topic: conceptual
-ms.custom: scenarios:getting-started, languages:JavaScript,TypeScript
+ms.custom: scenarios:getting-started
 localization_priority: Priority
 ---
 

--- a/docs/overview/office-add-ins.md
+++ b/docs/overview/office-add-ins.md
@@ -3,7 +3,7 @@ title: Office Add-ins platform overview | Microsoft Docs
 description:  Use familiar web technologies such as HTML, CSS, and JavaScript to extend and interact with Word, Excel, PowerPoint, OneNote, Project, and Outlook.
 ms.date: 07/05/2019
 ms.topic: conceptual
-ms.custom: scenarios:getting-started
+ms.custom: scenarios:getting-started, languages:JavaScript,TypeScript
 localization_priority: Priority
 ---
 

--- a/docs/overview/office-add-ins.md
+++ b/docs/overview/office-add-ins.md
@@ -2,8 +2,8 @@
 title: Office Add-ins platform overview | Microsoft Docs
 description:  Use familiar web technologies such as HTML, CSS, and JavaScript to extend and interact with Word, Excel, PowerPoint, OneNote, Project, and Outlook.
 ms.date: 07/05/2019
-ms.topic: overview
-scenarios: getting-started
+ms.topic: conceptual
+ms.custom: scenarios:getting-started
 localization_priority: Priority
 ---
 

--- a/docs/powerpoint/powerpoint-add-ins.md
+++ b/docs/powerpoint/powerpoint-add-ins.md
@@ -2,8 +2,8 @@
 title: PowerPoint add-ins
 description: ''
 ms.date: 09/03/2019
-ms.topic: overview
-scenarios: getting-started
+ms.topic: conceptual
+ms.custom: scenarios:getting-started
 localization_priority: Priority
 ---
 

--- a/docs/project/project-add-ins.md
+++ b/docs/project/project-add-ins.md
@@ -2,8 +2,8 @@
 title: Task pane add-ins for Project
 description: ''
 ms.date: 09/26/2019
-ms.topic: overview
-scenarios: getting-started
+ms.topic: conceptual
+ms.custom: scenarios:getting-started
 localization_priority: Priority
 ---
 

--- a/docs/reference/overview/visio-javascript-reference-overview.md
+++ b/docs/reference/overview/visio-javascript-reference-overview.md
@@ -3,8 +3,8 @@ title: Visio JavaScript API overview
 description: ''
 ms.date: 06/20/2019
 ms.prod: visio
-ms.topic: overview
-scenarios: getting-started
+ms.topic: conceptual
+ms.custom: scenarios:getting-started
 localization_priority: Priority
 ---
 

--- a/docs/word/word-add-ins-programming-overview.md
+++ b/docs/word/word-add-ins-programming-overview.md
@@ -2,8 +2,8 @@
 title: Word add-ins overview
 description: ''
 ms.date: 07/05/2019
-ms.topic: overview
-scenarios: getting-started
+ms.topic: conceptual
+ms.custom: scenarios:getting-started
 localization_priority: Priority
 ---
 


### PR DESCRIPTION
The data science and developer program team would like to recommend add-in getting started docs to users. However, we hit a few issues with the metadata:

1) Most platforms besides add-ins tag their overview docs as "conceptual" docs. When combining docs across all the platforms, the user now has to understand and distinguish between "overview" and "conceptual" docs (which adds a layer of confusion)
To alleviate this, I've changed the "ms.topic: overview" tags to "ms.topic: conceptual".

2) We are having trouble pulling the custom tags from telemetry. So, instead of calling the column "scenarios", I've added the ms.custom tag and nested scenarios there.

3) When combining the tutorials/quickstarts across products, we noticed the add-in tutorials and quickstarts were not being recommended. This was because they didn't have a language tag to map to user preferences. To fix this, I added languages to the ms.custom tag (only for tutorials and quickstarts)