### PR TITLE
[All Hosts] Update the Group element article in the manifest reference docs.

### DIFF
--- a/docs/reference/manifest/group.md
+++ b/docs/reference/manifest/group.md
@@ -23,7 +23,7 @@ Required. Unique identifier for the group. It is a string with a maximum of 125 
 |  Element |  Required  |  Description  |
 |:-----|:-----|:-----|
 |  [Label](#label)      | Yes |  The label for the CustomTab or a group.  |
-|  [Icon](icon.md)      | Yes |  An image for the group.  |
+|  [Icon](icon.md)      | Yes |  An image for a group.  |
 |  [Control](#control)    | Yes |  Collection of one or more Control objects.  |
 
 ### Label 

--- a/docs/reference/manifest/group.md
+++ b/docs/reference/manifest/group.md
@@ -23,11 +23,16 @@ Required. Unique identifier for the group. It is a string with a maximum of 125 
 |  Element |  Required  |  Description  |
 |:-----|:-----|:-----|
 |  [Label](#label)      | Yes |  The label for the CustomTab or a group.  |
+|  [Icon](icon.md)      | Yes |  An image for the group.  |
 |  [Control](#control)    | Yes |  Collection of one or more Control objects.  |
 
 ### Label 
 
 Required. The label of the group. The  **resid** attribute must be set to the value of the **id** attribute of a **String** element in the **ShortStrings** element in the [Resources](resources.md) element.
+
+### Icon
+
+Required. If a tab contains a lot of groups and the program window is resized, the specified image may display instead.
 
 ### Control
 A group requires at least one control. For details about the types of controls that are supported, see the [Control](control.md) element.
@@ -35,8 +40,13 @@ A group requires at least one control. For details about the types of controls t
 ```xml
 <Group id="msgreadCustomTab.grp1">
     <Label resid="residCustomTabGroupLabel"/>
+    <Icon>
+        <bt:Image size="16" resid="blue-icon-16" />
+        <bt:Image size="32" resid="blue-icon-32" />
+        <bt:Image size="80" resid="blue-icon-80" />
+    </Icon>
     <Control xsi:type="Button" id="Button2">
-    <!-- information on the control -->
+        <!-- information on the control -->
     </Control>
     <!-- other controls, as needed -->
 </Group>

--- a/docs/reference/manifest/group.md
+++ b/docs/reference/manifest/group.md
@@ -23,7 +23,7 @@ Required. Unique identifier for the group. It is a string with a maximum of 125 
 |  Element |  Required  |  Description  |
 |:-----|:-----|:-----|
 |  [Label](#label)      | Yes |  The label for the CustomTab or a group.  |
-|  [Icon](icon.md)      | Yes |  An image for a group.  |
+|  [Icon](icon.md)      | Yes |  The image for a group.  |
 |  [Control](#control)    | Yes |  Collection of one or more Control objects.  |
 
 ### Label 


### PR DESCRIPTION
Indicate that the `Icon` element is a required child element of the `Group` element in the manifest.

Fixes #1462