### PR TITLE
Update office.js CDN URL to all lowercase letters

### DIFF
--- a/docs/develop/specify-office-hosts-and-api-requirements.md
+++ b/docs/develop/specify-office-hosts-and-api-requirements.md
@@ -46,7 +46,7 @@ Your add-in's manifest must use version 1.1 of the add-in manifest schema. Set t
 If you use runtime checks, reference the most current version of the JavaScript API for Office library from the content delivery network (CDN). To do this, add the following  `script` tag to your HTML. Using `/1/` in the CDN URL ensures that you reference the most recent version of Office.js.
 
 ```HTML
-<script src="https://appsforoffice.microsoft.com/lib/1/hosted/Office.js" type="text/javascript"></script>
+<script src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js" type="text/javascript"></script>
 ```
 
 ## Options to specify Office hosts or API requirements

--- a/docs/develop/understanding-the-javascript-api-for-office.md
+++ b/docs/develop/understanding-the-javascript-api-for-office.md
@@ -17,7 +17,7 @@ This article provides information about the JavaScript API for Office and how to
 The [JavaScript API for Office](/office/dev/add-ins/reference/javascript-api-for-office) library consists of the Office.js file and associated host application-specific .js files, such as Excel-15.js and Outlook-15.js. The simplest method of referencing the API is using our CDN by adding the following `<script>` to your page's `<head>` tag:  
 
 ```html
-<script src="https://appsforoffice.microsoft.com/lib/1/hosted/Office.js" type="text/javascript"></script>
+<script src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js" type="text/javascript"></script>
 ```
 
 This will download and cache the JavaScript API for Office files the first time your add-in loads to make sure that it is using the most up-to-date implementation of Office.js and its associated files for the specified version.

--- a/docs/develop/update-your-javascript-api-for-office-and-manifest-schema-version.md
+++ b/docs/develop/update-your-javascript-api-for-office-and-manifest-schema-version.md
@@ -49,7 +49,7 @@ The following steps will update your Office library files to the latest version.
 You'll need to take a few additional steps to complete the update. In the **head** tag of your add-in's HTML pages, comment out or delete any existing office.js script references, and reference the updated JavaScript API for Office library as follows:
 
   ```html
-  <script src="https://appsforoffice.microsoft.com/lib/1/hosted/Office.js" type="text/javascript"></script>
+  <script src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js" type="text/javascript"></script>
   ```
 
    > [!NOTE] 
@@ -93,7 +93,7 @@ You don't need local copies of the JavaScript API for Office files (Office.js an
 2. In the **head** tag of your add-in's HTML pages, comment out or delete any existing office.js script references, and reference the updated JavaScript API for Office library as follows:
 
     ```html
-    <script src="https://appsforoffice.microsoft.com/lib/1/hosted/Office.js" type="text/javascript"></script>
+    <script src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js" type="text/javascript"></script>
     ```
 
    > [!NOTE]

--- a/docs/project/create-your-first-task-pane-add-in-for-project-by-using-a-text-editor.md
+++ b/docs/project/create-your-first-task-pane-add-in-for-project-by-using-a-text-editor.md
@@ -79,8 +79,8 @@ Procedure 2 shows how to create the HTML file that the JSOM_SimpleOMCalls.xml ma
             <script type="text/javascript" src="MicrosoftAjax.js"></script>
 
             <!-- Use the CDN reference to office.js when deploying your add-in. -->
-            <!-- <script src="https://appsforoffice.microsoft.com/lib/1/hosted/Office.js"></script> -->
-            <script type="text/javascript" src="Office.js"></script>
+            <!-- <script src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js"></script> -->
+            <script type="text/javascript" src="office.js"></script>
             <script type="text/javascript" src="JSOM_Sample.js"></script>
         </head>
         <body>
@@ -825,8 +825,8 @@ The Project 2013 SDK download contains the complete code in the JSOMCall.html fi
         <script type="text/javascript" src="MicrosoftAjax.js"></script>
 
         <!-- Use the CDN reference to office.js when deploying your add-in. -->
-        <!-- <script src="https://appsforoffice.microsoft.com/lib/1/hosted/Office.js"></script> -->
-        <script type="text/javascript" src="Office.js"></script>
+        <!-- <script src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js"></script> -->
+        <script type="text/javascript" src="office.js"></script>
         <script type="text/javascript" src="JSOM_Sample.js"></script>
 
         <style type="text/css">
@@ -1055,8 +1055,8 @@ To use the  **throwError** function, include the JQuery library and the SurfaceE
     <script type="text/javascript" src="MicrosoftAjax.js"></script>
 
     <!-- Use the CDN reference to Office.js and jQuery when deploying your add-in. -->
-    <!-- <script src="https://appsforoffice.microsoft.com/lib/1/hosted/Office.js"></script> -->
-    <script type="text/javascript" src="Office.js"></script>
+    <!-- <script src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js"></script> -->
+    <script type="text/javascript" src="office.js"></script>
     <script type="text/javascript" src="http://ajax.microsoft.com/ajax/jQuery/jquery-1.9.0.min.js"></script>
 
     <script type="text/javascript" src="JSOM_Sample.js"></script>


### PR DESCRIPTION
The CDN URL for office.js should be changed to all lowercase letters,
because many of our tools and samples are referencing it that way.
Furthermore, we are now prefetching the office.js using the lowercase
URL in Office Online. Using uppercase O in the URL causes us to be
unable to share the browser cache as the URLs are different.