### PR TITLE
[Admin] (Address build suggestion) Move H1 out of include file into each individual file.

### DIFF
--- a/docs/includes/file-get-the-whole-document-from-an-add-in-for-powerpoint-or-word.md
+++ b/docs/includes/file-get-the-whole-document-from-an-add-in-for-powerpoint-or-word.md
@@ -1,5 +1,3 @@
-# Get the whole document from an add-in for PowerPoint or Word
-
 You can create an Office Add-in to provide one-click sending or publishing of a Word 2013 or PowerPoint 2013 document to a remote location. This article demonstrates how to build a simple task pane add-in for PowerPoint 2013 that gets all of the presentation as a data object and sends that data to a web server via an HTTP request.
 
 ## Prerequisites for creating an add-in for PowerPoint or Word

--- a/docs/powerpoint/get-the-whole-document-from-an-add-in-for-powerpoint.md
+++ b/docs/powerpoint/get-the-whole-document-from-an-add-in-for-powerpoint.md
@@ -6,4 +6,6 @@ ROBOTS: NOINDEX
 localization_priority: Normal
 ---
 
+# Get the whole document from an add-in for PowerPoint or Word
+
 [!include[Get the whole document from an add-in for PowerPoint](../includes/file-get-the-whole-document-from-an-add-in-for-powerpoint-or-word.md)]

--- a/docs/word/get-the-whole-document-from-an-add-in-for-word.md
+++ b/docs/word/get-the-whole-document-from-an-add-in-for-word.md
@@ -5,4 +5,6 @@ ms.date: 12/04/2017
 localization_priority: Priority
 ---
 
+# Get the whole document from an add-in for PowerPoint or Word
+
 [!include[Get the whole document from an add-in for Word](../includes/file-get-the-whole-document-from-an-add-in-for-powerpoint-or-word.md)]


### PR DESCRIPTION
This is necessary to fix an OPS build warning (suggestion) which verifies that every article contains an H1.