### PR TITLE
[excel, CommonAPI] (Code patterns) Adding notes about range limits and promiseless callback methods

### DIFF
--- a/docs/develop/common-coding-issues.md
+++ b/docs/develop/common-coding-issues.md
@@ -9,11 +9,11 @@ localization_priority: Normal
 
 This article highlights aspects of the Office JavaScript API that may result in unexpected behavior or require specific coding patterns to achieve the desired outcome. If you encounter an issue that belongs in this list, please let us know by using the feedback form at the bottom of the article.
 
-## Common and Outlook APIs are not promise-based
+## Common APIs and Outlook APIs are not promise-based
 
-The [Common APIs](/javascript/api/office) (those that are not tied to a particular host) and [Outlook APIs](/javascript/api/outlook) use a callback-based programming model. Interacting with the underlying Office document requires an asynchronous read or write call that includes a callback to be ran when the operation completes. For an example of this pattern, see [AppointmentCompose.getAttachmentAsync](/javascript/api/office/office.file?view=common-js#getsliceasync-sliceindex--callback-).
+The [Common APIs](/javascript/api/office) (those that are not tied to a particular Office host) and [Outlook APIs](/javascript/api/outlook) use a callback-based programming model. Interacting with the underlying Office document requires an asynchronous read or write call that specifies a callback to be ran when the operation completes. For an example of this pattern, see [AppointmentCompose.getAttachmentAsync](/javascript/api/outlook/office.appointmentcompose?view=outlook-js-preview#getattachmentsasync-callback-).
 
-These Common and Outlook methods do not return [Promises](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise). As such, you cannot use [await](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/await) to pause the execution until the async operation completes. If you need `await` behavior, you can wrap the method call in an explicitly created Promise.
+These Common API and Outlook API methods do not return [Promises](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise). Therefore, you cannot use [await](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/await) to pause the execution until the asynchronous operation completes. If you need `await` behavior, you can wrap the method call in an explicitly created Promise.
 
 ## Some properties must be set with JSON structs
 
@@ -43,12 +43,12 @@ You can identify a property that must have its subproperties set with a JSON str
 
 ## Excel Range limits
 
-Excel developers need to be aware of two data size limitations:
+If you're building an Excel add-in that uses ranges, be aware of the following size limitations:
 
 - Excel on the web has a payload size limit for requests and responses of 5MB. `RichAPI.Error` will be thrown if that limit is exceeded.
 - A range is limited to five million cells for set operations.
 
-If you expect user input to exceed those amounts, be sure to check the data and split the ranges into multiple objects. You'll also need separate `context.sync()` calls to avoid overwhelming the Excel cloud service.
+If you expect user input to exceed these limits, be sure to check the data and split the ranges into multiple objects. You'll also need to submit multiple `context.sync()` calls to avoid the smaller range operations getting batched together again.
 
 Your add-in might be able to use [RangeAreas](/javascript/api/excel/excel.rangeareas) to strategically update cells within a larger range. See [Work with multiple ranges simultaneously in Excel add-ins](../excel/excel-add-ins-multiple-ranges.md) for more information.
 

--- a/docs/develop/common-coding-issues.md
+++ b/docs/develop/common-coding-issues.md
@@ -1,13 +1,19 @@
 ---
 title: Common coding issues and unexpected platform behaviors
 description: 'A list of Office JavaScript API platform issues frequently encountered by developers.'
-ms.date: 10/29/2019
+ms.date: 10/30/2019
 localization_priority: Normal
 ---
 
 # Common coding issues and unexpected platform behaviors
 
 This article highlights aspects of the Office JavaScript API that may result in unexpected behavior or require specific coding patterns to achieve the desired outcome. If you encounter an issue that belongs in this list, please let us know by using the feedback form at the bottom of the article.
+
+## Common and Outlook APIs are not promise-based
+
+The [Common APIs](/javascript/api/office) (those that are not tied to a particular host) and [Outlook APIs](/javascript/api/outlook) use a callback-based programming model. Interacting with the underlying Office document requires an asynchronous read or write call that includes a callback to be ran when the operation completes. For an example of this pattern, see [AppointmentCompose.getAttachmentAsync](/javascript/api/office/office.file?view=common-js#getsliceasync-sliceindex--callback-).
+
+These Common and Outlook methods do not return [Promises](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise). As such, you cannot use [await](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/await) to pause the execution until the async operation completes. If you need `await` behavior, you can wrap the method call in an explicitly created Promise.
 
 ## Some properties must be set with JSON structs
 
@@ -34,6 +40,17 @@ You can identify a property that must have its subproperties set with a JSON str
 
 - Read-only property: Subproperties can be set through navigation.
 - Writable property: Subproperties must be set with a JSON struct (and cannot be set through navigation).
+
+## Excel Range limits
+
+Excel developers need to be aware of two data size limitations:
+
+- Excel on the web has a payload size limit for requests and responses of 5MB. `RichAPI.Error` will be thrown if that limit is exceeded.
+- A range is limited to five million cells for set operations.
+
+If you expect user input to exceed those amounts, be sure to check the data and split the ranges into multiple objects. You'll also need separate `context.sync()` calls to avoid overwhelming the Excel cloud service.
+
+Your add-in might be able to use [RangeAreas](/javascript/api/excel/excel.rangeareas) to strategically update cells within a larger range. See [Work with multiple ranges simultaneously in Excel add-ins](../excel/excel-add-ins-multiple-ranges.md) for more information.
 
 ## Setting read-only properties
 

--- a/docs/excel/excel-add-ins-core-concepts.md
+++ b/docs/excel/excel-add-ins-core-concepts.md
@@ -206,8 +206,7 @@ range.values = 'Due Date';
 
 If a range contains a large number of cells, values, number formats, and/or formulas, it may not be possible to run API operations on that range. The API will always make a best attempt to run the requested operation on a range (i.e., to retrieve or write the specified data), but attempting to perform read or write operations for a large range may result in an API error due to excessive resource utilization. To avoid such errors, we recommend that you run separate read or write operations for smaller subsets of a large range, instead of attempting to run a single read or write operation on a large range.
 
-> [!IMPORTANT]
-> Excel on the web has a payload size limit for requests and responses of **5MB**. `RichAPI.Error` will be thrown if that limit is exceeded.
+For details on the system limitations, see [Excel Range limits](../develop/common-coding-issues.md#excel-range-limits).
 
 ## Update all cells in a range
 
@@ -249,3 +248,4 @@ When an API error occurs, the API returns an **error** object that contains a co
 - [Advanced programming concepts with the Excel JavaScript API](excel-add-ins-advanced-concepts.md)
 - [Excel JavaScript API performance optimization](/office/dev/add-ins/excel/performance)
 - [Excel JavaScript API reference](/office/dev/add-ins/reference/overview/excel-add-ins-reference-overview)
+- [Common coding issues and unexpected platform behaviors](../develop/common-coding-issues.md).


### PR DESCRIPTION
This adds a section centralizing the limitations with Excel range sizes. It also discusses the Common/Outlook programming model and its lack of promises. 