### PR TITLE
[All hosts] Refactor debugging/troubleshooting content.

### DIFF
--- a/docs/develop/add-in-manifests.md
+++ b/docs/develop/add-in-manifests.md
@@ -1,7 +1,7 @@
 ---
 title: Office Add-ins XML manifest
 description: ''
-ms.date: 09/26/2019
+ms.date: 12/31/2019
 localization_priority: Priority
 ---
 

--- a/docs/develop/add-in-manifests.md
+++ b/docs/develop/add-in-manifests.md
@@ -481,9 +481,9 @@ The following sections show examples of manifest v1.1 XML files for content, tas
 
 ---
 
-## Validate and troubleshoot issues with your manifest
+## Validate an Office Add-in's manifest
 
-For troubleshooting issues with your manifest, see [Validate and troubleshoot issues with your manifest](../testing/troubleshoot-manifest.md). There, you will find information on how to validate the manifest against the [XML Schema Definition (XSD)](https://github.com/OfficeDev/office-js-docs-pr/tree/master/docs/overview/schemas), and also how to use runtime logging to debug the manifest.
+For information about validating a manifest against the [XML Schema Definition (XSD)](https://github.com/OfficeDev/office-js-docs-pr/tree/master/docs/overview/schemas), see [Validate an Office Add-in's manifest](../testing/troubleshoot-manifest.md).
 
 ## See also
 
@@ -495,6 +495,6 @@ For troubleshooting issues with your manifest, see [Validate and troubleshoot is
 * [Update API and manifest version](update-your-javascript-api-for-office-and-manifest-schema-version.md)
 * [Identify an equivalent COM add-in](make-office-add-in-compatible-with-existing-com-add-in.md)
 * [Requesting permissions for API use in add-ins](requesting-permissions-for-api-use-in-content-and-task-pane-add-ins.md)
-* [Validate and troubleshoot issues with your manifest](../testing/troubleshoot-manifest.md)
+* [Validate an Office Add-in's manifest](../testing/troubleshoot-manifest.md)
 
 [add-in commands]: create-addin-commands.md

--- a/docs/develop/troubleshoot-sso-in-office-add-ins.md
+++ b/docs/develop/troubleshoot-sso-in-office-add-ins.md
@@ -59,7 +59,7 @@ User Type not supported. The user isn't signed into Office with a valid Microsof
 
 ### 13004
 
-Invalid Resource. (This error should only be seen in development.) The add-in manifest hasn’t been configured correctly. Update the manifest. For more information, see [Validate and troubleshoot issues with your manifest](../testing/troubleshoot-manifest.md). The most common problem is that the **Resource** element (in the **WebApplicationInfo** element) has a domain that does not match the domain of the add-in. Although the protocol part of the Resource value should be "api" not "https"; all other parts of the domain name (including port, if any) should be the same as for the add-in.
+Invalid Resource. (This error should only be seen in development.) The add-in manifest hasn’t been configured correctly. Update the manifest. For more information, see [Validate an Office Add-in's manifest](../testing/troubleshoot-manifest.md). The most common problem is that the **Resource** element (in the **WebApplicationInfo** element) has a domain that does not match the domain of the add-in. Although the protocol part of the Resource value should be "api" not "https"; all other parts of the domain name (including port, if any) should be the same as for the add-in.
 
 ### 13005
 

--- a/docs/excel/custom-functions-troubleshooting.md
+++ b/docs/excel/custom-functions-troubleshooting.md
@@ -29,7 +29,7 @@ Generally, these errors correspond to the errors you might already be familiar w
 
 ## Clear the Office cache
 
-Information about custom functions is cached by Office. Sometimes while developing and repeatedly reloading an add-in with custom functions your changes may not appear. You can fix this by clearing the Office cache. For more information, see [Clear the Office cache](../testing/clear-cache).
+Information about custom functions is cached by Office. Sometimes while developing and repeatedly reloading an add-in with custom functions your changes may not appear. You can fix this by clearing the Office cache. For more information, see [Clear the Office cache](../testing/clear-cache.md).
 
 ## Common issues
 

--- a/docs/excel/custom-functions-troubleshooting.md
+++ b/docs/excel/custom-functions-troubleshooting.md
@@ -1,5 +1,5 @@
 ---
-ms.date: 07/15/2019
+ms.date: 12/19/2019
 description: Troubleshoot common problems in Excel custom functions.
 title: Troubleshoot custom functions
 localization_priority: Priority

--- a/docs/excel/custom-functions-troubleshooting.md
+++ b/docs/excel/custom-functions-troubleshooting.md
@@ -1,5 +1,5 @@
 ---
-ms.date: 12/19/2019
+ms.date: 12/31/2019
 description: Troubleshoot common problems in Excel custom functions.
 title: Troubleshoot custom functions
 localization_priority: Priority
@@ -14,7 +14,7 @@ To resolve issues, you can [enable runtime logging to capture errors](#enable-ru
 
 ## Enable runtime logging
 
-If you are testing your add-in in Office on Windows, you should [enable runtime logging](../testing/runtime-logging.md). Runtime logging delivers `console.log` statements to a separate log file you create to help you uncover issues. The statements cover a variety of errors, including errors pertaining to your add-in's XML manifest file, runtime conditions, or installation of your custom functions.  For more information about runtime logging, see [Debug your add-in with runtime logging](../testing/runtime-logging.md).
+If you're testing your add-in in Office on Windows, you should [enable runtime logging](../testing/runtime-logging.md). Runtime logging delivers `console.log` statements to a separate log file you create to help you uncover issues. The statements cover a variety of errors, including errors pertaining to your add-in's XML manifest file, runtime conditions, or installation of your custom functions.  For more information about runtime logging, see [Debug your add-in with runtime logging](../testing/runtime-logging.md).
 
 ### Check for Excel error messages
 

--- a/docs/excel/custom-functions-troubleshooting.md
+++ b/docs/excel/custom-functions-troubleshooting.md
@@ -14,7 +14,7 @@ To resolve issues, you can [enable runtime logging to capture errors](#enable-ru
 
 ## Enable runtime logging
 
-If you're testing your add-in in Office on Windows, you should [enable runtime logging](../testing/runtime-logging.md). Runtime logging delivers `console.log` statements to a separate log file you create to help you uncover issues. The statements cover a variety of errors, including errors pertaining to your add-in's XML manifest file, runtime conditions, or installation of your custom functions.  For more information about runtime logging, see [Debug your add-in with runtime logging](../testing/runtime-logging.md).
+If you're testing your add-in in Office on Windows, you should [enable runtime logging](../testing/runtime-logging.md). Runtime logging delivers `console.log` statements to a separate log file you create to help you uncover issues. The statements cover a variety of errors, including errors pertaining to your add-in's XML manifest file, runtime conditions, or installation of your custom functions. For more information about runtime logging, see [Debug your add-in with runtime logging](../testing/runtime-logging.md).
 
 ### Check for Excel error messages
 

--- a/docs/excel/custom-functions-troubleshooting.md
+++ b/docs/excel/custom-functions-troubleshooting.md
@@ -14,7 +14,7 @@ To resolve issues, you can [enable runtime logging to capture errors](#enable-ru
 
 ## Enable runtime logging
 
-If you are testing your add-in in Office on Windows, you should [enable runtime logging](/office/dev/add-ins/testing/troubleshoot-manifest#use-runtime-logging-to-debug-your-add-in). Runtime logging delivers `console.log` statements to a separate log file you create to help you uncover issues. The statements cover a variety of errors, including errors pertaining to your add-in's XML manifest file, runtime conditions, or installation of your custom functions.  For more information about runtime logging, see [Use runtime logging to debug your add-in](/office/dev/add-ins/testing/troubleshoot-manifest#use-runtime-logging-to-debug-your-add-in).  
+If you are testing your add-in in Office on Windows, you should [enable runtime logging](../testing/runtime-logging.md). Runtime logging delivers `console.log` statements to a separate log file you create to help you uncover issues. The statements cover a variety of errors, including errors pertaining to your add-in's XML manifest file, runtime conditions, or installation of your custom functions.  For more information about runtime logging, see [Debug your add-in with runtime logging](../testing/runtime-logging.md).
 
 ### Check for Excel error messages
 
@@ -29,7 +29,7 @@ Generally, these errors correspond to the errors you might already be familiar w
 
 ## Clear the Office cache
 
-Information about custom functions is cached by Office. Sometimes while developing and repeatedly reloading an add-in with custom functions your changes may not appear. You can fix this by clearing the Office cache. For more information, see the "Clear the Office cache" section in the article [Validate and troubleshoot issues with your manifest](../testing/troubleshoot-manifest.md#clear-the-office-cache).
+Information about custom functions is cached by Office. Sometimes while developing and repeatedly reloading an add-in with custom functions your changes may not appear. You can fix this by clearing the Office cache. For more information, see [Clear the Office cache](../testing/clear-cache).
 
 ## Common issues
 

--- a/docs/testing/clear-cache.md
+++ b/docs/testing/clear-cache.md
@@ -26,7 +26,7 @@ To clear the Office cache on iOS, call `window.location.reload(true)` from JavaS
 ## See also
 
 - [Office Add-ins XML manifest](../develop/add-in-manifests.md)
-- [Validate and troubleshoot issues with your manifest](troubleshoot-manifest.md)
+- [Validate an Office Add-in's manifest](troubleshoot-manifest.md)
 - [Debug your add-in with runtime logging](runtime-logging.md)
 - [Sideload Office Add-ins for testing](sideload-office-add-ins-for-testing.md)
 - [Debug Office Add-ins](debug-add-ins-using-f12-developer-tools-on-windows-10.md)

--- a/docs/testing/clear-cache.md
+++ b/docs/testing/clear-cache.md
@@ -9,7 +9,7 @@ localization_priority: Priority
 
 You can remove an add-in that you've previously sideloaded on Windows, Mac, or iOS by clearing the Office cache on your computer. 
 
-If you make changes to your add-in's manifest (for example, update file names of icons or text of add-in commands), you should clear the Office cache and then sideload the updated manifest. Doing so will allow Office to correctly render the changes you've made to the add-in.
+Additionally, if you make changes to your add-in's manifest (for example, update file names of icons or text of add-in commands), you should clear the Office cache and then re-sideload the add-in using updated manifest. Doing so will allow Office to render the add-in as it's described by the updated manifest.
 
 ## Clear the Office cache on Windows
 
@@ -19,7 +19,7 @@ To clear the Office cache on Windows, delete the contents of the folder `%LOCALA
 
 [!include[additional cache folders on Mac](../includes/mac-cache-folders.md)]
 
-##  Clear the Office cache on iOS:
+##  Clear the Office cache on iOS
 
 To clear the Office cache on iOS, call `window.location.reload(true)` from JavaScript in the add-in to force a reload. Alternatively, you can reinstall Office.
 

--- a/docs/testing/clear-cache.md
+++ b/docs/testing/clear-cache.md
@@ -1,0 +1,32 @@
+---
+title: Clear the Office cache
+description: Learn how to clear the Office cache on your computer.
+ms.date: 12/31/2019
+localization_priority: Priority
+---
+
+# Clear the Office cache
+
+You can remove an add-in that you've previously sideloaded on Windows, Mac, or iOS by clearing the Office cache on your computer. 
+
+If you make changes to your add-in's manifest (for example, update file names of icons or text of add-in commands), you should clear the Office cache and then sideload the updated manifest. Doing so will allow Office to correctly render the changes you've made to the add-in.
+
+## Clear the Office cache on Windows
+
+To clear the Office cache on Windows, delete the contents of the folder `%LOCALAPPDATA%\Microsoft\Office\16.0\Wef\`.
+
+## Clear the Office cache on Mac
+
+[!include[additional cache folders on Mac](../includes/mac-cache-folders.md)]
+
+##  Clear the Office cache on iOS:
+
+To clear the Office cache on iOS, call `window.location.reload(true)` from JavaScript in the add-in to force a reload. Alternatively, you can reinstall Office.
+
+## See also
+
+- [Office Add-ins XML manifest](../develop/add-in-manifests.md)
+- [Validate and troubleshoot issues with your manifest](troubleshoot-manifest.md)
+- [Debug your add-in with runtime logging](runtime-logging.md)
+- [Sideload Office Add-ins for testing](sideload-office-add-ins-for-testing.md)
+- [Debug Office Add-ins](debug-add-ins-using-f12-developer-tools-on-windows-10.md)

--- a/docs/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins.md
+++ b/docs/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins.md
@@ -1,7 +1,7 @@
 ---
 title: Sideload Office Add-ins for testing
 description: ''
-ms.date: 12/06/2019
+ms.date: 12/31/2019
 localization_priority: Priority
 ---
 
@@ -117,5 +117,5 @@ The following video walks you through the process of sideloading your add-in in 
 ## See also
 
 - [Validate and troubleshoot issues with your manifest](troubleshoot-manifest.md)
+- [Clear the Office cache](clear-cache.md)
 - [Publish your Office Add-in](../publish/publish.md)
-    

--- a/docs/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins.md
+++ b/docs/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins.md
@@ -116,6 +116,6 @@ The following video walks you through the process of sideloading your add-in in 
 
 ## See also
 
-- [Validate and troubleshoot issues with your manifest](troubleshoot-manifest.md)
+- [Validate an Office Add-in's manifest](troubleshoot-manifest.md)
 - [Clear the Office cache](clear-cache.md)
 - [Publish your Office Add-in](../publish/publish.md)

--- a/docs/testing/runtime-logging.md
+++ b/docs/testing/runtime-logging.md
@@ -1,0 +1,144 @@
+---
+title: Debug your add-in with runtime logging
+description: Learn how to use runtime logging to debug your add-in.
+ms.date: 12/31/2019
+localization_priority: Priority
+---
+
+# Debug your add-in with runtime logging
+
+You can use runtime logging to debug your add-in's manifest as well as several installation errors. This feature can help you identify and fix issues with your manifest that are not detected by XSD schema validation, such as a mismatch between resource IDs. Runtime logging is particularly  useful for debugging add-ins that implement add-in commands and Excel custom functions.   
+
+> [!NOTE]
+> The runtime logging feature is currently available for Office 2016 desktop.
+
+> [!IMPORTANT]
+> Runtime Logging affects performance. Turn it on only when you need to debug issues with your add-in manifest.
+
+## Use runtime logging from the command line
+
+Enabling runtime logging from the command line is the fastest way to use this logging tool. These use npx, which is provided by default as part of npm@5.2.0+. If you have an earlier version of [npm](https://www.npmjs.com/), try [Runtime logging on Windows](#runtime-logging-on-windows) or [Runtime logging on Mac](#runtime-logging-on-mac) instructions, or [install npx](https://www.npmjs.com/package/npx).
+
+- To enable runtime logging:
+    ```command&nbsp;line
+	npx office-addin-dev-settings runtime-log --enable
+	```
+- To enable runtime logging only for a specific file, use the same command with a filename:
+
+    ```command&nbsp;line
+	npx office-addin-dev-settings runtime-log --enable [filename.txt]
+	```
+
+- To disable runtime logging:
+
+    ```command&nbsp;line
+	npx office-addin-dev-settings runtime-log --disable
+	```
+
+- To display whether runtime logging is enabled:
+
+    ```command&nbsp;line
+	npx office-addin-dev-settings runtime-log
+	```
+
+- To display help within the command line for runtime logging:
+
+    ```command&nbsp;line
+	npx office-addin-dev-settings runtime-log --help
+	```
+
+## Runtime logging on Windows
+
+1. Make sure that you are running Office 2016 desktop build **16.0.7019** or later. 
+
+2. Add the `RuntimeLogging` registry key under `HKEY_CURRENT_USER\SOFTWARE\Microsoft\Office\16.0\WEF\Developer\`. 
+
+    > [!NOTE]
+    > If the `Developer` key (folder) does not already exist under `HKEY_CURRENT_USER\SOFTWARE\Microsoft\Office\16.0\WEF\`, complete the following steps to create it: 
+	> 1. Right-click the **WEF** key (folder) and select **New** > **Key**.
+	> 2. Name the new key **Developer**.
+
+3. Set the default value of the **RuntimeLogging** key to the full path of the file where you want the log to be written. For an example, see [EnableRuntimeLogging.zip](https://github.com/OfficeDev/Office-Add-in-Commands-Samples/raw/master/Tools/RuntimeLogging/EnableRuntimeLogging.zip). 
+
+    > [!NOTE]
+    > The directory in which the log file will be written must already exist, and you must have write permissions to it. 
+ 
+The following image shows what the registry should look like. To turn the feature off, remove the `RuntimeLogging` key from the registry. 
+
+![Screenshot of the registry editor with a RuntimeLogging registry key](http://i.imgur.com/Sa9TyI6.png)
+
+## Runtime logging on Mac
+
+1. Make sure that you are running Office 2016 desktop build **16.27** (19071500) or later.
+
+2. Open **Terminal** and set a runtime logging preference by using the `defaults` command:
+    
+	```command&nbsp;line
+	defaults write <bundle id> CEFRuntimeLoggingFile -string <file_name>
+	```
+
+	`<bundle id>` identifies which the host for which to enable runtime logging. `<file_name>` is the name of the text file to which the log will be written.
+
+	Set `<bundle id>` to one of the following values to enable runtime logging for the corresponding host:
+
+	- `com.microsoft.Word`
+	- `com.microsoft.Excel`
+	- `com.microsoft.Powerpoint`
+	- `com.microsoft.Outlook`
+
+The following example enables runtime logging for Word and then opens the log file:
+
+```command&nbsp;line
+defaults write com.microsoft.Word CEFRuntimeLoggingFile -string "runtime_logs.txt"
+open ~/library/Containers/com.microsoft.Word/Data/runtime_logs.txt
+```
+
+> [!NOTE] 
+> You'll need to restart Office after running the `defaults` command to enable runtime logging.
+
+To turn off runtime logging, use the `defaults delete` command:
+
+```command&nbsp;line
+defaults delete <bundle id> CEFRuntimeLoggingFile
+```
+
+The following example will turn off runtime logging for Word:
+
+```command&nbsp;line
+defaults delete com.microsoft.Word CEFRuntimeLoggingFile
+```
+
+## Use runtime logging to troubleshoot issues with your manifest
+
+To use runtime logging to troubleshoot issues loading an add-in:
+ 
+1. [Sideload your add-in](sideload-office-add-ins-for-testing.md) for testing. 
+
+	> [!NOTE]
+	> We recommend that you sideload only the add-in that you are testing to minimize the number of messages in the log file.
+
+2. If nothing happens and you don't see your add-in (and it's not appearing in the add-ins dialog box), open the log file.
+
+3. Search the log file for your add-in ID, which you define in your manifest. In the log file, this ID is labeled `SolutionId`. 
+
+In the following example, the log file identifies a control that points to a resource file that doesn't exist. For this example, the fix would be to correct the typo in the manifest or to add the missing resource.
+
+![Screenshot of a log file with an entry that specifies a Resource ID that is not found](http://i.imgur.com/f8bouLA.png) 
+
+## Known issues with runtime logging
+
+You might see messages in the log file that are confusing or that are classified incorrectly. For example:
+
+- The message `Medium Current host not in add-in's host list` followed by `Unexpected Parsed manifest targeting different host` is incorrectly classified as an error.
+
+- If you see the message `Unexpected Add-in is missing required manifest fields	DisplayName` and it doesn't contain a SolutionId, the error is most likely not related to the add-in you are debugging. 
+
+- Any `Monitorable` messages are expected errors from a system point of view. Sometimes they indicate an issue with your manifest, such as a misspelled element that was skipped but didn't cause the manifest to fail. 
+
+## See also
+
+- [Office Add-ins XML manifest](../develop/add-in-manifests.md)
+- [Validate and troubleshoot issues with your manifest](troubleshoot-manifest.md)
+- [Clear the Office cache](clear-cache.md)
+- [Sideload Office Add-ins for testing](sideload-office-add-ins-for-testing.md)
+- [Debug Office Add-ins](debug-add-ins-using-f12-developer-tools-on-windows-10.md)

--- a/docs/testing/runtime-logging.md
+++ b/docs/testing/runtime-logging.md
@@ -138,7 +138,7 @@ You might see messages in the log file that are confusing or that are classified
 ## See also
 
 - [Office Add-ins XML manifest](../develop/add-in-manifests.md)
-- [Validate and troubleshoot issues with your manifest](troubleshoot-manifest.md)
+- [Validate an Office Add-in's manifest](troubleshoot-manifest.md)
 - [Clear the Office cache](clear-cache.md)
 - [Sideload Office Add-ins for testing](sideload-office-add-ins-for-testing.md)
 - [Debug Office Add-ins](debug-add-ins-using-f12-developer-tools-on-windows-10.md)

--- a/docs/testing/testing-and-troubleshooting.md
+++ b/docs/testing/testing-and-troubleshooting.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshoot user errors with Office Add-ins
 description: ''
-ms.date: 11/26/2019
+ms.date: 12/31/2019
 localization_priority: Priority
 ---
 

--- a/docs/testing/testing-and-troubleshooting.md
+++ b/docs/testing/testing-and-troubleshooting.md
@@ -61,7 +61,7 @@ Verify that the latest Office updates are installed, or download the [update for
 
 ## Add-in doesn't load in task pane or other issues with the add-in manifest
 
-See [Validate and troubleshoot issues with your manifest](troubleshoot-manifest.md) and [Debug your add-in with runtime logging](runtime-logging.md) to debug add-in manifest issues.
+See [Validate an Office Add-in's manifest](troubleshoot-manifest.md) and [Debug your add-in with runtime logging](runtime-logging.md) to debug add-in manifest issues.
 
 
 ## Add-in dialog box cannot be displayed
@@ -138,5 +138,5 @@ del /s /f /q %LOCALAPPDATA%\Packages\Microsoft.Win32WebViewHost_cw5n1h2txyewy\AC
 - [Debug add-ins in Office on the web](debug-add-ins-in-office-online.md) 
 - [Sideload an Office Add-in on iPad and Mac](sideload-an-office-add-in-on-ipad-and-mac.md)  
 - [Debug Office Add-ins on iPad and Mac](debug-office-add-ins-on-ipad-and-mac.md)  
-- [Validate and troubleshoot issues with your manifest](troubleshoot-manifest.md)
+- [Validate an Office Add-in's manifest](troubleshoot-manifest.md)
 - [Debug your add-in with runtime logging](runtime-logging.md)

--- a/docs/testing/testing-and-troubleshooting.md
+++ b/docs/testing/testing-and-troubleshooting.md
@@ -61,7 +61,7 @@ Verify that the latest Office updates are installed, or download the [update for
 
 ## Add-in doesn't load in task pane or other issues with the add-in manifest
 
-See [Validate and troubleshoot issues with your manifest](troubleshoot-manifest.md) to debug add-in manifest issues.
+See [Validate and troubleshoot issues with your manifest](troubleshoot-manifest.md) and [Debug your add-in with runtime logging](runtime-logging.md) to debug add-in manifest issues.
 
 
 ## Add-in dialog box cannot be displayed
@@ -139,3 +139,4 @@ del /s /f /q %LOCALAPPDATA%\Packages\Microsoft.Win32WebViewHost_cw5n1h2txyewy\AC
 - [Sideload an Office Add-in on iPad and Mac](sideload-an-office-add-in-on-ipad-and-mac.md)  
 - [Debug Office Add-ins on iPad and Mac](debug-office-add-ins-on-ipad-and-mac.md)  
 - [Validate and troubleshoot issues with your manifest](troubleshoot-manifest.md)
+- [Debug your add-in with runtime logging](runtime-logging.md)

--- a/docs/testing/troubleshoot-manifest.md
+++ b/docs/testing/troubleshoot-manifest.md
@@ -1,11 +1,11 @@
 ---
-title: Validate and troubleshoot issues with your manifest
+title: Validate an Office Add-in's manifest
 description: Learn how to validate an Office Add-in's manifest.
 ms.date: 12/31/2019
 localization_priority: Priority
 ---
 
-# Validate and troubleshoot issues with your manifest
+# Validate an Office Add-in's manifest
 
 You may want to validate your add-in's manifest file to ensure that it's correct and complete. Validation can also identify issues that are causing the error "Your add-in manifest is not valid" when you attempt to sideload your add-in. This article describes multiple ways to validate the manifest file.
 

--- a/docs/testing/troubleshoot-manifest.md
+++ b/docs/testing/troubleshoot-manifest.md
@@ -1,6 +1,6 @@
 ---
 title: Validate an Office Add-in's manifest
-description: Learn how to validate an Office Add-in's manifest.
+description: Learn how to validate an Office Add-in's manifest using the XML schema and other tools.
 ms.date: 12/31/2019
 localization_priority: Priority
 ---

--- a/docs/testing/troubleshoot-manifest.md
+++ b/docs/testing/troubleshoot-manifest.md
@@ -9,6 +9,9 @@ localization_priority: Priority
 
 You may want to validate your add-in's manifest file to ensure that it's correct and complete. Validation can also identify issues that are causing the error "Your add-in manifest is not valid" when you attempt to sideload your add-in. This article describes multiple ways to validate the manifest file.
 
+> [!NOTE]
+> For details about using runtime logging to troubleshoot issues with your add-in's manifest, see [Debug your add-in with runtime logging](runtime-logging.md).
+
 ## Validate your manifest with the Yeoman generator for Office Add-ins
 
 If you used the [Yeoman generator for Office Add-ins](https://www.npmjs.com/package/generator-office) to create your add-in, you can also use it to validate your project's manifest file. Run the following command in the root directory of your project:

--- a/docs/testing/troubleshoot-manifest.md
+++ b/docs/testing/troubleshoot-manifest.md
@@ -1,13 +1,13 @@
 ---
 title: Validate and troubleshoot issues with your manifest
-description: Use these methods to validate the Office Add-ins manifest.
-ms.date: 11/26/2019
+description: Learn how to validate an Office Add-in's manifest.
+ms.date: 12/31/2019
 localization_priority: Priority
 ---
 
 # Validate and troubleshoot issues with your manifest
 
-You may want to validate your add-in's manifest file to ensure that it's correct and complete. Validation can also identify issues that are causing the error "Your add-in manifest is not valid" when you attempt to sideload your add-in. This article describes multiple ways to validate the manifest file and troubleshoot problems with your add-in.
+You may want to validate your add-in's manifest file to ensure that it's correct and complete. Validation can also identify issues that are causing the error "Your add-in manifest is not valid" when you attempt to sideload your add-in. This article describes multiple ways to validate the manifest file.
 
 ## Validate your manifest with the Yeoman generator for Office Add-ins
 
@@ -53,152 +53,10 @@ You can validate the manifest file against the [XML Schema Definition (XSD)](htt
 	xmllint --noout --schema XSD_FILE XML_FILE
 	```
 
-## Use runtime logging to debug your add-in
-
-You can use runtime logging to debug your add-in's manifest as well as several installation errors. This feature can help you identify and fix issues with your manifest that are not detected by XSD schema validation, such as a mismatch between resource IDs. Runtime logging is particularly  useful for debugging add-ins that implement add-in commands and Excel custom functions.   
-
-> [!NOTE]
-> The runtime logging feature is currently available for Office 2016 desktop.
-
-> [!IMPORTANT]
-> Runtime Logging affects performance. Turn it on only when you need to debug issues with your add-in manifest.
-
-### Use runtime logging from the command line
-
-Enabling runtime logging from the command line is the fastest way to use this logging tool. These use npx, which is provided by default as part of npm@5.2.0+. If you have an earlier version of [npm](https://www.npmjs.com/), try [Runtime logging on Windows](#runtime-logging-on-windows) or [Runtime logging on Mac](#runtime-logging-on-mac) instructions, or [install npx](https://www.npmjs.com/package/npx).
-
-- To enable runtime logging:
-    ```command&nbsp;line
-	npx office-addin-dev-settings runtime-log --enable
-	```
-- To enable runtime logging only for a specific file, use the same command with a filename:
-
-    ```command&nbsp;line
-	npx office-addin-dev-settings runtime-log --enable [filename.txt]
-	```
-
-- To disable runtime logging:
-
-    ```command&nbsp;line
-	npx office-addin-dev-settings runtime-log --disable
-	```
-
-- To display whether runtime logging is enabled:
-
-    ```command&nbsp;line
-	npx office-addin-dev-settings runtime-log
-	```
-
-- To display help within the command line for runtime logging:
-
-    ```command&nbsp;line
-	npx office-addin-dev-settings runtime-log --help
-	```
-
-### Runtime logging on Windows
-
-1. Make sure that you are running Office 2016 desktop build **16.0.7019** or later. 
-
-2. Add the `RuntimeLogging` registry key under `HKEY_CURRENT_USER\SOFTWARE\Microsoft\Office\16.0\WEF\Developer\`. 
-
-    > [!NOTE]
-    > If the `Developer` key (folder) does not already exist under `HKEY_CURRENT_USER\SOFTWARE\Microsoft\Office\16.0\WEF\`, complete the following steps to create it: 
-	> 1. Right-click the **WEF** key (folder) and select **New** > **Key**.
-	> 2. Name the new key **Developer**.
-
-3. Set the default value of the **RuntimeLogging** key to the full path of the file where you want the log to be written. For an example, see [EnableRuntimeLogging.zip](https://github.com/OfficeDev/Office-Add-in-Commands-Samples/raw/master/Tools/RuntimeLogging/EnableRuntimeLogging.zip). 
-
-    > [!NOTE]
-    > The directory in which the log file will be written must already exist, and you must have write permissions to it. 
- 
-The following image shows what the registry should look like. To turn the feature off, remove the `RuntimeLogging` key from the registry. 
-
-![Screenshot of the registry editor with a RuntimeLogging registry key](http://i.imgur.com/Sa9TyI6.png)
-
-### Runtime logging on Mac
-
-1. Make sure that you are running Office 2016 desktop build **16.27** (19071500) or later.
-
-2. Open **Terminal** and set a runtime logging preference by using the `defaults` command:
-    
-	```command&nbsp;line
-	defaults write <bundle id> CEFRuntimeLoggingFile -string <file_name>
-	```
-
-	`<bundle id>` identifies which the host for which to enable runtime logging. `<file_name>` is the name of the text file to which the log will be written.
-
-	Set `<bundle id>` to one of the following values to enable runtime logging for the corresponding host:
-
-	- `com.microsoft.Word`
-	- `com.microsoft.Excel`
-	- `com.microsoft.Powerpoint`
-	- `com.microsoft.Outlook`
-
-The following example enables runtime logging for Word and then opens the log file:
-
-```command&nbsp;line
-defaults write com.microsoft.Word CEFRuntimeLoggingFile -string "runtime_logs.txt"
-open ~/library/Containers/com.microsoft.Word/Data/runtime_logs.txt
-```
-
-> [!NOTE] 
-> You'll need to restart Office after running the `defaults` command to enable runtime logging.
-
-To turn off runtime logging, use the `defaults delete` command:
-
-```command&nbsp;line
-defaults delete <bundle id> CEFRuntimeLoggingFile
-```
-
-The following example will turn off runtime logging for Word:
-
-```command&nbsp;line
-defaults delete com.microsoft.Word CEFRuntimeLoggingFile
-```
-
-### To troubleshoot issues with your manifest
-
-To use runtime logging to troubleshoot issues loading an add-in:
- 
-1. [Sideload your add-in](sideload-office-add-ins-for-testing.md) for testing. 
-
-	> [!NOTE]
-	> We recommend that you sideload only the add-in that you are testing to minimize the number of messages in the log file.
-
-2. If nothing happens and you don't see your add-in (and it's not appearing in the add-ins dialog box), open the log file.
-
-3. Search the log file for your add-in ID, which you define in your manifest. In the log file, this ID is labeled `SolutionId`. 
-
-In the following example, the log file identifies a control that points to a resource file that doesn't exist. For this example, the fix would be to correct the typo in the manifest or to add the missing resource.
-
-![Screenshot of a log file with an entry that specifies a Resource ID that is not found](http://i.imgur.com/f8bouLA.png) 
-
-### Known issues with runtime logging
-
-You might see messages in the log file that are confusing or that are classified incorrectly. For example:
-
-- The message `Medium Current host not in add-in's host list` followed by `Unexpected Parsed manifest targeting different host` is incorrectly classified as an error.
-
-- If you see the message `Unexpected Add-in is missing required manifest fields	DisplayName` and it doesn't contain a SolutionId, the error is most likely not related to the add-in you are debugging. 
-
-- Any `Monitorable` messages are expected errors from a system point of view. Sometimes they indicate an issue with your manifest, such as a misspelled element that was skipped but didn't cause the manifest to fail. 
-
-## Clear the Office cache
-
-If changes you've made in the manifest, such as file names of ribbon button icons or text of add-in commands, do not seem to take effect, try clearing the Office cache on your computer. 
-
-#### For Windows:
-Delete the contents of the folder `%LOCALAPPDATA%\Microsoft\Office\16.0\Wef\`.
-
-#### For Mac:
-
-[!include[additional cache folders on Mac](../includes/mac-cache-folders.md)]
-
-#### For iOS:
-Call `window.location.reload(true)` from JavaScript in the add-in to force a reload. Alternatively, you can reinstall Office.
-
 ## See also
 
 - [Office Add-ins XML manifest](../develop/add-in-manifests.md)
+- [Clear the Office cache](clear-cache.md)
+- [Debug your add-in with runtime logging](runtime-logging.md)
 - [Sideload Office Add-ins for testing](sideload-office-add-ins-for-testing.md)
 - [Debug Office Add-ins](debug-add-ins-using-f12-developer-tools-on-windows-10.md)

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -243,11 +243,15 @@
         href: testing/sideload-an-office-add-in-on-ipad-and-mac.md
       - name: Debug on Mac
         href: testing/debug-office-add-ins-on-ipad-and-mac.md
+    - name: Clear the Office cache
+      href: testing/clear-cache.md
+    - name: Debug with runtime logging
+      href: testing/runtime-logging.md
     - name: Troubleshoot user errors
       href: testing/testing-and-troubleshooting.md
     - name: Usability testing
       href: develop/usability-testing.md
-    - name: Validate an add-in manifest and troubleshoot issues
+    - name: Validate an add-in's manifest
       href: testing/troubleshoot-manifest.md
 
   - name: Publish


### PR DESCRIPTION
This PR moves information about "clearing the Office cache" and "debugging with runtime logging" into separate articles (for improved discoverability of this important info), making it so that the "validate an add-in's manifest" article contains only information relevant to that topic.

(re internal work item # 2660004)