### PR TITLE
[all] debugging ui-less code with Edge DevTools

### DIFF
--- a/docs/concepts/browsers-used-by-office-web-add-ins.md
+++ b/docs/concepts/browsers-used-by-office-web-add-ins.md
@@ -1,7 +1,7 @@
 ---
 title: Browsers used by Office Add-ins
 description: 'Specifies how the operating system and Office version determine what browser is used by Office Add-ins.'
-ms.date: 09/25/2019
+ms.date: 12/13/2019
 localization_priority: Priority
 ---
 

--- a/docs/concepts/browsers-used-by-office-web-add-ins.md
+++ b/docs/concepts/browsers-used-by-office-web-add-ins.md
@@ -32,19 +32,6 @@ The following table shows which browser is used for the various platforms and op
 > [!IMPORTANT]
 > Internet Explorer 11 does not support JavaScript versions later than ES5. If any of your add-in's users have platforms that use Internet Explorer 11, then to use the syntax and features of ECMAScript 2015 or later, you will need to either transpile your JavaScript to ES5 or use a polyfill. Also, Internet Explorer 11 does not support some HTML5 features such as media, recording, and location.
 
-> [!NOTE]
-> Until they are generally available, you need to be a Windows Insider to get a Windows version 1903 or greater, and you need to be an Office Insider to get Office version 16.0.11629 or greater.
->
-> To join Windows Insiders:
-> 
-> 1. Go to [Windows Insider](https://insider.windows.com) and click the link to join Windows Insiders.
-> 2. You will be taken to a page with instructions about how to use Windows Settings to enable preview builds of Windows. Follow the instructions. When you select the pace of updates, choose the fastest option.
->
-> To join Office Insiders:
-> 
-> 1. Go to [Get started as an Office Insider](https://insider.office.com/join).
-> 2. Follow the instruction on that page to join. When asked to specify a channel, select Insider.
-
 ## Troubleshooting Microsoft Edge Issues
 
 ### Scroll bar does not appear in task pane

--- a/docs/develop/create-and-debug-office-add-ins-in-visual-studio.md
+++ b/docs/develop/create-and-debug-office-add-ins-in-visual-studio.md
@@ -102,7 +102,7 @@ You can use Visual Studio to debug your add-in in the Office desktop client on W
 
 ### Enable debugging for add-in commands and UI-less code
 
-When Visual Studio debugs Excel on Windows, the add-in is hosted in either a Microsoft Internet Explorer or Microsoft Edge browser instance. To determine which browser is being used on your development computer, see [Browsers used by Office Add-ins](../concepts/browsers-used-by-office-web-add-ins.md).
+When Visual Studio debugs Office on Windows, the add-in is hosted in either a Microsoft Internet Explorer or Microsoft Edge browser instance. To determine which browser is being used on your development computer, see [Browsers used by Office Add-ins](../concepts/browsers-used-by-office-web-add-ins.md).
 
 [!include[Enable debugging on Microsoft Edge DevTools](../includes/enable-debugging-on-edge-devtools.md)]
 

--- a/docs/develop/create-and-debug-office-add-ins-in-visual-studio.md
+++ b/docs/develop/create-and-debug-office-add-ins-in-visual-studio.md
@@ -90,6 +90,7 @@ The web application project contains a default HTML file, JavaScript file, and C
 
 You can use Visual Studio to debug your add-in in the Office desktop client on Windows, as described in the following sections:
 
+- [Enable debugging for add-in commands and UI-less code](#enable-debugging-for-add-in-commands-and-ui-less-code)
 - [Review the build and debug properties](#review-the-build-and-debug-properties)
 - [Use an existing document to debug the add-in](#use-an-existing-document-to-debug-the-add-in)
 - [Start the project](#start-the-project)

--- a/docs/develop/create-and-debug-office-add-ins-in-visual-studio.md
+++ b/docs/develop/create-and-debug-office-add-ins-in-visual-studio.md
@@ -1,7 +1,7 @@
 ---
 title: Create and debug Office Add-ins in Visual Studio
 description: 'Use Visual Studio to create and debug Office Add-ins in the Office desktop client on Windows'
-ms.date: 12/13/2019
+ms.date: 12/16/2019
 localization_priority: Priority
 ---
 

--- a/docs/develop/create-and-debug-office-add-ins-in-visual-studio.md
+++ b/docs/develop/create-and-debug-office-add-ins-in-visual-studio.md
@@ -99,6 +99,10 @@ You can use Visual Studio to debug your add-in in the Office desktop client on W
 > [!NOTE]
 > You cannot use Visual Studio to debug add-ins in Office on the web or Mac. For information about debugging on these platforms, see [Debug Office Add-ins in Office on the web](../testing/debug-add-ins-in-office-online.md) or [Debug Office Add-ins on iPad and Mac](../testing/debug-office-add-ins-on-ipad-and-mac.md)
 
+### Enable debugging for add-in commands and UI-less code
+
+[!include[Enable debugging on Microsoft Edge DevTools](../includes/enable-debugging-on-edge-devtools.md)]
+
 ### Review the build and debug properties
 
 Before you start debugging, review the properties of each project to confirm that Visual Studio will open the desired host application and that other build and debug properties are set appropriately.

--- a/docs/develop/create-and-debug-office-add-ins-in-visual-studio.md
+++ b/docs/develop/create-and-debug-office-add-ins-in-visual-studio.md
@@ -1,7 +1,7 @@
 ---
 title: Create and debug Office Add-ins in Visual Studio
 description: 'Use Visual Studio to create and debug Office Add-ins in the Office desktop client on Windows'
-ms.date: 10/11/2019
+ms.date: 12/13/2019
 localization_priority: Priority
 ---
 

--- a/docs/develop/create-and-debug-office-add-ins-in-visual-studio.md
+++ b/docs/develop/create-and-debug-office-add-ins-in-visual-studio.md
@@ -102,6 +102,8 @@ You can use Visual Studio to debug your add-in in the Office desktop client on W
 
 ### Enable debugging for add-in commands and UI-less code
 
+When Visual Studio debugs Excel on Windows, the add-in is hosted in either a Microsoft Internet Explorer or Microsoft Edge browser instance. To determine which browser is being used on your development computer, see [Browsers used by Office Add-ins](../concepts/browsers-used-by-office-web-add-ins.md).
+
 [!include[Enable debugging on Microsoft Edge DevTools](../includes/enable-debugging-on-edge-devtools.md)]
 
 ### Review the build and debug properties

--- a/docs/includes/enable-debugging-on-edge-devtools.md
+++ b/docs/includes/enable-debugging-on-edge-devtools.md
@@ -1,4 +1,5 @@
-UI-less code, such as add-in commands, or code running while the task pane is not visible, will not be able to attach to a debugger by default. You'll need to use [Windows PowerShell](https://docs.microsoft.com/powershell/scripting/getting-started/getting-started-with-windows-powershell) to run a couple commands to enable debugging.
+When the add-in is running in Microsoft Edge, UI-less code will not be able to attach to a debugger by default.
+UI-less code is any code running while the task pane is not visible, such as add-in commands. To enable debugging, you need to run the following [Windows PowerShell](https://docs.microsoft.com/powershell/scripting/getting-started/getting-started-with-windows-powershell) commands.
 
 1. Run the following command to get information for the **Microsoft.Win32WebViewHost** app package.
     

--- a/docs/includes/enable-debugging-on-edge-devtools.md
+++ b/docs/includes/enable-debugging-on-edge-devtools.md
@@ -1,0 +1,37 @@
+UI-less code, such as add-in commands, or code running while the task pane is not visible, will not be able to attach to a debugger by default. You'll need to use [Windows PowerShell](https://docs.microsoft.com/powershell/scripting/getting-started/getting-started-with-windows-powershell) to run a couple commands to enable debugging.
+
+1. Run the following command to get information for the **Microsoft.Win32WebViewHost** app package.
+    
+    ```powershell
+    Get-AppxPackage Microsoft.Win32WebViewHost
+    ```
+    
+    The command lists app package information similar to the following output.
+    
+    ```powershell
+    Name              : Microsoft.Win32WebViewHost
+    Publisher         : CN=Microsoft Windows, O=Microsoft Corporation, L=Redmond, S=Washington, C=US
+    Architecture      : Neutral
+    ResourceId        : neutral
+    Version           : 10.0.18362.449
+    PackageFullName   : Microsoft.Win32WebViewHost_10.0.18362.449_neutral_neutral_cw5n1h2txyewy
+    InstallLocation   : C:\Windows\SystemApps\Microsoft.Win32WebViewHost_cw5n1h2txyewy
+    IsFramework       : False
+    PackageFamilyName : Microsoft.Win32WebViewHost_cw5n1h2txyewy
+    PublisherId       : cw5n1h2txyewy
+    IsResourcePackage : False
+    IsBundle          : False
+    IsDevelopmentMode : False
+    NonRemovable      : True
+    IsPartiallyStaged : False
+    SignatureKind     : System
+    Status            : Ok
+    ```
+    
+2. Run the following command to enabled debugging. Use the value for the **PackageFullName** listed from the previous command.
+    
+    ```powershell
+    setx JS_DEBUG <PackageFullName>
+    ```
+    
+3. If Office was already running, close and restart Office so that it picks up the debugging change.

--- a/docs/testing/debug-add-ins-using-f12-developer-tools-on-windows-10.md
+++ b/docs/testing/debug-add-ins-using-f12-developer-tools-on-windows-10.md
@@ -16,41 +16,7 @@ The tool that you use depends on whether the add-in is running in Microsoft Edge
 
 ## Enable debugging for add-in commands and UI-less code
 
-UI-less code, such as add-in commands, or code running while the task pane is not visible, will not be able to attach to a debugger by default. You'll need to use [Windows PowerShell](https://docs.microsoft.com/powershell/scripting/getting-started/getting-started-with-windows-powershell) to run a couple commands to enable debugging.
-
-1. Run the following command to get information for the **Microsoft.Win32WebViewHost** app package.
-    
-    ```powershell
-    Get-AppxPackage Microsoft.Win32WebViewHost
-    ```
-    
-    The command lists app package information similar to the following output.
-    
-    ```powershell
-    Name              : Microsoft.Win32WebViewHost
-    Publisher         : CN=Microsoft Windows, O=Microsoft Corporation, L=Redmond, S=Washington, C=US
-    Architecture      : Neutral
-    ResourceId        : neutral
-    Version           : 10.0.18362.449
-    PackageFullName   : Microsoft.Win32WebViewHost_10.0.18362.449_neutral_neutral_cw5n1h2txyewy
-    InstallLocation   : C:\Windows\SystemApps\Microsoft.Win32WebViewHost_cw5n1h2txyewy
-    IsFramework       : False
-    PackageFamilyName : Microsoft.Win32WebViewHost_cw5n1h2txyewy
-    PublisherId       : cw5n1h2txyewy
-    IsResourcePackage : False
-    IsBundle          : False
-    IsDevelopmentMode : False
-    NonRemovable      : True
-    IsPartiallyStaged : False
-    SignatureKind     : System
-    Status            : Ok
-    ```
-    
-2. Run the following command to enabled debugging. Use the value for the **PackageFullName** listed from the previous command.
-    
-    ```powershell
-    setx JS_DEBUG <PackageFullName>
-    ```
+[!include[Enable debugging on Microsoft Edge DevTools](../includes/enable-debugging-on-edge-devtools.md)]
 
 ## When the add-in is running in Microsoft Edge
 

--- a/docs/testing/debug-add-ins-using-f12-developer-tools-on-windows-10.md
+++ b/docs/testing/debug-add-ins-using-f12-developer-tools-on-windows-10.md
@@ -1,7 +1,7 @@
 ---
 title: Debug add-ins using developer tools on Windows 10
-description: ''
-ms.date: 07/01/2019
+description: 'Debug add-ins using Microsoft Edge developer tools on Windows 10'
+ms.date: 12/13/2019
 localization_priority: Priority
 ---
 
@@ -11,15 +11,52 @@ There are developer tools outside of IDEs available to help you debug your add-i
 
 The tool that you use depends on whether the add-in is running in Microsoft Edge or Internet Explorer. This is determined by the version of Windows 10 and the version of Office that are installed on the computer. To determine which browser is being used on your development computer, see [Browsers used by Office Add-ins](../concepts/browsers-used-by-office-web-add-ins.md). 
 
-
 > [!NOTE]
 > The instructions in this article cannot be used to debug an Outlook add-in that uses Execute Functions. To debug an Outlook add-in that uses Execute Functions, we recommend that you attach to Visual Studio in script mode or to some other script debugger.
+
+## Enable debugging for add-in commands and UI-less code
+
+UI-less code, such as add-in commands, or code running while the task pane is not visible, will not be able to attach to a debugger by default. You'll need to use [Windows PowerShell](https://docs.microsoft.com/powershell/scripting/getting-started/getting-started-with-windows-powershell) to run a couple commands to enable debugging.
+
+1. Run the following command to get information for the **Microsoft.Win32WebViewHost** app package.
+    
+    ```powershell
+    Get-AppxPackage Microsoft.Win32WebViewHost
+    ```
+    
+    The command lists app package information similar to the following output.
+    
+    ```powershell
+    Name              : Microsoft.Win32WebViewHost
+    Publisher         : CN=Microsoft Windows, O=Microsoft Corporation, L=Redmond, S=Washington, C=US
+    Architecture      : Neutral
+    ResourceId        : neutral
+    Version           : 10.0.18362.449
+    PackageFullName   : Microsoft.Win32WebViewHost_10.0.18362.449_neutral_neutral_cw5n1h2txyewy
+    InstallLocation   : C:\Windows\SystemApps\Microsoft.Win32WebViewHost_cw5n1h2txyewy
+    IsFramework       : False
+    PackageFamilyName : Microsoft.Win32WebViewHost_cw5n1h2txyewy
+    PublisherId       : cw5n1h2txyewy
+    IsResourcePackage : False
+    IsBundle          : False
+    IsDevelopmentMode : False
+    NonRemovable      : True
+    IsPartiallyStaged : False
+    SignatureKind     : System
+    Status            : Ok
+    ```
+    
+2. Run the following command to enabled debugging. Use the value for the **PackageFullName** listed from the previous command.
+    
+    ```powershell
+    setx JS_DEBUG <PackageFullName>
+    ```
 
 ## When the add-in is running in Microsoft Edge
 
 When the add-in is running in Microsoft Edge, you can use the [Microsoft Edge DevTools](https://www.microsoft.com/p/microsoft-edge-devtools-preview/9mzbfrmz0mnj?activetab=pivot%3Aoverviewtab). 
 
-1. Run the add-in. 
+1. Run the add-in.
 
 2. Run the Microsoft Edge DevTools.
 

--- a/docs/testing/debug-add-ins-using-f12-developer-tools-on-windows-10.md
+++ b/docs/testing/debug-add-ins-using-f12-developer-tools-on-windows-10.md
@@ -16,13 +16,11 @@ The tool that you use depends on whether the add-in is running in Microsoft Edge
 
 ## When the add-in is running in Microsoft Edge
 
-When the add-in is running in Microsoft Edge, you can use the [Microsoft Edge DevTools](https://www.microsoft.com/p/microsoft-edge-devtools-preview/9mzbfrmz0mnj?activetab=pivot%3Aoverviewtab).
-
-### Enable debugging for add-in commands and UI-less code
-
 [!include[Enable debugging on Microsoft Edge DevTools](../includes/enable-debugging-on-edge-devtools.md)]
 
 ### Debug using Microsoft Edge DevTools
+
+When the add-in is running in Microsoft Edge, you can use the [Microsoft Edge DevTools](https://www.microsoft.com/p/microsoft-edge-devtools-preview/9mzbfrmz0mnj?activetab=pivot%3Aoverviewtab).
 
 1. Run the add-in.
 

--- a/docs/testing/debug-add-ins-using-f12-developer-tools-on-windows-10.md
+++ b/docs/testing/debug-add-ins-using-f12-developer-tools-on-windows-10.md
@@ -1,7 +1,7 @@
 ---
 title: Debug add-ins using developer tools on Windows 10
 description: 'Debug add-ins using Microsoft Edge developer tools on Windows 10'
-ms.date: 12/13/2019
+ms.date: 12/16/2019
 localization_priority: Priority
 ---
 
@@ -9,18 +9,20 @@ localization_priority: Priority
 
 There are developer tools outside of IDEs available to help you debug your add-ins on Windows 10. These are useful when you need to investigate a problem while running your add-in outside the IDE.
 
-The tool that you use depends on whether the add-in is running in Microsoft Edge or Internet Explorer. This is determined by the version of Windows 10 and the version of Office that are installed on the computer. To determine which browser is being used on your development computer, see [Browsers used by Office Add-ins](../concepts/browsers-used-by-office-web-add-ins.md). 
+The tool that you use depends on whether the add-in is running in Microsoft Edge or Internet Explorer. This is determined by the version of Windows 10 and the version of Office that are installed on the computer. To determine which browser is being used on your development computer, see [Browsers used by Office Add-ins](../concepts/browsers-used-by-office-web-add-ins.md).
 
 > [!NOTE]
 > The instructions in this article cannot be used to debug an Outlook add-in that uses Execute Functions. To debug an Outlook add-in that uses Execute Functions, we recommend that you attach to Visual Studio in script mode or to some other script debugger.
 
-## Enable debugging for add-in commands and UI-less code
+## When the add-in is running in Microsoft Edge
+
+When the add-in is running in Microsoft Edge, you can use the [Microsoft Edge DevTools](https://www.microsoft.com/p/microsoft-edge-devtools-preview/9mzbfrmz0mnj?activetab=pivot%3Aoverviewtab).
+
+### Enable debugging for add-in commands and UI-less code
 
 [!include[Enable debugging on Microsoft Edge DevTools](../includes/enable-debugging-on-edge-devtools.md)]
 
-## When the add-in is running in Microsoft Edge
-
-When the add-in is running in Microsoft Edge, you can use the [Microsoft Edge DevTools](https://www.microsoft.com/p/microsoft-edge-devtools-preview/9mzbfrmz0mnj?activetab=pivot%3Aoverviewtab). 
+### Debug using Microsoft Edge DevTools
 
 1. Run the add-in.
 


### PR DESCRIPTION
This adds information about how to enable debugging for UI-less code (like add-in commands) that are running in the Edge WebView.