### PR TITLE
[testing] (Sideloading) Linking to cache clearing article

### DIFF
--- a/docs/testing/clear-cache.md
+++ b/docs/testing/clear-cache.md
@@ -7,20 +7,20 @@ localization_priority: Normal
 
 # Clear the Office cache
 
-You can remove an add-in that you've previously sideloaded on Windows, Mac, or iOS by clearing the Office cache on your computer. 
+You can remove an add-in that you've previously sideloaded on Windows, Mac, or iOS by clearing the Office cache on your computer.
 
 Additionally, if you make changes to your add-in's manifest (for example, update file names of icons or text of add-in commands), you should clear the Office cache and then re-sideload the add-in using updated manifest. Doing so will allow Office to render the add-in as it's described by the updated manifest.
 
 ## Clear the Office cache on Windows
 
-To remove all sideloaded add-ins from Excel, Word, and PowerPoint, delete the contents of the folder `%LOCALAPPDATA%\Microsoft\Office\16.0\Wef\`. 
+To remove all sideloaded add-ins from Excel, Word, and PowerPoint, delete the contents of the folder `%LOCALAPPDATA%\Microsoft\Office\16.0\Wef\`.
 
 To remove a sideloaded add-in from Outlook, use the steps outlined in [Sideload Outlook add-ins for testing](/outlook/add-ins/sideload-outlook-add-ins-for-testing) to find the add-in in the **Custom add-ins** section of the dialog box that lists your installed add-ins. Choose the ellipsis (`...`) for the the add-in and then choose **Remove** to remove that specific add-in.
 
 Additionally, to clear the Office cache on Windows 10 when the add-in is running in Microsoft Edge, you can use the Microsoft Edge DevTools.
 
 > [!TIP]
-> If you're just wanting the sideloaded add-in to reflect recent changes to its HTML or JavaScript source files, you shouldn't need to use the following steps to clear the cache. Instead, just put focus in the add-in's task pane (by clicking anywhere within the task pane) and then press **F5** to reload the add-in. 
+> If you're just wanting the sideloaded add-in to reflect recent changes to its HTML or JavaScript source files, you shouldn't need to use the following steps to clear the cache. Instead, just put focus in the add-in's task pane (by clicking anywhere within the task pane) and then press **F5** to reload the add-in.
 
 > [!NOTE]
 > To clear the Office cache using the following steps, your add-in must have a task pane. If your add-in is a UI-less add-in -- for example, one that uses the [on-send](/outlook/add-ins/outlook-on-send-addins) feature -- you'll need to add a task pane to your add-in that uses the same domain for [SourceLocation](../reference/manifest/sourcelocation.md), before you can use the following steps to clear the cache.
@@ -47,7 +47,7 @@ Additionally, to clear the Office cache on Windows 10 when the add-in is running
 
 [!include[additional cache folders on Mac](../includes/mac-cache-folders.md)]
 
-##  Clear the Office cache on iOS
+## Clear the Office cache on iOS
 
 To clear the Office cache on iOS, call `window.location.reload(true)` from JavaScript in the add-in to force a reload. Alternatively, you can reinstall Office.
 
@@ -58,4 +58,3 @@ To clear the Office cache on iOS, call `window.location.reload(true)` from JavaS
 - [Sideload Office Add-ins for testing](sideload-office-add-ins-for-testing.md)
 - [Office Add-ins XML manifest](../develop/add-in-manifests.md)
 - [Validate an Office Add-in's manifest](troubleshoot-manifest.md)
-

--- a/docs/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins.md
+++ b/docs/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins.md
@@ -1,7 +1,7 @@
 ---
 title: Sideload Office Add-ins for testing
 description: ''
-ms.date: 12/31/2019
+ms.date: 02/18/2020
 localization_priority: Normal
 ---
 
@@ -40,22 +40,22 @@ The following video walks you through the process of sideloading your add-in in 
 
 6. Choose the **Close** button to close the **Properties** dialog window.
 
-## Specify the shared folder as a trusted catalog 
+## Specify the shared folder as a trusted catalog
 
 ### Configure the trust manually
-      
+
 1. Open a new document in Excel, Word, PowerPoint, or Project.
-    
+
 2. Choose the **File** tab, and then choose **Options**.
-    
+
 3. Choose **Trust Center**, and then choose the **Trust Center Settings** button.
-    
+
 4. Choose **Trusted Add-in Catalogs**.
-    
-5. In the **Catalog Url** box, enter the full network path to the folder that you [shared](#share-a-folder) previously. If you failed to note the folder's full network path when you shared the folder, you can get it from the folder's **Properties** dialog window, as shown in the following screenshot. 
+
+5. In the **Catalog Url** box, enter the full network path to the folder that you [shared](#share-a-folder) previously. If you failed to note the folder's full network path when you shared the folder, you can get it from the folder's **Properties** dialog window, as shown in the following screenshot.
 
     ![folder Properties dialog with the Sharing tab and network path highlighted](../images/sideload-windows-properties-dialog-2.png)
-    
+
 6. After you've entered the full network path of the folder into the **Catalog Url** box, choose the **Add catalog** button.
 
 7. Select the **Show in Menu** check box for the newly-added item, and then choose the **OK** button to close the **Trust Center** dialog window. 
@@ -68,11 +68,11 @@ The following video walks you through the process of sideloading your add-in in 
 
 ### Configure the trust with a Registry script
 
-1. In a text editor, create a file named TrustNetworkShareCatalog.reg. 
+1. In a text editor, create a file named TrustNetworkShareCatalog.reg.
 
 2. Add the following content to the file:
 
-	```
+    ```
 	Windows Registry Editor Version 5.00
 	
 	[HKEY_CURRENT_USER\Software\Microsoft\Office\16.0\WEF\TrustedCatalogs\{-random-GUID-here-}]
@@ -82,10 +82,10 @@ The following video walks you through the process of sideloading your add-in in 
 	```
 3. Use one of the many online GUID generation tools, such as [GUID Generator](https://guidgenerator.com/), to generate a random GUID, and within the TrustNetworkShareCatalog.reg file, replace the string "-random-GUID-here-" *in both places* with the GUID. (The enclosing `{}` symbols should remain.)
 
-4. Replace the `Url` value with the full network path to the folder that you [shared](#share-a-folder) previously. (Note that any `\` characters in the URL must be doubled.) If you failed to note the folder's full network path when you shared the folder, you can get it from the folder's **Properties** dialog window, as shown in the following screenshot. 
+4. Replace the `Url` value with the full network path to the folder that you [shared](#share-a-folder) previously. (Note that any `\` characters in the URL must be doubled.) If you failed to note the folder's full network path when you shared the folder, you can get it from the folder's **Properties** dialog window, as shown in the following screenshot.
 
     ![folder Properties dialog with the Sharing tab and network path highlighted](../images/sideload-windows-properties-dialog-2.png)
-	
+
 5. The file should now look like the following. Save it.
 
 	```
@@ -108,11 +108,15 @@ The following video walks you through the process of sideloading your add-in in 
     > [!IMPORTANT]
     > [!include[HTTPS guidance](../includes/https-guidance.md)]
 
-2. In Excel, Word, or PowerPoint, select **My Add-ins** on the **Insert** tab of the ribbon. In Project, select **My Add-ins** on the **Project** tab of the ribbon. 
+2. In Excel, Word, or PowerPoint, select **My Add-ins** on the **Insert** tab of the ribbon. In Project, select **My Add-ins** on the **Project** tab of the ribbon.
 
 3. Choose **SHARED FOLDER** at the top of the **Office Add-ins** dialog box.
 
 4. Select the name of the add-in and choose **Add** to insert the add-in.
+
+## Remove a sideloaded add-in
+
+You can remove a previously sideloaded add-in by clearing the Office cache on your computer. Details on how to clear the cache on Windows can be found in the article [Clear the Office cache](clear-cache.md#clear-the-office-cache-on-windows).
 
 ## See also
 

--- a/docs/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins.md
+++ b/docs/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins.md
@@ -73,13 +73,13 @@ The following video walks you through the process of sideloading your add-in in 
 2. Add the following content to the file:
 
     ```
-	Windows Registry Editor Version 5.00
-	
-	[HKEY_CURRENT_USER\Software\Microsoft\Office\16.0\WEF\TrustedCatalogs\{-random-GUID-here-}]
-	"Id"="{-random-GUID-here-}"
-	"Url"="\\\\-share-\\-folder-"
-	"Flags"=dword:00000001
-	```
+    Windows Registry Editor Version 5.00
+
+    [HKEY_CURRENT_USER\Software\Microsoft\Office\16.0\WEF\TrustedCatalogs\{-random-GUID-here-}]
+    "Id"="{-random-GUID-here-}"
+    "Url"="\\\\-share-\\-folder-"
+    "Flags"=dword:00000001
+    ```
 3. Use one of the many online GUID generation tools, such as [GUID Generator](https://guidgenerator.com/), to generate a random GUID, and within the TrustNetworkShareCatalog.reg file, replace the string "-random-GUID-here-" *in both places* with the GUID. (The enclosing `{}` symbols should remain.)
 
 4. Replace the `Url` value with the full network path to the folder that you [shared](#share-a-folder) previously. (Note that any `\` characters in the URL must be doubled.) If you failed to note the folder's full network path when you shared the folder, you can get it from the folder's **Properties** dialog window, as shown in the following screenshot.
@@ -88,14 +88,14 @@ The following video walks you through the process of sideloading your add-in in 
 
 5. The file should now look like the following. Save it.
 
-	```
-	Windows Registry Editor Version 5.00
-	
-	[HKEY_CURRENT_USER\Software\Microsoft\Office\16.0\WEF\TrustedCatalogs\{01234567-89ab-cedf-0123-456789abcedf}]
-	"Id"="{01234567-89ab-cedf-0123-456789abcedf}"
-	"Url"="\\\\TestServer\\OfficeAddinManifests"
-	"Flags"=dword:00000001
-	```
+    ```
+    Windows Registry Editor Version 5.00
+
+    [HKEY_CURRENT_USER\Software\Microsoft\Office\16.0\WEF\TrustedCatalogs\{01234567-89ab-cedf-0123-456789abcedf}]
+    "Id"="{01234567-89ab-cedf-0123-456789abcedf}"
+    "Url"="\\\\TestServer\\OfficeAddinManifests"
+    "Flags"=dword:00000001
+    ```
 
 6. Close *all* Office applications.
 

--- a/docs/testing/sideload-an-office-add-in-on-ipad-and-mac.md
+++ b/docs/testing/sideload-an-office-add-in-on-ipad-and-mac.md
@@ -1,35 +1,33 @@
 ---
 title: Sideload Office Add-ins on iPad and Mac for testing
 description: ''
-ms.date: 11/26/2019
+ms.date: 02/18/2020
 localization_priority: Normal
 ---
 
 # Sideload Office Add-ins on iPad and Mac for testing
 
-To see how your add-in will run in Office on iOS, you can sideload your add-in's manifest onto an iPad using iTunes, or sideload your add-in's manifest directly in Office on Mac. This action won't enable you to set breakpoints and debug your add-in's code while it's running, but you can see how it behaves and verify that the UI is usable and rendering appropriately. 
+To see how your add-in will run in Office on iOS, you can sideload your add-in's manifest onto an iPad using iTunes, or sideload your add-in's manifest directly in Office on Mac. This action won't enable you to set breakpoints and debug your add-in's code while it's running, but you can see how it behaves and verify that the UI is usable and rendering appropriately.
 
 ## Prerequisites for Office on iOS
 
 - A Windows or Mac computer with [iTunes](https://www.apple.com/itunes/download/) installed.
-    
+
 - An iPad running iOS 8.2 or later with [Excel on iPad](https://itunes.apple.com/us/app/microsoft-excel/id586683407?mt=8) installed, and a sync cable.
-    
+
 - The manifest .xml file for the add-in you want to test.
-    
 
 ## Prerequisites for Office on Mac
 
 - A Mac running OS X v10.10 "Yosemite" or later with [Office on Mac](https://products.office.com/buy/compare-microsoft-office-products?tab=omac) installed.
-    
+
 - Word on Mac version 15.18 (160109).
-   
+
 - Excel on Mac version 15.19 (160206).
 
 - PowerPoint on Mac version 15.24 (160614)
-    
+
 - The manifest .xml file for the add-in you want to test.
-    
 
 ## Sideload an add-in on Excel or Word on iPad
 
@@ -41,16 +39,15 @@ To see how your add-in will run in Office on iOS, you can sideload your add-in's
 
 4. On the right side of iTunes, scroll down to  **File Sharing**, and then choose  **Excel** or **Word** in the **Add-ins** column.
 
-5. At the bottom of the  **Excel** or **Word Documents** column, choose **Add File**, and then select the manifest .xml file of the add-in you want to sideload. 
-    
-6. Open the Excel or Word app on your iPad. If the Excel or Word app is already running, choose the  **Home** button, and then close and restart the app.
-    
-7. Open a document.
-    
-8. Choose  **Add-ins** on the **Insert** tab. Your sideloaded add-in is available to insert under the **Developer** heading in the **Add-ins** UI.
-    
-    ![Insert Add-ins in the Excel app](../images/excel-insert-add-in.png)
+5. At the bottom of the  **Excel** or **Word Documents** column, choose **Add File**, and then select the manifest .xml file of the add-in you want to sideload.
 
+6. Open the Excel or Word app on your iPad. If the Excel or Word app is already running, choose the  **Home** button, and then close and restart the app.
+
+7. Open a document.
+
+8. Choose  **Add-ins** on the **Insert** tab. Your sideloaded add-in is available to insert under the **Developer** heading in the **Add-ins** UI.
+
+    ![Insert Add-ins in the Excel app](../images/excel-insert-add-in.png)
 
 ## Sideload an add-in in Office on Mac
 
@@ -58,31 +55,31 @@ To see how your add-in will run in Office on iOS, you can sideload your add-in's
 > To sideload an Outlook add-in on Mac, see [Sideload Outlook add-ins for testing](/outlook/add-ins/sideload-outlook-add-ins-for-testing).
 
 1. Open  **Terminal** and go to one of the following folders where you'll save your add-in's manifest file. If the `wef` folder doesn't exist on your computer, create it.
-    
+
     - For Word:  `/Users/<username>/Library/Containers/com.microsoft.Word/Data/Documents/wef`    
     - For Excel:  `/Users/<username>/Library/Containers/com.microsoft.Excel/Data/Documents/wef`
     - For PowerPoint: `/Users/<username>/Library/Containers/com.microsoft.Powerpoint/Data/Documents/wef`
-    
+
 2. Open the folder in  **Finder** using the command `open .` (including the period or dot). Copy your add-in's manifest file to this folder.
-    
+
     ![Wef folder in Office on Mac](../images/all-my-files.png)
 
 3. Open Word, and then open a document. Restart Word if it's already running.
-    
+
 4. In Word, choose  **Insert** > **Add-ins** > **My Add-ins** (drop-down menu), and then choose your add-in.
-    
+
     ![My Add-ins in Office on Mac](../images/my-add-ins-wikipedia.png)
 
     > [!IMPORTANT]
-    > Sideloaded add-ins will not show up in the My Add-ins dialog box. They are only visible within the drop-down menu (small down-arrow to the right of My Add-ins on the **Insert** tab). Sideloaded add-ins are listed under the **Developer Add-ins** heading in this menu. 
-    
-5. Verify that your add-in is displayed in Word.
-    
-    ![Office Add-in displayed in Office on Mac](../images/lorem-ipsum-wikipedia.png)
-    
-### Clearing the Office application's cache on a Mac
+    > Sideloaded add-ins will not show up in the My Add-ins dialog box. They are only visible within the drop-down menu (small down-arrow to the right of My Add-ins on the **Insert** tab). Sideloaded add-ins are listed under the **Developer Add-ins** heading in this menu.
 
-[!include[additional cache folders on Mac](../includes/mac-cache-folders.md)]
+5. Verify that your add-in is displayed in Word.
+
+    ![Office Add-in displayed in Office on Mac](../images/lorem-ipsum-wikipedia.png)
+
+## Remove a sideloaded add-in
+
+You can remove a previously sideloaded add-in by clearing the Office cache on your computer. Details on how to clear the cache for each platform and host can be found in the article [Clear the Office cache](clear-cache.md).
 
 ## See also
 

--- a/docs/testing/sideload-office-add-ins-for-testing.md
+++ b/docs/testing/sideload-office-add-ins-for-testing.md
@@ -1,39 +1,37 @@
 ---
 title: Sideload Office Add-ins in Office on the web for testing
 description: 'Test your Office Add-in in Office on the web by sideloading'
-ms.date: 06/20/2019
+ms.date: 02/18/2020
 localization_priority: Normal
 ---
 
 # Sideload Office Add-ins in Office on the web for testing
 
-You can install an Office Add-in for testing without having to first put it in an add-in catalog by using sideloading. Sideloading can be done in either Office 365 or Office on the web. The procedure is slightly different for the two platforms. 
+You can install an Office Add-in for testing without having to first put it in an add-in catalog by using sideloading. Sideloading can be done in either Office 365 or Office on the web. The procedure is slightly different for the two platforms.
 
 When you sideload an add-in, the add-in manifest is stored in the browser's local storage, so if you clear the browser's cache, or switch to a different browser, you have to sideload the add-in again.
-
 
 > [!NOTE]
 > Sideloading as described in this article is supported on Word, Excel, and PowerPoint. To sideload an Outlook add-in, see [Sideload Outlook add-ins for testing](/outlook/add-ins/sideload-outlook-add-ins-for-testing).
 
 The following video walks you through the process of sideloading your add-in in Office on the web or desktop.
 
-
 > [!VIDEO https://www.youtube.com/embed/XXsAw2UUiQo]
 
 ## Sideload an Office Add-in in Office on the web
 
 1. Open [Microsoft Office on the web](https://office.live.com/).
-    
+
 2. In  **Get started with the online apps now**, choose  **Excel**,  **Word**, or  **PowerPoint**; and then open a new document.
-    
+
 3. Open the  **Insert** tab on the ribbon and, in the **Add-ins** section, choose **Office Add-ins**.
-    
+
 4. On the  **Office Add-ins** dialog, select the **MY ADD-INS** tab, choose **Manage My Add-ins**, and then  **Upload My Add-in**.
-    
+
     ![The Office Add-ins dialog with a drop-down in the upper right reading "Manage my add-ins" and a drop-down below it with the option "Upload My Add-in"](../images/office-add-ins-my-account.png)
 
-5.  **Browse** to the add-in manifest file, and then select **Upload**.
-    
+5. **Browse** to the add-in manifest file, and then select **Upload**.
+
     ![The upload add-in dialog with buttons for browse, upload, and cancel.](../images/upload-add-in.png)
 
 6. Verify that your add-in is installed. For example, if it is an add-in command, it should appear on either the ribbon or the context menu. If it is a task pane add-in, the pane should appear.
@@ -47,15 +45,13 @@ The following video walks you through the process of sideloading your add-in in 
 
 >    ![The Microsoft Edge Allow localhost loopback option with the box checked.](../images/allow-localhost-loopback.png)
 
-
 ## Sideload an Office Add-in in Office 365
 
 1. Sign in to your Office 365 account.
-    
-2. Open the App Launcher on the left end of the toolbar and select  **Excel**,  **Word**, or  **PowerPoint**, and then create a new document.
-    
-3. Steps 3 - 6 are the same as in the preceding section **Sideload an Office Add-in in Office on the web**.
 
+2. Open the App Launcher on the left end of the toolbar and select  **Excel**,  **Word**, or  **PowerPoint**, and then create a new document.
+
+3. Steps 3 - 6 are the same as in the preceding section **Sideload an Office Add-in in Office on the web**.
 
 ## Sideload an add-in when using Visual Studio
 
@@ -72,3 +68,7 @@ If you're using Visual Studio to develop your add-in, the process to sideload is
 6. Save the XML file.
 7. Right click the web project and choose **Debug** -> **Start new instance**. This will run the web project without launching Office.
 8. From Office on the web, sideload the add-in using steps previously described in [Sideload an Office Add-in in Office on the web](#sideload-an-office-add-in-in-office-on-the-web).
+
+## Remove a sideloaded add-in
+
+You can remove a previously sideloaded add-in by clearing your browser's cache. Additionally, if you make changes to your add-in's manifest (for example, update file names of icons or text of add-in commands), you may need to clear the cache and then re-sideload the add-in using updated manifest. Doing so will allow Office to render the add-in as it's described by the updated manifest.

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -260,6 +260,7 @@
         href: testing/debug-office-add-ins-on-ipad-and-mac.md
     - name: Clear the Office cache
       href: testing/clear-cache.md
+      displayName: uninstall, sideload
     - name: Debug with runtime logging
       href: testing/runtime-logging.md
     - name: Troubleshoot user errors


### PR DESCRIPTION
Fixes #1137. 

These changes should clarify how to remove a side loaded add-in by clearing the cache. @kbrandl can you please make the analogous change in PR #1597 (specifically [this article](https://docs.microsoft.com/en-us/outlook/add-ins/sideload-outlook-add-ins-for-testing))?

I also cleaned up some formatting according to docs markdown linter.