### PR TITLE
[admin] (Links) Add missing link to scalar object setting example

### DIFF
--- a/docs/excel/excel-add-ins-advanced-concepts.md
+++ b/docs/excel/excel-add-ins-advanced-concepts.md
@@ -140,7 +140,7 @@ myWorksheets.load({
 
 ## Scalar and navigation properties
 
-There are two categories of properties: **scalar** and **navigational**. Scalar properties are assignable types such as strings, integers, and JSON structs. Navigation properties are readonly objects and collections of objects that have their fields assigned, instead of directly assigning the property. For example, `name` and `position` members on the [Worksheet](/javascript/api/excel/excel.worksheet) object are scalar properties, whereas `protection` and `tables` are navigation properties. `prompt` on the [DataValidation] object is an example of a scalar property that must be set using a JSON object (`dv.prompt = { title: "MyPrompt"}`), instead of setting the sub-properties (`dv.prompt.title = "MyPrompt" // will not set the title`).
+There are two categories of properties: **scalar** and **navigational**. Scalar properties are assignable types such as strings, integers, and JSON structs. Navigation properties are readonly objects and collections of objects that have their fields assigned, instead of directly assigning the property. For example, `name` and `position` members on the [Worksheet](/javascript/api/excel/excel.worksheet) object are scalar properties, whereas `protection` and `tables` are navigation properties. `prompt` on the [DataValidation](/javascript/api/excel/excel.datavalidation) object is an example of a scalar property that must be set using a JSON object (`dv.prompt = { title: "MyPrompt"}`), instead of setting the sub-properties (`dv.prompt.title = "MyPrompt" // will not set the title`).
 
 ### Scalar properties and navigation properties with `object.load()`
 


### PR DESCRIPTION
This was supposed to link to the [DataValidation](https://docs.microsoft.com/en-us/javascript/api/excel/excel.datavalidation?view=excel-js-preview) reference page, but that link was accidentally omitted.