### PR TITLE
[admin] (Ease-of-use) Switch folder path to code block

### DIFF
--- a/docs/testing/clear-cache.md
+++ b/docs/testing/clear-cache.md
@@ -13,7 +13,11 @@ Additionally, if you make changes to your add-in's manifest (for example, update
 
 ## Clear the Office cache on Windows
 
-To remove all sideloaded add-ins from Excel, Word, and PowerPoint, delete the contents of the folder `%LOCALAPPDATA%\Microsoft\Office\16.0\Wef\`.
+To remove all sideloaded add-ins from Excel, Word, and PowerPoint, delete the contents of the folder:
+
+```
+%LOCALAPPDATA%\Microsoft\Office\16.0\Wef\
+```
 
 To remove a sideloaded add-in from Outlook, use the steps outlined in [Sideload Outlook add-ins for testing](../outlook/sideload-outlook-add-ins-for-testing.md) to find the add-in in the **Custom add-ins** section of the dialog box that lists your installed add-ins. Choose the ellipsis (`...`) for the the add-in and then choose **Remove** to remove that specific add-in.
 

--- a/docs/testing/clear-cache.md
+++ b/docs/testing/clear-cache.md
@@ -19,7 +19,7 @@ To remove all sideloaded add-ins from Excel, Word, and PowerPoint, delete the co
 %LOCALAPPDATA%\Microsoft\Office\16.0\Wef\
 ```
 
-To remove a sideloaded add-in from Outlook, use the steps outlined in [Sideload Outlook add-ins for testing](../outlook/sideload-outlook-add-ins-for-testing.md) to find the add-in in the **Custom add-ins** section of the dialog box that lists your installed add-ins. Choose the ellipsis (`...`) for the the add-in and then choose **Remove** to remove that specific add-in.
+To remove a sideloaded add-in from Outlook, use the steps outlined in [Sideload Outlook add-ins for testing](../outlook/sideload-outlook-add-ins-for-testing.md) to find the add-in in the **Custom add-ins** section of the dialog box that lists your installed add-ins. Choose the ellipsis (`...`) for the add-in and then choose **Remove** to remove that specific add-in.
 
 Additionally, to clear the Office cache on Windows 10 when the add-in is running in Microsoft Edge, you can use the Microsoft Edge DevTools.
 


### PR DESCRIPTION
Every time I try to copy this folder path, I accidentally grab the '.' at the end of the sentence. Making this a code block gives users the "Copy" button. It also draws the eyes to the most important information on this page.