### PR TITLE
[all] (CDN) Standardizing CDN URL to /1/

### DIFF
--- a/docs/excel/custom-functions-overview.md
+++ b/docs/excel/custom-functions-overview.md
@@ -66,7 +66,7 @@ function add(first, second){
 Note that the **functions.html** file, which governs the loading of the custom functions runtime, must link to the current CDN for custom functions. Projects prepared with the current version of the Yo Office generator reference the correct CDN. If you are retrofitting a previous custom function project from March 2019 or earlier, you need to copy in the code below to the **functions.html** page.
 
 ```HTML
-<script src="https://appsforoffice.microsoft.com/lib/1.1/hosted/custom-functions-runtime.js" type="text/javascript"></script>
+<script src="https://appsforoffice.microsoft.com/lib/1/hosted/custom-functions-runtime.js" type="text/javascript"></script>
 ```
 
 ### Manifest file

--- a/docs/tutorials/excel-tutorial.md
+++ b/docs/tutorials/excel-tutorial.md
@@ -786,7 +786,7 @@ In this final step of the tutorial, you'll open a dialog in your add-in, pass a 
             <!-- For more information on Office UI Fabric, visit https://developer.microsoft.com/fabric. -->
             <link rel="stylesheet" href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/9.6.1/css/fabric.min.css"/>
 
-            <script type="text/javascript" src="https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js"></script>
+            <script type="text/javascript" src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js"></script>
             <script type="text/javascript" src="popup.js"></script>
 
         </head>


### PR DESCRIPTION
Fixes #1452.

As per a conversation with @sumurthy:

> AlexJerabek: What is the difference between the /1/ and /1.1/ CDN endpoints? 
> sumurthy: They point to the same thing. We should just use one of them in the docs =>  /1/ 

@mscharlock, I tested the Custom Function endpoint and this appears to be true there too. Please verify that's correct.