### PR TITLE
[excel] (Range) Adding a `Range.moveTo` sample

### DIFF
--- a/docs/excel/excel-add-ins-comments.md
+++ b/docs/excel/excel-add-ins-comments.md
@@ -1,7 +1,7 @@
 ---
 title: Work with comments using the Excel JavaScript API
-description: ''
-ms.date: 10/22/2019
+description: 'Information on using the APIs to add, remove, and edit comments and comment threads.'
+ms.date: 02/11/2020
 localization_priority: Normal
 ---
 
@@ -106,7 +106,7 @@ Excel.run(function (context) {
 });
 ```
 
-## Resolve comment threads
+## Resolve comment threads ([preview](../reference/requirement-sets/excel-preview-apis.md))
 
 A comment thread has a configurable boolean value, `resolved`, to indicate if it is resolved. A value of `true` means the comment thread is resolved. A value of `false` means the comment thread is either new or reopened.
 
@@ -164,7 +164,7 @@ Excel.run(function (context) {
 });
 ```
 
-## Mentions (preview)
+## Mentions ([online-only](../reference/requirement-sets/excel-api-online-requirement-set.md))
 
 > [!NOTE]
 > The comment mention APIs are currently available only in public preview. [!INCLUDE [Information about using preview APIs](../includes/using-excel-preview-apis.md)]

--- a/docs/excel/excel-add-ins-comments.md
+++ b/docs/excel/excel-add-ins-comments.md
@@ -20,7 +20,7 @@ Comments within a workbook are tracked by the `Workbook.comments` property. This
 Use the `CommentCollection.add` method to add comments to a workbook. This method takes up to three parameters:
 
 - `cellAddress`: The cell where the comment is added. This can either be a string or [Range](/javascript/api/excel/excel.range) object. The range must be a single cell.
-- `content`: The comment's content. Use a string for plain text comments. Use a [CommentRichContent](/javascript/api/excel/excel.commentrichcontent) object for comments with [mentions](#mentions-preview).
+- `content`: The comment's content. Use a string for plain text comments. Use a [CommentRichContent](/javascript/api/excel/excel.commentrichcontent) object for comments with [mentions](#mentions-online-only).
 - `contentType`: A [ContentType](/javascript/api/excel/excel.contenttype) enum specifying type of content. The default value is `ContentType.plain`.
 
 The following code sample adds a comment to cell **A2**.

--- a/docs/excel/excel-add-ins-events.md
+++ b/docs/excel/excel-add-ins-events.md
@@ -1,7 +1,7 @@
 ---
 title: Work with Events using the Excel JavaScript API
-description: ''
-ms.date: 10/22/2019
+description: 'A list of events for Excel JavaScript objects. This includes information on using event handlers and the associated patterns.'
+ms.date: 02/11/2020
 localization_priority: Normal
 ---
 
@@ -106,7 +106,7 @@ function handleChange(event)
 
 ## Remove an event handler
 
-The following code sample registers an event handler for the `onSelectionChanged` event in the worksheet named **Sample** and defines the `handleSelectionChange` function that will run when the event occurs. It also defines the `remove()` function that can subsequently be called to remove that event handler.
+The following code sample registers an event handler for the `onSelectionChanged` event in the worksheet named **Sample** and defines the `handleSelectionChange` function that will run when the event occurs. It also defines the `remove()` function that can subsequently be called to remove that event handler. Note that the `RequestContext` used to create the event handler is needed to remove it.
 
 ```js
 var eventResult;

--- a/docs/excel/excel-add-ins-ranges-advanced.md
+++ b/docs/excel/excel-add-ins-ranges-advanced.md
@@ -167,9 +167,11 @@ Excel.run(function (context) {
 })
 ```
 
+## Cut, copy, and paste
+
 ## Copy and paste
 
-The [Range.copyFrom](/javascript/api/excel/excel.range#copyfrom-sourcerange--copytype--skipblanks--transpose-) method replicates the copy-and-paste behavior of the Excel UI. The range object that `copyFrom` is called on is the destination. The source to be copied is passed as a range or a string address representing a range.
+The [Range.copyFrom](/javascript/api/excel/excel.range#copyfrom-sourcerange--copytype--skipblanks--transpose-) method replicates the **Copy** and **Paste** actions of the Excel UI. The range object that `copyFrom` is called on is the destination. The source to be copied is passed as a range or a string address representing a range.
 
 The following code sample copies the data from **A1:E1** into the range starting at **G1** (which ends up pasting into **G1:K1**).
 
@@ -228,7 +230,7 @@ Excel.run(function (context) {
 
 ![Data in Excel after range’s copy method has been run](../images/excel-range-copyfrom-skipblanks-after.png)
 
-### Move cells ([online-only](../reference/requirement-sets/excel-api-online-requirement-set.md))
+### Cut and paste (move) cells ([online-only](../reference/requirement-sets/excel-api-online-requirement-set.md))
 
 The [Range.moveTo](/javascript/api/excel/excel.range#moveto-destinationrange-) method moves cells to a new location in the workbook. This cell movement behavior works the same as when cells are moved by [dragging the range border](https://support.office.com/article/Move-or-copy-cells-and-cell-contents-803d65eb-6a3e-4534-8c6f-ff12d1c4139e) or when taking the **Cut** and **Paste** actions. Both the formatting and values of the range are moved to the location specified as the `destinationRange` parameter.
 

--- a/docs/excel/excel-add-ins-ranges-advanced.md
+++ b/docs/excel/excel-add-ins-ranges-advanced.md
@@ -1,7 +1,7 @@
 ---
 title: Work with ranges using the Excel JavaScript API (advanced)
-description: ''
-ms.date: 10/22/2019
+description: 'Advanced range object functions and scenarios, such as special cells, remove duplicates, and working with dates.'
+ms.date: 02/11/2020
 localization_priority: Normal
 ---
 
@@ -227,6 +227,23 @@ Excel.run(function (context) {
 *After the preceding function has been run.*
 
 ![Data in Excel after range’s copy method has been run](../images/excel-range-copyfrom-skipblanks-after.png)
+
+### Move cells ([online-only](../reference/requirement-sets/excel-api-online-requirement-set.md))
+
+The [Range.moveTo](/javascript/api/excel/excel.range#moveto-destinationrange-) method moves cells to a new location in the workbook. This cell movement behavior works the same as when cells are moved by [dragging the range border](https://support.office.com/article/Move-or-copy-cells-and-cell-contents-803d65eb-6a3e-4534-8c6f-ff12d1c4139e) or when taking the **Cut** and **Paste** actions. Both the formatting and values of the range are moved to the location specified as the `destinationRange` parameter.
+
+The following code sample shows a range being moved with the `Range.moveTo` method. Note that if the destination range is smaller than the source, it will be expanded to encompass the source content.
+
+```js
+Excel.run(function (context) {
+    var sheet = context.workbook.worksheets.getActiveWorksheet();
+    sheet.getRange("F1").values = [["Moved Range"]];
+
+    // Move the cells "A1:E1" to "G1" (which fills the range "G1:K1").
+    sheet.getRange("A1:E1").moveTo("G1");
+    return context.sync();
+});
+```
 
 ## Remove duplicates
 

--- a/docs/excel/excel-add-ins-ranges-advanced.md
+++ b/docs/excel/excel-add-ins-ranges-advanced.md
@@ -169,7 +169,7 @@ Excel.run(function (context) {
 
 ## Cut, copy, and paste
 
-## Copy and paste
+### Copy and paste
 
 The [Range.copyFrom](/javascript/api/excel/excel.range#copyfrom-sourcerange--copytype--skipblanks--transpose-) method replicates the **Copy** and **Paste** actions of the Excel UI. The range object that `copyFrom` is called on is the destination. The source to be copied is passed as a range or a string address representing a range.
 


### PR DESCRIPTION
This also corrects the labeling of some preview or online-only features in the Comment article and adds a behavior clarification to the remove event handler section.