### PR TITLE
[All Hosts] (toc) fix misleading TOC folder name

### DIFF
--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -61,7 +61,7 @@
         href: develop/initialize-add-in.md
       - name: Coding guidance for common issues
         href: develop/common-coding-issues.md
-      - name: Common APIs (Office 2013+)
+      - name: Common APIs
         items:
         - name: Common JavaScript API object model
           href: develop/office-javascript-api-object-model.md


### PR DESCRIPTION
The "(Office 2013+)" at the end of this folder name implies that the Common APIs are only available on the perpetual license Office. They are actually available on all platforms including subscription.