### PR TITLE
[excel, word] (Requirement sets) Simplifying note about perpetual versions

### DIFF
--- a/docs/reference/requirement-sets/excel-api-requirement-sets.md
+++ b/docs/reference/requirement-sets/excel-api-requirement-sets.md
@@ -1,7 +1,7 @@
 ---
 title: Excel JavaScript API requirement sets
 description: 'Office Add-in requirement set information for Excel builds'
-ms.date: 01/03/2020
+ms.date: 01/06/2020
 ms.prod: excel
 localization_priority: Priority
 ---
@@ -35,10 +35,10 @@ Excel add-ins run across multiple versions of Office, including Office 2016 or l
 | [ExcelApi 1.1](excel-api-1-1-requirement-set.md)  | Version 1509 (Build 4266.1001) or later   | 1.19 or later | 15.20 or later | January 2016 |
 
 > [!NOTE]
-> Users on perpetual versions of Office will be restricted to certain requirement set.
+> Perpetual versions of Office support requirement sets as follows:
 >
-> - Office 2019 contains ExcelApi 1.8 and earlier.
-> - Office 2016 only contains the ExcelApi 1.1 requirement set.
+> - Office 2019 supports ExcelApi 1.8 and earlier.
+> - Office 2016 only supports the ExcelApi 1.1 requirement set.
 
 ## Office versions and build numbers
 

--- a/docs/reference/requirement-sets/excel-api-requirement-sets.md
+++ b/docs/reference/requirement-sets/excel-api-requirement-sets.md
@@ -1,7 +1,7 @@
 ---
 title: Excel JavaScript API requirement sets
 description: 'Office Add-in requirement set information for Excel builds'
-ms.date: 12/24/2019
+ms.date: 01/03/2020
 ms.prod: excel
 localization_priority: Priority
 ---
@@ -35,7 +35,10 @@ Excel add-ins run across multiple versions of Office, including Office 2016 or l
 | [ExcelApi 1.1](excel-api-1-1-requirement-set.md)  | Version 1509 (Build 4266.1001) or later   | 1.19 or later | 15.20 or later | January 2016 |
 
 > [!NOTE]
-> The build number for Office 2016 installed via MSI is 16.0.4266.1001. This version only contains the ExcelApi 1.1 requirement set.
+> Users on perpetual versions of Office will be restricted to certain requirement set.
+>
+> - Office 2019 contains ExcelApi 1.8 and earlier.
+> - Office 2016 only contains the ExcelApi 1.1 requirement set.
 
 ## Office versions and build numbers
 

--- a/docs/reference/requirement-sets/word-api-requirement-sets.md
+++ b/docs/reference/requirement-sets/word-api-requirement-sets.md
@@ -1,7 +1,7 @@
 ---
 title: Word JavaScript API requirement sets
 description: 'Office Add-in requirement set information for Word builds'
-ms.date: 01/03/2020
+ms.date: 01/06/2020
 ms.prod: word
 localization_priority: Priority
 ---
@@ -27,9 +27,10 @@ Word add-ins run across multiple versions of Office, including Office 2016 or la
 | [WordApi 1.1](word-api-1-1-requirement-set.md) | Version 1509 (Build 4266.1001) or later| January 2016, 1.18 or later | January 2016, 15.19 or later| September 2016 |
 
 > [!NOTE]
-> Users on perpetual versions of Office will be restricted to certain requirement set.
+> Perpetual versions of Office support requirement sets as follows:
 >
-> - Office 2016 only contains the WordApi 1.1 requirement set.
+> - Office 2019 supports WordApi 1.3 and earlier.
+> - Office 2016 only supports the WordApi 1.1 requirement set.
 
 ## Office versions and build numbers
 

--- a/docs/reference/requirement-sets/word-api-requirement-sets.md
+++ b/docs/reference/requirement-sets/word-api-requirement-sets.md
@@ -1,7 +1,7 @@
 ---
 title: Word JavaScript API requirement sets
 description: 'Office Add-in requirement set information for Word builds'
-ms.date: 07/17/2019
+ms.date: 01/03/2020
 ms.prod: word
 localization_priority: Priority
 ---
@@ -27,7 +27,9 @@ Word add-ins run across multiple versions of Office, including Office 2016 or la
 | [WordApi 1.1](word-api-1-1-requirement-set.md) | Version 1509 (Build 4266.1001) or later| January 2016, 1.18 or later | January 2016, 15.19 or later| September 2016 |
 
 > [!NOTE]
-> The build number for Office 2016 installed via MSI is 16.0.4266.1001. This version only contains the WordApi 1.1 requirement set.
+> Users on perpetual versions of Office will be restricted to certain requirement set.
+>
+> - Office 2016 only contains the WordApi 1.1 requirement set.
 
 ## Office versions and build numbers
 


### PR DESCRIPTION
I want to make these notes more direct and clear, to lessen the confusion about Office 2016/2019 restrictions.