### PR TITLE
[quickstarts] (Visual Studio) Add note about console for VS

### DIFF
--- a/docs/includes/console-tool-note.md
+++ b/docs/includes/console-tool-note.md
@@ -1,0 +1,2 @@
+> [!NOTE]
+> To see the `console.log` output, you'll need a separate set of developer tools for a JavaScript console. Visit [Debug add-ins using developer tools on Windows 10](../testing/debug-add-ins-using-f12-developer-tools-on-windows-10.md) to learn more about F12 tools and the Microsoft Edge DevTools.

--- a/docs/quickstarts/excel-quickstart-jquery.md
+++ b/docs/quickstarts/excel-quickstart-jquery.md
@@ -1,14 +1,14 @@
 ---
 title: Build your first Excel task pane add-in
 description: Learn how to build a simple Excel task pane add-in by using the Office JS API.
-ms.date: 01/16/2020
+ms.date: 03/19/2020
 ms.prod: excel
 localization_priority: Priority
 ---
 
 # Build an Excel task pane add-in
 
-In this article, you'll walk through the process of building an Excel task pane add-in. 
+In this article, you'll walk through the process of building an Excel task pane add-in.
 
 ## Create the add-in
 
@@ -49,7 +49,7 @@ After you complete the wizard, the generator creates the project and installs su
     cd "My Office Add-in"
     ```
 
-2. [!include[Start server section](../includes/quickstart-yo-start-server-excel.md)] 
+2. [!include[Start server section](../includes/quickstart-yo-start-server-excel.md)]
 
 3. In Excel, choose the **Home** tab, and then choose the **Show Taskpane** button in the ribbon to open the add-in task pane.
 
@@ -109,7 +109,7 @@ Congratulations, you've successfully created an Excel task pane add-in! Next, le
     </body>
     ```
 
-2. Open the file **Home.js** in the root of the web application project. This file specifies the script for the add-in. Replace the entire contents with the following code and save the file. 
+2. Open the file **Home.js** in the root of the web application project. This file specifies the script for the add-in. Replace the entire contents with the following code and save the file.
 
     ```js
     'use strict';
@@ -140,7 +140,7 @@ Congratulations, you've successfully created an Excel task pane add-in! Next, le
     })();
     ```
 
-3. Open the file **Home.css** in the root of the web application project. This file specifies the custom styles for the add-in. Replace the entire contents with the following code and save the file. 
+3. Open the file **Home.css** in the root of the web application project. This file specifies the custom styles for the add-in. Replace the entire contents with the following code and save the file.
 
     ```css
     #content-header {
@@ -150,7 +150,7 @@ Congratulations, you've successfully created an Excel task pane add-in! Next, le
         top: 0;
         left: 0;
         width: 100%;
-        height: 80px; 
+        height: 80px;
         overflow: hidden;
     }
 
@@ -161,7 +161,7 @@ Congratulations, you've successfully created an Excel task pane add-in! Next, le
         left: 0;
         right: 0;
         bottom: 0;
-        overflow: auto; 
+        overflow: auto;
     }
 
     .padding {
@@ -193,7 +193,7 @@ Congratulations, you've successfully created an Excel task pane add-in! Next, le
 
 ### Try it out
 
-1. Using Visual Studio, test the newly created Excel add-in by pressing **F5** or choosing the **Start** button to launch Excel with the **Show Taskpane** add-in button displayed in the ribbon. The add-in will be hosted locally on IIS.
+1. Using Visual Studio, test the newly created Excel add-in by pressing **F5** or choosing the **Start** button to launch Excel with the **Show Taskpane** add-in button displayed in the ribbon. The add-in will be hosted locally on IIS. If you are asked to trust a certificate, do so to allow the add-in to connect to its host.
 
 2. In Excel, choose the **Home** tab, and then choose the **Show Taskpane** button in the ribbon to open the add-in task pane.
 
@@ -204,6 +204,8 @@ Congratulations, you've successfully created an Excel task pane add-in! Next, le
 4. In the task pane, choose the **Set color** button to set the color of the selected range to green.
 
     ![Excel add-in](../images/excel-quickstart-addin-2c.png)
+
+[!include[Console tool note](../includes/console-tool-note.md)]
 
 ### Next steps
 

--- a/docs/quickstarts/outlook-quickstart.md
+++ b/docs/quickstarts/outlook-quickstart.md
@@ -1,7 +1,7 @@
 ---
 title: Build your first Outlook add-in
 description: Learn how to build a simple Outlook task pane add-in by using the Office JS API.
-ms.date: 03/19/2020
+ms.date: 12/28/2019
 ms.prod: outlook
 localization_priority: Priority
 ---
@@ -278,8 +278,6 @@ When you've completed the wizard, Visual Studio creates a solution that contains
 
     > [!NOTE]
     > If the task pane doesn't load, try to verify by opening it in a browser on the same machine.
-
-[!include[Console tool note](../includes/console-tool-note.md)]
 
 ### Next steps
 

--- a/docs/quickstarts/outlook-quickstart.md
+++ b/docs/quickstarts/outlook-quickstart.md
@@ -1,7 +1,7 @@
 ---
 title: Build your first Outlook add-in
 description: Learn how to build a simple Outlook task pane add-in by using the Office JS API.
-ms.date: 12/28/2019
+ms.date: 03/19/2020
 ms.prod: outlook
 localization_priority: Priority
 ---
@@ -278,6 +278,8 @@ When you've completed the wizard, Visual Studio creates a solution that contains
 
     > [!NOTE]
     > If the task pane doesn't load, try to verify by opening it in a browser on the same machine.
+
+[!include[Console tool note](../includes/console-tool-note.md)]
 
 ### Next steps
 

--- a/docs/quickstarts/powerpoint-quickstart.md
+++ b/docs/quickstarts/powerpoint-quickstart.md
@@ -1,7 +1,7 @@
 ---
 title: Build your first PowerPoint task pane add-in
 description: Learn how to build a simple PowerPoint task pane add-in by using the Office JS API.
-ms.date: 01/16/2020
+ms.date: 03/19/2020
 ms.prod: powerpoint
 localization_priority: Priority
 ---
@@ -245,6 +245,8 @@ Congratulations, you've successfully created a PowerPoint task pane add-in! Next
 4. In the task pane, choose the **Insert Text** button to add text to the selected slide.
 
     ![A screenshot of PowerPoint with an image of a dog and the text 'Hello World` displayed on the slide](../images/powerpoint_quickstart_addin_3.png)
+
+[!include[Console tool note](../includes/console-tool-note.md)]
 
 ### Next steps
 

--- a/docs/quickstarts/word-quickstart.md
+++ b/docs/quickstarts/word-quickstart.md
@@ -1,7 +1,7 @@
 ---
 title: Build your first Word task pane add-in
 description: Learn how to build a simple Word task pane add-in by using the Office JS API.
-ms.date: 01/16/2020
+ms.date: 03/19/2020
 ms.prod: word
 localization_priority: Priority
 ---
@@ -301,6 +301,8 @@ Congratulations, you've successfully created a Word task pane add-in! Next, lear
 3. In the task pane, choose any of the buttons to add boilerplate text to the document.
 
     ![Screenshot of the Word application with the boilerplate add-in loaded](../images/word-quickstart-addin-1b.png)
+
+[!include[Console tool note](../includes/console-tool-note.md)]
 
 ### Next steps
 


### PR DESCRIPTION
Fixes #1676. 

This gives quick-start users information about finding the `console.log` output the quick start add-ins generate.