### PR TITLE
Removed remark about Label in CustomTab

### DIFF
--- a/docs/develop/add-in-manifests.md
+++ b/docs/develop/add-in-manifests.md
@@ -310,7 +310,7 @@ The following sections show examples of manifest v1.1 XML files for content, tas
               </Group>
 
               <!-- Label of your tab -->
-              <!-- If validating with XSD it needs to be at the end, we might change this before release -->
+              <!-- If validating with XSD it needs to be at the end -->
               <Label resid="Contoso.Tab1.TabLabel" />
             </CustomTab>
           </ExtensionPoint>


### PR DESCRIPTION
There was a remark that before the product launch the strict position enforcement through XSD could be changed. Just tested it and it hasn't changed, thus removing the comment to provide clarity.