### PR TITLE
Added missing descriptions to quickstarts

### DIFF
--- a/docs/quickstarts/excel-quickstart-angular.md
+++ b/docs/quickstarts/excel-quickstart-angular.md
@@ -1,6 +1,6 @@
 ---
 title: Build an Excel task pane add-in using Angular
-description: 
+description: Learn how to build a simple Excel task pane add-in by using the Office JS API and Angular.
 ms.date: 01/16/2020
 ms.prod: excel
 localization_priority: Priority

--- a/docs/quickstarts/excel-quickstart-react.md
+++ b/docs/quickstarts/excel-quickstart-react.md
@@ -1,6 +1,6 @@
 ---
 title: Build an Excel task pane add-in using React
-description: 
+description: Learn how to build a simple Excel task pane add-in by using the Office JS API and React.
 ms.date: 01/16/2020
 ms.prod: excel
 localization_priority: Priority

--- a/docs/quickstarts/excel-quickstart-vue.md
+++ b/docs/quickstarts/excel-quickstart-vue.md
@@ -1,6 +1,6 @@
 ---
 title: Build an Excel task pane add-in using Vue
-description:
+description: Learn how to build a simple Excel task pane add-in by using the Office JS API and Vue.
 ms.date: 01/16/2020
 ms.prod: excel
 localization_priority: Priority

--- a/docs/quickstarts/onenote-quickstart.md
+++ b/docs/quickstarts/onenote-quickstart.md
@@ -1,6 +1,6 @@
 ---
 title: Build your first OneNote task pane add-in
-description: 
+description: Learn how to build a simple OneNote task pane add-in by using the Office JS API.
 ms.date: 01/16/2020
 ms.prod: onenote
 localization_priority: Priority

--- a/docs/quickstarts/project-quickstart.md
+++ b/docs/quickstarts/project-quickstart.md
@@ -1,6 +1,6 @@
 ---
 title: Build your first Project task pane add-in
-description: 
+description: Learn how to build a simple Project task pane add-in by using the Office JS API.
 ms.date: 01/16/2020
 ms.prod: project
 localization_priority: Priority


### PR DESCRIPTION
Added descriptions for a few of the quickstarts that didn't have them. These descriptions were modeled after the Word quickstart description, and will help make sure we display content properly when we pull the quickstarts into the dev program.