### PR TITLE
[excel] (ExcelApi 1.11) ExcelApi Requirement Set 1.11 Updates

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -12,7 +12,7 @@
       "locale": "en-us",
       "monikers": [],
       "moniker_ranges": ["common-js",
-                         "excel-js-preview", "excel-js-1.1", "excel-js-1.2", "excel-js-1.3", "excel-js-1.4", "excel-js-1.5", "excel-js-1.6", "excel-js-1.7", "excel-js-1.8", "excel-js-1.9", "excel-js-1.10", "excel-js-online",
+                         "excel-js-preview", "excel-js-1.1", "excel-js-1.2", "excel-js-1.3", "excel-js-1.4", "excel-js-1.5", "excel-js-1.6", "excel-js-1.7", "excel-js-1.8", "excel-js-1.9", "excel-js-1.10", "excel-js-1.11", "excel-js-online",
                          "onenote-js-1.1",
                          "outlook-js-preview", "outlook-js-1.1", "outlook-js-1.2", "outlook-js-1.3", "outlook-js-1.4", "outlook-js-1.5", "outlook-js-1.6", "outlook-js-1.7", "outlook-js-1.8",
                          "powerpoint-js-1.1",

--- a/docs/excel/excel-add-ins-comments.md
+++ b/docs/excel/excel-add-ins-comments.md
@@ -106,7 +106,7 @@ Excel.run(function (context) {
 });
 ```
 
-## Resolve comment threads ([preview](../reference/requirement-sets/excel-preview-apis.md)) 
+## Resolve comment threads
 
 A comment thread has a configurable boolean value, `resolved`, to indicate if it is resolved. A value of `true` means the comment thread is resolved. A value of `false` means the comment thread is either new or reopened.
 
@@ -164,13 +164,7 @@ Excel.run(function (context) {
 });
 ```
 
-## Mentions ([online-only](../reference/requirement-sets/excel-api-online-requirement-set.md)) 
-
-> [!NOTE]
-> The comment mention APIs are currently available only in public preview. [!INCLUDE [Information about using preview APIs](../includes/using-excel-preview-apis.md)]
-
-> [!IMPORTANT]
-> Comment mentions are currently only supported for Excel on the web.
+## Mentions
 
 [Mentions](https://support.office.com/article/use-mention-in-comments-to-tag-someone-for-feedback-644bf689-31a0-4977-a4fb-afe01820c1fd) are used to tag colleagues in a comment. This sends them notifications with your comment's content. Your add-in can create these mentions on your behalf.
 

--- a/docs/excel/excel-add-ins-comments.md
+++ b/docs/excel/excel-add-ins-comments.md
@@ -20,7 +20,7 @@ Comments within a workbook are tracked by the `Workbook.comments` property. This
 Use the `CommentCollection.add` method to add comments to a workbook. This method takes up to three parameters:
 
 - `cellAddress`: The cell where the comment is added. This can either be a string or [Range](/javascript/api/excel/excel.range) object. The range must be a single cell.
-- `content`: The comment's content. Use a string for plain text comments. Use a [CommentRichContent](/javascript/api/excel/excel.commentrichcontent) object for comments with [mentions](#mentions-online-only). 
+- `content`: The comment's content. Use a string for plain text comments. Use a [CommentRichContent](/javascript/api/excel/excel.commentrichcontent) object for comments with [mentions](#mentions).
 - `contentType`: A [ContentType](/javascript/api/excel/excel.contenttype) enum specifying type of content. The default value is `ContentType.plain`.
 
 The following code sample adds a comment to cell **A2**.

--- a/docs/excel/excel-add-ins-events.md
+++ b/docs/excel/excel-add-ins-events.md
@@ -1,7 +1,7 @@
 ---
 title: Work with Events using the Excel JavaScript API
 description: 'A list of events for Excel JavaScript objects. This includes information on using event handlers and the associated patterns.' 
-ms.date: 03/31/2020
+ms.date: 05/06/2020
 localization_priority: Normal
 ---
 
@@ -27,6 +27,7 @@ Each time certain types of changes occur in an Excel workbook, an event notifica
 | `onFormatChanged` | Occurs when the format is changed on a worksheet. | [**Worksheet**](/javascript/api/excel/excel.worksheet#onformatchanged), [**WorksheetCollection**](/javascript/api/excel/excel.worksheetcollection#onformatchanged) |
 | `onRowSorted` | Occurs when one or more rows have been sorted. This happens as the result of a top-to-bottom sort operation. | [**Worksheet**](/javascript/api/excel/excel.worksheet#onrowsorted), [**WorksheetCollection**](/javascript/api/excel/excel.worksheetcollection#onrowsorted) |
 | `onSelectionChanged` | Occurs when the active cell or selected range is changed. | [**Binding**](/javascript/api/excel/excel.binding#onselectionchanged), [**Table**](/javascript/api/excel/excel.table#onselectionchanged), [**Workbook**](/javascript/api/excel/excel.workbook#onselectionchanged), [**Worksheet**](/javascript/api/excel/excel.worksheet#onselectionchanged), [**WorksheetCollection**](/javascript/api/excel/excel.worksheetcollection#onselectionchanged) |
+| `onRowHiddenChanged` | Occurs when the row-hidden state changes on a specific worksheet. | [**Worksheet**](/javascript/api/excel/excel.worksheet#onrowhiddenchanged), [**WorksheetCollection**](/javascript/api/excel/excel.worksheetcollection#onrowhiddenchanged) |
 | `onSettingsChanged` | Occurs when the Settings in the document are changed. | [**SettingCollection**](/javascript/api/excel/excel.settingcollection#onsettingschanged) |
 | `onSingleClicked` | Occurs when left-clicked/tapped action occurs in the worksheet. | [**Worksheet**](/javascript/api/excel/excel.worksheet#onsingleclicked), [**WorksheetCollection**](/javascript/api/excel/excel.worksheetcollection#onsingleclicked) |
 
@@ -47,7 +48,6 @@ Each time certain types of changes occur in an Excel workbook, an event notifica
 | Event | Description | Supported objects |
 |:---------------|:-------------|:-----------|
 | `onFiltered` | Occurs when a filter is applied to an object. | [**Table**](/javascript/api/excel/excel.table#onfiltered), [**TableCollection**](/javascript/api/excel/excel.tablecollection#onfiltered), [**Worksheet**](/javascript/api/excel/excel.worksheet#onfiltered), [**WorksheetCollection**](/javascript/api/excel/excel.worksheetcollection#onfiltered) |
-| `onRowHiddenChanged` | Occurs when the row-hidden state changes on a specific worksheet. | [**Worksheet**](/javascript/api/excel/excel.worksheet#onrowhiddenchanged), [**WorksheetCollection**](/javascript/api/excel/excel.worksheetcollection#onrowhiddenchanged) |
 
 ### Event triggers
 

--- a/docs/excel/excel-add-ins-ranges-advanced.md
+++ b/docs/excel/excel-add-ins-ranges-advanced.md
@@ -1,7 +1,7 @@
 ---
 title: Work with ranges using the Excel JavaScript API (advanced)
 description: 'Advanced range object functions and scenarios, such as special cells, remove duplicates, and working with dates.' 
-ms.date: 02/11/2020 
+ms.date: 05/06/2020 
 localization_priority: Normal
 ---
 
@@ -167,11 +167,11 @@ Excel.run(function (context) {
 })
 ```
 
-## Cut, copy, and paste 
+## Cut, copy, and paste
 
-### Copy and paste 
+### Copy and paste
 
-The [Range.copyFrom](/javascript/api/excel/excel.range#copyfrom-sourcerange--copytype--skipblanks--transpose-) method replicates the **Copy** and **Paste** actions of the Excel UI. The range object that `copyFrom` is called on is the destination. The source to be copied is passed as a range or a string address representing a range. 
+The [Range.copyFrom](/javascript/api/excel/excel.range#copyfrom-sourcerange--copytype--skipblanks--transpose-) method replicates the **Copy** and **Paste** actions of the Excel UI. The range object that `copyFrom` is called on is the destination. The source to be copied is passed as a range or a string address representing a range.
 
 The following code sample copies the data from **A1:E1** into the range starting at **G1** (which ends up pasting into **G1:K1**).
 
@@ -230,22 +230,22 @@ Excel.run(function (context) {
 
 ![Data in Excel after range's copy method has been run](../images/excel-range-copyfrom-skipblanks-after.png)
 
-### Cut and paste (move) cells ([online-only](../reference/requirement-sets/excel-api-online-requirement-set.md)) 
+### Cut and paste (move) cells
 
-The [Range.moveTo](/javascript/api/excel/excel.range#moveto-destinationrange-) method moves cells to a new location in the workbook. This cell movement behavior works the same as when cells are moved by [dragging the range border](https://support.office.com/article/Move-or-copy-cells-and-cell-contents-803d65eb-6a3e-4534-8c6f-ff12d1c4139e) or when taking the **Cut** and **Paste** actions. Both the formatting and values of the range are moved to the location specified as the `destinationRange` parameter. 
+The [Range.moveTo](/javascript/api/excel/excel.range#moveto-destinationrange-) method moves cells to a new location in the workbook. This cell movement behavior works the same as when cells are moved by [dragging the range border](https://support.office.com/article/Move-or-copy-cells-and-cell-contents-803d65eb-6a3e-4534-8c6f-ff12d1c4139e) or when taking the **Cut** and **Paste** actions. Both the formatting and values of the range are moved to the location specified as the `destinationRange` parameter.
 
-The following code sample shows a range being moved with the `Range.moveTo` method. Note that if the destination range is smaller than the source, it will be expanded to encompass the source content. 
+The following code sample shows a range being moved with the `Range.moveTo` method. Note that if the destination range is smaller than the source, it will be expanded to encompass the source content.
 
-```js 
-Excel.run(function (context) { 
-    var sheet = context.workbook.worksheets.getActiveWorksheet(); 
-    sheet.getRange("F1").values = [["Moved Range"]]; 
+```js
+Excel.run(function (context) {
+    var sheet = context.workbook.worksheets.getActiveWorksheet();
+    sheet.getRange("F1").values = [["Moved Range"]];
 
-    // Move the cells "A1:E1" to "G1" (which fills the range "G1:K1"). 
-    sheet.getRange("A1:E1").moveTo("G1"); 
-    return context.sync(); 
-}); 
-``` 
+    // Move the cells "A1:E1" to "G1" (which fills the range "G1:K1").
+    sheet.getRange("A1:E1").moveTo("G1");
+    return context.sync();
+});
+```
 
 ## Remove duplicates
 

--- a/docs/excel/excel-add-ins-workbooks.md
+++ b/docs/excel/excel-add-ins-workbooks.md
@@ -1,7 +1,7 @@
 ---
 title: Work with workbooks using the Excel JavaScript API
 description: 'Code samples that show how to perform common tasks with workbooks or application-level features using the Excel JavaScript API.'
-ms.date: 03/19/2020
+ms.date: 05/06/2020
 localization_priority: Normal
 ---
 
@@ -181,7 +181,7 @@ Excel.run(function (context) {
 }).catch(errorHandlerFunction);
 ```
 
-## Access application culture settings (preview)
+## Access application culture settings
 
 A workbook has language and culture settings that affect how certain data is displayed. These settings can help localize data when your add-in's users are sharing workbooks across different languages and cultures. Your add-in can use string parsing to localize the format of numbers, dates, and times based on the system culture settings so that each user sees data in their own culture's format.
 
@@ -292,10 +292,7 @@ The Excel API also lets add-ins turn off calculations until `RequestContext.sync
 context.application.suspendApiCalculationUntilNextSync();
 ```
 
-## Save the workbook (preview)
-
-> [!NOTE]
-> The `Workbook.save` method is currently available only in public preview. [!INCLUDE [Information about using preview APIs](../includes/using-excel-preview-apis.md)]
+## Save the workbook
 
 `Workbook.save` saves the workbook to persistent storage. The `save` method takes a single, optional `saveBehavior` parameter that can be one of the following values:
 
@@ -309,10 +306,7 @@ context.application.suspendApiCalculationUntilNextSync();
 context.workbook.save(Excel.SaveBehavior.prompt);
 ```
 
-## Close the workbook (preview)
-
-> [!NOTE]
-> The `Workbook.close` method is currently available only in public preview. [!INCLUDE [Information about using preview APIs](../includes/using-excel-preview-apis.md)]
+## Close the workbook
 
 `Workbook.close` closes the workbook, along with add-ins that are associated with the workbook (the Excel application remains open). The `close` method takes a single, optional `closeBehavior` parameter that can be one of the following values:
 

--- a/docs/reference/requirement-sets/excel-api-1-11-requirement-set.md
+++ b/docs/reference/requirement-sets/excel-api-1-11-requirement-set.md
@@ -1,0 +1,66 @@
+---
+title: Excel JavaScript API requirement set 1.11
+description: 'Details about the ExcelApi 1.11 requirement set'
+ms.date: 05/06/2020
+ms.prod: excel
+localization_priority: Normal
+---
+
+# What's new in Excel JavaScript API 1.11
+
+The ExcelApi 1.11 improved support for comments and workbook-level controls (such as saving and closing the workbook). It also added access to culture settings to help account for localization.
+
+| Feature area | Description | Relevant objects |
+|:--- |:--- |:--- |
+| Comment [Mentions](../../excel/excel-add-ins-comments#mentions) |Tags and notifies other workbook users through comments. | [Comment](/javascript/api/excel/excel.comment), [CommentRichContent](/javascript/api/excel/excel.commentrichcontent) |
+| Comment [Resolution](../../excel/excel-add-ins-comments.md#resolve-comment-threads) | Resolve comment threads and get the resolution status. | [Comment](/javascript/api/excel/excel.comment) |
+| [Culture settings](../../excel/excel-add-ins-workbooks.md#access-application-culture-settings) | Gets cultural system settings for the workbook, such as number formatting. | [CultureInfo](/javascript/api/excel/excel.cultureinfo), [NumberFormatInfo](/javascript/api/excel/excel.numberformatinfo) [Application](/javascript/api/excel/excel.application) |
+| Workbook [Save](../../excel/excel-add-ins-workbooks.md#save-the-workbook) and [Close](../../excel/excel-add-ins-workbooks.md#close-the-workbook) | Save and close workbooks. | [Workbook](/javascript/api/excel/excel.workbook) |
+| Worksheet events | Additional events and event information for worksheet calculations and hidden rows. | [WorksheetCalculatedEventArgs](/javascript/api/excel/excel.worksheetcalculatedeventargs), [WorksheetRowHiddenChangedEventArgs](/javascript/api/excel/excel.worksheetrowhiddenchangedeventargs) |
+
+## API list
+
+The following table lists the APIs in Excel JavaScript API requirement set 1.11. To view API reference documentation for all APIs supported by Excel JavaScript API requirement set 1.11 or earlier, see [Excel APIs in requirement set 1.10 or earlier](/javascript/api/excel?view=excel-js-1.11).
+
+| Class | Fields | Description |
+|:---|:---|:---|
+|[Application](/javascript/api/excel/excel.application)|[cultureInfo](/javascript/api/excel/excel.application#cultureinfo)|Provides information based on current system culture settings. This includes the culture names, number formatting, and other culturally dependent settings.|
+||[decimalSeparator](/javascript/api/excel/excel.application#decimalseparator)|Gets the string used as the decimal separator for numeric values. This is based on Excel's local settings.|
+||[thousandsSeparator](/javascript/api/excel/excel.application#thousandsseparator)|Gets the string used to separate groups of digits to the left of the decimal for numeric values. This is based on Excel's local settings.|
+||[useSystemSeparators](/javascript/api/excel/excel.application#usesystemseparators)|Specifies if the system separators of Excel are enabled.|
+|[Comment](/javascript/api/excel/excel.comment)|[mentions](/javascript/api/excel/excel.comment#mentions)|Gets the entities (e.g., people) that are mentioned in comments.|
+||[richContent](/javascript/api/excel/excel.comment#richcontent)|Gets the rich comment content (e.g., mentions in comments). This string is not meant to be displayed to end-users. Your add-in should only use this to parse rich comment content.|
+||[resolved](/javascript/api/excel/excel.comment#resolved)|The comment thread status. A value of "true" means the comment thread is resolved.|
+||[updateMentions(contentWithMentions: Excel.CommentRichContent)](/javascript/api/excel/excel.comment#updatementions-contentwithmentions-)|Updates the comment content with a specially formatted string and a list of mentions.|
+|[CommentCollection](/javascript/api/excel/excel.commentcollection)|[add(cellAddress: Range \| string, content: CommentRichContent \| string, contentType?: Excel.ContentType)](/javascript/api/excel/excel.commentcollection#add-celladdress--content--contenttype-)|Creates a new comment with the given content on the given cell. An `InvalidArgument` error is thrown if the provided range is larger than one cell.|
+|[CommentMention](/javascript/api/excel/excel.commentmention)|[email](/javascript/api/excel/excel.commentmention#email)|The email address of the entity that is mentioned in comment.|
+||[id](/javascript/api/excel/excel.commentmention#id)|The id of the entity. The id matches one of the ids in `CommentRichContent.richContent`.|
+||[name](/javascript/api/excel/excel.commentmention#name)|The name of the entity that is mentioned in comment.|
+|[CommentReply](/javascript/api/excel/excel.commentreply)|[mentions](/javascript/api/excel/excel.commentreply#mentions)|The entities (e.g., people) that are mentioned in comments.|
+||[resolved](/javascript/api/excel/excel.commentreply#resolved)|The comment reply status. A value of "true" means the reply is in the resolved state.|
+||[richContent](/javascript/api/excel/excel.commentreply#richcontent)|The rich comment content (e.g., mentions in comments). This string is not meant to be displayed to end-users. Your add-in should only use this to parse rich comment content.|
+||[updateMentions(contentWithMentions: Excel.CommentRichContent)](/javascript/api/excel/excel.commentreply#updatementions-contentwithmentions-)|Updates the comment content with a specially formatted string and a list of mentions.|
+|[CommentReplyCollection](/javascript/api/excel/excel.commentreplycollection)|[add(content: CommentRichContent \| string, contentType?: Excel.ContentType)](/javascript/api/excel/excel.commentreplycollection#add-content--contenttype-)|Creates a comment reply for comment.|
+|[CommentRichContent](/javascript/api/excel/excel.commentrichcontent)|[mentions](/javascript/api/excel/excel.commentrichcontent#mentions)|An array containing all the entities (e.g., people) mentioned within the comment.|
+||[richContent](/javascript/api/excel/excel.commentrichcontent#richcontent)|Specifies the rich content of the comment (e.g., comment content with mentions, the first mentioned entity has an id attribute of 0, and the second mentioned entity has an id attribute of 1.|
+|[CultureInfo](/javascript/api/excel/excel.cultureinfo)|[name](/javascript/api/excel/excel.cultureinfo#name)|Gets the culture name in the format languagecode2-country/regioncode2 (e.g., "zh-cn" or "en-us"). This is based on current system settings.|
+||[numberFormat](/javascript/api/excel/excel.cultureinfo#numberformat)|Defines the culturally appropriate format of displaying numbers. This is based on current system culture settings.|
+|[NumberFormatInfo](/javascript/api/excel/excel.numberformatinfo)|[numberDecimalSeparator](/javascript/api/excel/excel.numberformatinfo#numberdecimalseparator)|Gets the string used as the decimal separator for numeric values. This is based on current system settings.|
+||[numberGroupSeparator](/javascript/api/excel/excel.numberformatinfo#numbergroupseparator)|Gets the string used to separate groups of digits to the left of the decimal for numeric values. This is based on current system settings.|
+|[Range](/javascript/api/excel/excel.range)|[moveTo(destinationRange: Range \| string)](/javascript/api/excel/excel.range#moveto-destinationrange-)|Moves cell values, formatting, and formulas from current range to the destination range, replacing the old information in those cells.|
+|[RangeFormat](/javascript/api/excel/excel.rangeformat)|[adjustIndent(amount: number)](/javascript/api/excel/excel.rangeformat#adjustindent-amount-)|Adjusts the indentation of the range formatting. The indent value ranges from 0 to 250 and is measured in characters.|
+|[Workbook](/javascript/api/excel/excel.workbook)|[close(closeBehavior?: Excel.CloseBehavior)](/javascript/api/excel/excel.workbook#close-closebehavior-)|Close current workbook.|
+||[save(saveBehavior?: Excel.SaveBehavior)](/javascript/api/excel/excel.workbook#save-savebehavior-)|Save current workbook.|
+|[Worksheet](/javascript/api/excel/excel.worksheet)|[onRowHiddenChanged](/javascript/api/excel/excel.worksheet#onrowhiddenchanged)|Occurs when the hidden state of one or more rows has changed on a specific worksheet.|
+|[WorksheetCalculatedEventArgs](/javascript/api/excel/excel.worksheetcalculatedeventargs)|[address](/javascript/api/excel/excel.worksheetcalculatedeventargs#address)|The address of the range that completed calculation.|
+|[WorksheetCollection](/javascript/api/excel/excel.worksheetcollection)|[onRowHiddenChanged](/javascript/api/excel/excel.worksheetcollection#onrowhiddenchanged)|Occurs when the hidden state of one or more rows has changed on a specific worksheet.|
+|[WorksheetRowHiddenChangedEventArgs](/javascript/api/excel/excel.worksheetrowhiddenchangedeventargs)|[address](/javascript/api/excel/excel.worksheetrowhiddenchangedeventargs#address)|Gets the range address that represents the changed area of a specific worksheet.|
+||[changeType](/javascript/api/excel/excel.worksheetrowhiddenchangedeventargs#changetype)|Gets the type of change that represents how the event was triggered. See `Excel.RowHiddenChangeType` for details.|
+||[source](/javascript/api/excel/excel.worksheetrowhiddenchangedeventargs#source)|Gets the source of the event. See Excel.EventSource for details.|
+||[type](/javascript/api/excel/excel.worksheetrowhiddenchangedeventargs#type)|Gets the type of the event. See Excel.EventType for details.|
+||[worksheetId](/javascript/api/excel/excel.worksheetrowhiddenchangedeventargs#worksheetid)|Gets the id of the worksheet in which the data changed.|
+
+## See also
+
+- [Excel JavaScript API Reference Documentation](/javascript/api/excel?view=excel-js-1.11)
+- [Excel JavaScript API requirement sets](./excel-api-requirement-sets.md)

--- a/docs/reference/requirement-sets/excel-api-1-11-requirement-set.md
+++ b/docs/reference/requirement-sets/excel-api-1-11-requirement-set.md
@@ -12,9 +12,10 @@ The ExcelApi 1.11 improved support for comments and workbook-level controls (suc
 
 | Feature area | Description | Relevant objects |
 |:--- |:--- |:--- |
-| Comment [Mentions](../../excel/excel-add-ins-comments#mentions) |Tags and notifies other workbook users through comments. | [Comment](/javascript/api/excel/excel.comment), [CommentRichContent](/javascript/api/excel/excel.commentrichcontent) |
+| Comment [Mentions](../../excel/excel-add-ins-comments.md#mentions) |Tags and notifies other workbook users through comments. | [Comment](/javascript/api/excel/excel.comment), [CommentRichContent](/javascript/api/excel/excel.commentrichcontent) |
 | Comment [Resolution](../../excel/excel-add-ins-comments.md#resolve-comment-threads) | Resolve comment threads and get the resolution status. | [Comment](/javascript/api/excel/excel.comment) |
 | [Culture settings](../../excel/excel-add-ins-workbooks.md#access-application-culture-settings) | Gets cultural system settings for the workbook, such as number formatting. | [CultureInfo](/javascript/api/excel/excel.cultureinfo), [NumberFormatInfo](/javascript/api/excel/excel.numberformatinfo) [Application](/javascript/api/excel/excel.application) |
+| [Cut and paste (moveTo)](../../excel/excel-add-ins-ranges-advanced.md#cut-copy-and-paste) | Replicates the cut-and-paste functionality in Excel for a Range. | [Range](/javascript/api/excel/excel.range) |
 | Workbook [Save](../../excel/excel-add-ins-workbooks.md#save-the-workbook) and [Close](../../excel/excel-add-ins-workbooks.md#close-the-workbook) | Save and close workbooks. | [Workbook](/javascript/api/excel/excel.workbook) |
 | Worksheet events | Additional events and event information for worksheet calculations and hidden rows. | [WorksheetCalculatedEventArgs](/javascript/api/excel/excel.worksheetcalculatedeventargs), [WorksheetRowHiddenChangedEventArgs](/javascript/api/excel/excel.worksheetrowhiddenchangedeventargs) |
 

--- a/docs/reference/requirement-sets/excel-api-online-requirement-set.md
+++ b/docs/reference/requirement-sets/excel-api-online-requirement-set.md
@@ -1,7 +1,7 @@
 ---
 title: Excel JavaScript API online-only requirement set
 description: 'Details about the ExcelApiOnline requirement set'
-ms.date: 12/05/2019
+ms.date: 05/06/2020
 ms.prod: excel
 localization_priority: Normal
 ---
@@ -39,19 +39,13 @@ The following APIs are currently available for Excel on the web as part of the `
 
 | Class | Fields | Description |
 |:---|:---|:---|
-|[Comment](/javascript/api/excel/excel.comment)|[mentions](/javascript/api/excel/excel.comment#mentions)|Gets the entities (e.g. people) that are mentioned in comments.|
-||[richContent](/javascript/api/excel/excel.comment#richcontent)|Gets the rich comment content (e.g. mentions in comments). This string is not meant to be displayed to end-users. Your add-in should only use this to parse rich comment content.|
-||[updateMentions(contentWithMentions: Excel.CommentRichContent)](/javascript/api/excel/excel.comment#updatementions-contentwithmentions-)|Updates the comment content with a specially formatted string and a list of mentions.|
-|[CommentMention](/javascript/api/excel/excel.commentmention)|[email](/javascript/api/excel/excel.commentmention#email)|Gets or sets the email address of the entity that is mentioned in comment.|
-||[id](/javascript/api/excel/excel.commentmention#id)|Gets or sets the id of the entity. This matches one of the ids in `CommentRichContent.richContent`.|
-||[name](/javascript/api/excel/excel.commentmention#name)|Gets or sets the name of the entity that is mentioned in comment.|
-|[CommentReply](/javascript/api/excel/excel.commentreply)|[mentions](/javascript/api/excel/excel.commentreply#mentions)|Gets the entities (e.g. people) that are mentioned in comments.|
-||[richContent](/javascript/api/excel/excel.commentreply#richcontent)|Gets the rich comment content (e.g. mentions in comments). This string is not meant to be displayed to end-users. Your add-in should only use this to parse rich comment content.|
-||[updateMentions(contentWithMentions: Excel.CommentRichContent)](/javascript/api/excel/excel.commentreply#updatementions-contentwithmentions-)|Updates the comment content with a specially formatted string and a list of mentions.|
-|[CommentRichContent](/javascript/api/excel/excel.commentrichcontent)|[mentions](/javascript/api/excel/excel.commentrichcontent#mentions)|An array containing all the entities (e.g. people) mentioned within the comment.|
-||[richContent](/javascript/api/excel/excel.commentrichcontent#richcontent)||
-|[Range](/javascript/api/excel/excel.range)|[moveTo(destinationRange: Range \| string)](/javascript/api/excel/excel.range#moveto-destinationrange-)|Moves cell values, formatting, and formulas from current range to the destination range, replacing the old information in those cells.|
-|[RangeFormat](/javascript/api/excel/excel.rangeformat)|[adjustIndent(amount: number)](/javascript/api/excel/excel.rangeformat#adjustindent-amount-)|Adjusts the indentation of the range formatting. The indent value ranges from 0 to 250 and is measured in characters.|
+|[ChartAxisTitle](/javascript/api/excel/excel.chartaxistitle)|[textOrientation](/javascript/api/excel/excel.chartaxistitle#textorientation)|Specifies the angle to which the text is oriented for the chart axis title. The value should either be an integer from -90 to 90 or the integer 180 for vertically-oriented text.|
+|[PivotTableScopedCollection](/javascript/api/excel/excel.pivottablescopedcollection)|[getCount()](/javascript/api/excel/excel.pivottablescopedcollection#getcount--)|Gets the number of PivotTables in the collection.|
+||[getFirst()](/javascript/api/excel/excel.pivottablescopedcollection#getfirst--)|Gets the first PivotTable in the collection. The PivotTables in the collection are sorted top to bottom and left to right, such that top-left table is the first PivotTable in the collection.|
+||[getItem(key: string)](/javascript/api/excel/excel.pivottablescopedcollection#getitem-key-)|Gets a PivotTable by name.|
+||[getItemOrNullObject(name: string)](/javascript/api/excel/excel.pivottablescopedcollection#getitemornullobject-name-)|Gets a PivotTable by name. If the PivotTable does not exist, will return a null object.|
+||[items](/javascript/api/excel/excel.pivottablescopedcollection#items)|Gets the loaded child items in this collection.|
+|[Range](/javascript/api/excel/excel.range)|[getPivotTables(fullyContained?: boolean)](/javascript/api/excel/excel.range#getpivottables-fullycontained-)|Gets a scoped collection of PivotTables that overlap with the range.|
 
 ## See also
 

--- a/docs/reference/requirement-sets/excel-api-requirement-sets.md
+++ b/docs/reference/requirement-sets/excel-api-requirement-sets.md
@@ -1,7 +1,7 @@
 ---
 title: Excel JavaScript API requirement sets
 description: 'Office Add-in requirement set information for Excel builds.'
-ms.date: 04/16/2020
+ms.date: 05/06/2020
 ms.prod: excel
 localization_priority: Priority
 ---
@@ -23,16 +23,17 @@ Excel add-ins run across multiple versions of Office, including Office 2016 or l
 |:-----|-----|:-----|:-----|:-----|:-----|
 | [Preview](excel-preview-apis.md)  | Please use the latest Office version to try preview APIs (you may need to join the [Office Insider program](https://insider.office.com)) |
 | [ExcelApiOnline](excel-api-online-requirement-set.md) | N/A | N/A | N/A | Latest (see [requirement set page](./excel-api-online-requirement-set.md)) |
-| [ExcelApi 1.10](excel-api-1-10-requirement-set.md) | Version 1907 (Build 11929.20306) or later | 2.30 or later | 16.30 or later | October 2019 |
-| [ExcelApi 1.9](excel-api-1-9-requirement-set.md)  | Version 1903 (Build 11425.20204) or later | 2.24 or later | 16.24 or later | May 2019 |
-| [ExcelApi 1.8](excel-api-1-8-requirement-set.md)  | Version 1808 (Build 10730.20102) or later | 2.17 or later | 16.17 or later | September 2018 |
-| [ExcelApi 1.7](excel-api-1-7-requirement-set.md)  | Version 1801 (Build 9001.2171) or later   | 2.9 or later  | 16.9 or later  | April 2018 |
-| [ExcelApi 1.6](excel-api-1-6-requirement-set.md)  | Version 1704 (Build 8201.2001) or later   | 2.2 or later  | 15.36 or later | April 2017 |
-| [ExcelApi 1.5](excel-api-1-5-requirement-set.md)  | Version 1703 (Build 8067.2070) or later   | 2.2 or later  | 15.36 or later | March 2017 |
-| [ExcelApi 1.4](excel-api-1-4-requirement-set.md)  | Version 1701 (Build 7870.2024) or later   | 2.2 or later  | 15.36 or later | January 2017 |
-| [ExcelApi 1.3](excel-api-1-3-requirement-set.md)  | Version 1608 (Build 7369.2055) or later   | 1.27 or later | 15.27 or later | September 2016 |
-| [ExcelApi 1.2](excel-api-1-2-requirement-set.md)  | Version 1601 (Build 6741.2088) or later   | 1.21 or later | 15.22 or later | January 2016 |
-| [ExcelApi 1.1](excel-api-1-1-requirement-set.md)  | Version 1509 (Build 4266.1001) or later   | 1.19 or later | 15.20 or later | January 2016 |
+| [ExcelApi 1.11](excel-api-1-11-requirement-set.md) | Version 2002 (Build 12527.20470) or later | 16.35 or later | 16.33 or later | May 2020 |
+| [ExcelApi 1.10](excel-api-1-10-requirement-set.md) | Version 1907 (Build 11929.20306) or later | 16.0 or later | 16.30 or later | October 2019 |
+| [ExcelApi 1.9](excel-api-1-9-requirement-set.md)  | Version 1903 (Build 11425.20204) or later | 16.0 or later | 16.24 or later | May 2019 |
+| [ExcelApi 1.8](excel-api-1-8-requirement-set.md)  | Version 1808 (Build 10730.20102) or later | 16.0 or later | 16.17 or later | September 2018 |
+| [ExcelApi 1.7](excel-api-1-7-requirement-set.md)  | Version 1801 (Build 9001.2171) or later   | 16.0 or later  | 16.9 or later  | April 2018 |
+| [ExcelApi 1.6](excel-api-1-6-requirement-set.md)  | Version 1704 (Build 8201.2001) or later   | 15.0 or later  | 15.36 or later | April 2017 |
+| [ExcelApi 1.5](excel-api-1-5-requirement-set.md)  | Version 1703 (Build 8067.2070) or later   | 15.0 or later  | 15.36 or later | March 2017 |
+| [ExcelApi 1.4](excel-api-1-4-requirement-set.md)  | Version 1701 (Build 7870.2024) or later   | 15.0 or later  | 15.36 or later | January 2017 |
+| [ExcelApi 1.3](excel-api-1-3-requirement-set.md)  | Version 1608 (Build 7369.2055) or later   | 15.0 or later | 15.27 or later | September 2016 |
+| [ExcelApi 1.2](excel-api-1-2-requirement-set.md)  | Version 1601 (Build 6741.2088) or later   | 15.0 or later | 15.22 or later | January 2016 |
+| [ExcelApi 1.1](excel-api-1-1-requirement-set.md)  | Version 1509 (Build 4266.1001) or later   | 15.0 or later | 15.20 or later | January 2016 |
 
 > [!NOTE]
 > Perpetual versions of Office support requirement sets as follows:

--- a/docs/reference/requirement-sets/excel-preview-apis.md
+++ b/docs/reference/requirement-sets/excel-preview-apis.md
@@ -1,7 +1,7 @@
 ---
 title: Excel JavaScript preview APIs
 description: 'Details about upcoming Excel JavaScript APIs'
-ms.date: 03/19/2020
+ms.date: 05/06/2020
 ms.prod: excel
 localization_priority: Normal
 ---
@@ -16,10 +16,10 @@ The first table provides a concise summary of the APIs, while the subsequent tab
 
 | Feature area | Description | Relevant objects |
 |:--- |:--- |:--- |
-| [Culture settings](../../excel/excel-add-ins-workbooks.md#access-application-culture-settings-preview) | Gets cultural system settings for the workbook, such as number formatting. | [CultureInfo](/javascript/api/excel/excel.cultureinfo), [NumberFormatInfo](/javascript/api/excel/excel.numberformatinfo) [Application](/javascript/api/excel/excel.application) |
+| Date and time [Culture settings](../../excel/excel-add-ins-workbooks.md#access-application-culture-settings) | Gives access to additional cultural settings around date and time formatting. | [CultureInfo](/javascript/api/excel/excel.cultureinfo), [NumberFormatInfo](/javascript/api/excel/excel.numberformatinfo) [Application](/javascript/api/excel/excel.application) |
 | [Insert workbook](../../excel/excel-add-ins-workbooks.md#insert-a-copy-of-an-existing-workbook-into-the-current-one-preview) | Insert one workbook into another.  | [Workbook](/javascript/api/excel/excel.worksheetcollection) |
 | Pivot Filters | Applies value-driven filters to the fields of a PivotTable. | [PivotField](/javascript/api/excel/excel.pivotfield#applyfilter-filter-), [PivotFilters](/javascript/api/excel/excel.pivotFilters) |
-| Workbook [Save](../../excel/excel-add-ins-workbooks.md#save-the-workbook-preview) and [Close](../../excel/excel-add-ins-workbooks.md#close-the-workbook-preview) | Save and close workbooks.  | [Workbook](/javascript/api/excel/excel.workbook) |
+|Range spilling | Lets add-ins find ranges associated with [dynamic array](https://support.microsoft.com/office/dynamic-array-formulas-and-spilled-array-behavior-205c6b06-03ba-4151-89a1-87a7eb36e531) results. | [Range](/javascript/api/excel/excel.range) |
 
 ## API list
 
@@ -27,33 +27,22 @@ The following table lists the Excel JavaScript APIs currently in preview. To see
 
 | Class | Fields | Description |
 |:---|:---|:---|
-|[Application](/javascript/api/excel/excel.application)|[cultureInfo](/javascript/api/excel/excel.application#cultureinfo)|Provides information based on current system culture settings. This includes the culture names, number formatting, and other culturally dependent settings.|
-||[decimalSeparator](/javascript/api/excel/excel.application#decimalseparator)|Gets the string used as the decimal separator for numeric values. This is based on Excel's local settings.|
-||[thousandsSeparator](/javascript/api/excel/excel.application#thousandsseparator)|Gets the string used to separate groups of digits to the left of the decimal for numeric values. This is based on Excel's local settings.|
-||[useSystemSeparators](/javascript/api/excel/excel.application#usesystemseparators)|Specifies whether the system separators of Microsoft Excel are enabled.|
-|[ChartAxisTitle](/javascript/api/excel/excel.chartaxistitle)|[textOrientation](/javascript/api/excel/excel.chartaxistitle#textorientation)|Represents the angle to which the text is oriented for the chart axis title. The value should either be an integer from -90 to 90 or the integer 180 for vertically-oriented text.|
 |[ChartSeries](/javascript/api/excel/excel.chartseries)|[getDimensionValues(dimension: Excel.ChartSeriesDimension)](/javascript/api/excel/excel.chartseries#getdimensionvalues-dimension-)|Gets the values from a single dimension of the chart series. These could be either category values or data values, depending on the dimension specified and how the data is mapped for the chart series.|
 |[Comment](/javascript/api/excel/excel.comment)|[contentType](/javascript/api/excel/excel.comment#contenttype)|Gets the content type of the comment.|
-||[resolved](/javascript/api/excel/excel.comment#resolved)|Gets or sets the status of the comment thread. A value of "true" means the thread is resolved.|
-|[CommentReply](/javascript/api/excel/excel.commentreply)|[contentType](/javascript/api/excel/excel.commentreply#contenttype)|Gets the content type of the reply.|
-||[resolved](/javascript/api/excel/excel.commentreply#resolved)|Gets or sets the reply status. A value of "true" means the reply is in the resolved state.|
+|[CommentReply](/javascript/api/excel/excel.commentreply)|[contentType](/javascript/api/excel/excel.commentreply#contenttype)|The content type of the reply.|
 |[CultureInfo](/javascript/api/excel/excel.cultureinfo)|[datetimeFormat](/javascript/api/excel/excel.cultureinfo#datetimeformat)|Defines the culturally appropriate format of displaying date and time. This is based on current system culture settings.|
-||[name](/javascript/api/excel/excel.cultureinfo#name)|Gets the culture name in the format languagecode2-country/regioncode2 (e.g. "zh-cn" or "en-us"). This is based on current system settings.|
-||[numberFormat](/javascript/api/excel/excel.cultureinfo#numberformat)|Defines the culturally appropriate format of displaying numbers. This is based on current system culture settings.|
 |[DatetimeFormatInfo](/javascript/api/excel/excel.datetimeformatinfo)|[dateSeparator](/javascript/api/excel/excel.datetimeformatinfo#dateseparator)|Gets the string used as the date separator. This is based on current system settings.|
 ||[longDatePattern](/javascript/api/excel/excel.datetimeformatinfo#longdatepattern)|Gets the format string for a long date value. This is based on current system settings.|
 ||[longTimePattern](/javascript/api/excel/excel.datetimeformatinfo#longtimepattern)|Gets the format string for a long time value. This is based on current system settings.|
 ||[shortDatePattern](/javascript/api/excel/excel.datetimeformatinfo#shortdatepattern)|Gets the format string for a short date value. This is based on current system settings.|
 ||[timeSeparator](/javascript/api/excel/excel.datetimeformatinfo#timeseparator)|Gets the string used as the time separator. This is based on current system settings.|
-|[NumberFormatInfo](/javascript/api/excel/excel.numberformatinfo)|[numberDecimalSeparator](/javascript/api/excel/excel.numberformatinfo#numberdecimalseparator)|Gets the string used as the decimal separator for numeric values. This is based on current system settings.|
-||[numberGroupSeparator](/javascript/api/excel/excel.numberformatinfo#numbergroupseparator)|Gets the string used to separate groups of digits to the left of the decimal for numeric values. This is based on current system settings.|
 |[PivotDateFilter](/javascript/api/excel/excel.pivotdatefilter)|[comparator](/javascript/api/excel/excel.pivotdatefilter#comparator)|The comparator is the static value to which other values are compared. The type of comparison is defined by the condition.|
-||[condition](/javascript/api/excel/excel.pivotdatefilter#condition)|Indicates the condition for the filter, which defines the necessary filtering criteria.|
+||[condition](/javascript/api/excel/excel.pivotdatefilter#condition)|Specifies the condition for the filter, which defines the necessary filtering criteria.|
 ||[exclusive](/javascript/api/excel/excel.pivotdatefilter#exclusive)|If true, filter *excludes* items that meet criteria. The default is false (filter to include items that meet criteria).|
 ||[lowerBound](/javascript/api/excel/excel.pivotdatefilter#lowerbound)|The lower-bound of the range for the `Between` filter condition.|
 ||[upperBound](/javascript/api/excel/excel.pivotdatefilter#upperbound)|The upper-bound of the range for the `Between` filter condition.|
 ||[wholeDays](/javascript/api/excel/excel.pivotdatefilter#wholedays)|For `Equals`, `Before`, `After`, and `Between` filter conditions, indicates if comparisons should be made as whole days.|
-|[PivotField](/javascript/api/excel/excel.pivotfield)|[applyFilter(filter: PivotValueFilter \| PivotLabelFilter \| PivotManualFilter \| PivotDateFilter \| PivotFilters)](/javascript/api/excel/excel.pivotfield#applyfilter-filter-)|Sets one or multiple of the field's current PivotFilters and applies them to the field.|
+|[PivotField](/javascript/api/excel/excel.pivotfield)|[applyFilter(filter: Excel.PivotFilters)](/javascript/api/excel/excel.pivotfield#applyfilter-filter-)|Sets one or multiple of the field's current PivotFilters and applies them to the field.|
 ||[clearAllFilters()](/javascript/api/excel/excel.pivotfield#clearallfilters--)|Clears all criteria from all of the field's filters. This removes any active filtering on the field.|
 ||[clearFilter(filterType: Excel.PivotFilterType)](/javascript/api/excel/excel.pivotfield#clearfilter-filtertype-)|Clears all existing criteria from the field's filter of the given type (if one is currently applied).|
 ||[getFilters()](/javascript/api/excel/excel.pivotfield#getfilters--)|Gets all filters currently applied on the field.|
@@ -63,7 +52,7 @@ The following table lists the Excel JavaScript APIs currently in preview. To see
 ||[manualFilter](/javascript/api/excel/excel.pivotfilters#manualfilter)|The PivotField's currently applied manual filter. Null if none is applied.|
 ||[valueFilter](/javascript/api/excel/excel.pivotfilters#valuefilter)|The PivotField's currently applied value filter. Null if none is applied.|
 |[PivotLabelFilter](/javascript/api/excel/excel.pivotlabelfilter)|[comparator](/javascript/api/excel/excel.pivotlabelfilter#comparator)|The comparator is the static value to which other values are compared. The type of comparison is defined by the condition.|
-||[condition](/javascript/api/excel/excel.pivotlabelfilter#condition)|Indicates the condition for the filter, which defines the necessary filtering criteria.|
+||[condition](/javascript/api/excel/excel.pivotlabelfilter#condition)|Specifies the condition for the filter, which defines the necessary filtering criteria.|
 ||[exclusive](/javascript/api/excel/excel.pivotlabelfilter#exclusive)|If true, filter *excludes* items that meet criteria. The default is false (filter to include items that meet criteria).|
 ||[lowerBound](/javascript/api/excel/excel.pivotlabelfilter#lowerbound)|The lower-bound of the range for the Between filter condition.|
 ||[substring](/javascript/api/excel/excel.pivotlabelfilter#substring)|The substring used for `BeginsWith`, `EndsWith`, and `Contains` filter conditions.|
@@ -72,27 +61,21 @@ The following table lists the Excel JavaScript APIs currently in preview. To see
 ||[pivotStyle](/javascript/api/excel/excel.pivotlayout#pivotstyle)|The style applied to the PivotTable.|
 ||[setStyle(style: string \| PivotTableStyle \| BuiltInPivotTableStyle)](/javascript/api/excel/excel.pivotlayout#setstyle-style-)|Sets the style applied to the PivotTable.|
 |[PivotManualFilter](/javascript/api/excel/excel.pivotmanualfilter)|[selectedItems](/javascript/api/excel/excel.pivotmanualfilter#selecteditems)|A list of selected items to manually filter. These must be existing and valid items from the chosen field.|
-|[PivotTable](/javascript/api/excel/excel.pivottable)|[allowMultipleFiltersPerField](/javascript/api/excel/excel.pivottable#allowmultiplefiltersperfield)|Specifies whether the PivotTable allows the application of multiple PivotFilters on a given PivotField in the table.|
-|[PivotTableScopedCollection](/javascript/api/excel/excel.pivottablescopedcollection)|[getCount()](/javascript/api/excel/excel.pivottablescopedcollection#getcount--)|Gets the number of PivotTables in the collection.|
-||[getFirst()](/javascript/api/excel/excel.pivottablescopedcollection#getfirst--)|Gets the first PivotTable in the collection. The PivotTables in the collection are sorted top to bottom and left to right, such that top-left table is the first PivotTable in the collection.|
-||[getItem(key: string)](/javascript/api/excel/excel.pivottablescopedcollection#getitem-key-)|Gets a PivotTable by name.|
-||[getItemOrNullObject(name: string)](/javascript/api/excel/excel.pivottablescopedcollection#getitemornullobject-name-)|Gets a PivotTable by name. If the PivotTable does not exist, will return a null object.|
-||[items](/javascript/api/excel/excel.pivottablescopedcollection#items)|Gets the loaded child items in this collection.|
+|[PivotTable](/javascript/api/excel/excel.pivottable)|[allowMultipleFiltersPerField](/javascript/api/excel/excel.pivottable#allowmultiplefiltersperfield)|Specifies if the PivotTable allows the application of multiple PivotFilters on a given PivotField in the table.|
 |[PivotValueFilter](/javascript/api/excel/excel.pivotvaluefilter)|[comparator](/javascript/api/excel/excel.pivotvaluefilter#comparator)|The comparator is the static value to which other values are compared. The type of comparison is defined by the condition.|
-||[condition](/javascript/api/excel/excel.pivotvaluefilter#condition)|Indicates the condition for the filter, which defines the necessary filtering criteria.|
+||[condition](/javascript/api/excel/excel.pivotvaluefilter#condition)|Specifies the condition for the filter, which defines the necessary filtering criteria.|
 ||[exclusive](/javascript/api/excel/excel.pivotvaluefilter#exclusive)|If true, filter *excludes* items that meet criteria. The default is false (filter to include items that meet criteria).|
 ||[lowerBound](/javascript/api/excel/excel.pivotvaluefilter#lowerbound)|The lower-bound of the range for the `Between` filter condition.|
-||[selectionType](/javascript/api/excel/excel.pivotvaluefilter#selectiontype)|Indicates whether the filter is for the top/bottom N items, top/bottom N percent, or top/bottom N sum.|
+||[selectionType](/javascript/api/excel/excel.pivotvaluefilter#selectiontype)|Specifies if the filter is for the top/bottom N items, top/bottom N percent, or top/bottom N sum.|
 ||[threshold](/javascript/api/excel/excel.pivotvaluefilter#threshold)|The "N" threshold number of items, percent, or sum to be filtered for a Top/Bottom filter condition.|
 ||[upperBound](/javascript/api/excel/excel.pivotvaluefilter#upperbound)|The upper-bound of the range for the `Between` filter condition.|
 ||[value](/javascript/api/excel/excel.pivotvaluefilter#value)|Name of the chosen "value" in the field by which to filter.|
-|[Range](/javascript/api/excel/excel.range)|[getPivotTables(fullyContained?: boolean)](/javascript/api/excel/excel.range#getpivottables-fullycontained-)|Gets a scoped collection of PivotTables that overlap with the range.|
-||[getSpillParent()](/javascript/api/excel/excel.range#getspillparent--)|Gets the range object containing the anchor cell for a cell getting spilled into. Fails if applied to a range with more than one cell. Read-only.|
-||[getSpillParentOrNullObject()](/javascript/api/excel/excel.range#getspillparentornullobject--)|Gets the range object containing the anchor cell for a cell getting spilled into. Read-only.|
-||[getSpillingToRange()](/javascript/api/excel/excel.range#getspillingtorange--)|Gets the range object containing the spill range when called on an anchor cell. Fails if applied to a range with more than one cell. Read-only.|
-||[getSpillingToRangeOrNullObject()](/javascript/api/excel/excel.range#getspillingtorangeornullobject--)|Gets the range object containing the spill range when called on an anchor cell. Read-only.|
+|[Range](/javascript/api/excel/excel.range)|[getSpillParent()](/javascript/api/excel/excel.range#getspillparent--)|Gets the range object containing the anchor cell for a cell getting spilled into. Fails if applied to a range with more than one cell.|
+||[getSpillParentOrNullObject()](/javascript/api/excel/excel.range#getspillparentornullobject--)|Gets the range object containing the anchor cell for a cell getting spilled into.|
+||[getSpillingToRange()](/javascript/api/excel/excel.range#getspillingtorange--)|Gets the range object containing the spill range when called on an anchor cell. Fails if applied to a range with more than one cell.|
+||[getSpillingToRangeOrNullObject()](/javascript/api/excel/excel.range#getspillingtorangeornullobject--)|Gets the range object containing the spill range when called on an anchor cell.|
 ||[hasSpill](/javascript/api/excel/excel.range#hasspill)|Represents if all cells have a spill border.|
-||[numberFormatCategories](/javascript/api/excel/excel.range#numberformatcategories)|Represents the category of number format of each cell. Read-only.|
+||[numberFormatCategories](/javascript/api/excel/excel.range#numberformatcategories)|Represents the category of number format of each cell.|
 ||[savedAsArray](/javascript/api/excel/excel.range#savedasarray)|Represents if ALL the cells would be saved as an array formula.|
 |[ShapeCollection](/javascript/api/excel/excel.shapecollection)|[addSvg(xml: string)](/javascript/api/excel/excel.shapecollection#addsvg-xml-)|Creates a scalable vector graphic (SVG) from an XML string and adds it to the worksheet. Returns a Shape object that represents the new image.|
 |[Slicer](/javascript/api/excel/excel.slicer)|[nameInFormula](/javascript/api/excel/excel.slicer#nameinformula)|Represents the slicer name used in the formula.|
@@ -106,29 +89,22 @@ The following table lists the Excel JavaScript APIs currently in preview. To see
 |[TableFilteredEventArgs](/javascript/api/excel/excel.tablefilteredeventargs)|[tableId](/javascript/api/excel/excel.tablefilteredeventargs#tableid)|Gets the id of the table in which the filter is applied.|
 ||[type](/javascript/api/excel/excel.tablefilteredeventargs#type)|Gets the type of the event. See Excel.EventType for details.|
 ||[worksheetId](/javascript/api/excel/excel.tablefilteredeventargs#worksheetid)|Gets the id of the worksheet which contains the table.|
-|[Workbook](/javascript/api/excel/excel.workbook)|[close(closeBehavior?: Excel.CloseBehavior)](/javascript/api/excel/excel.workbook#close-closebehavior-)|Close current workbook.|
-||[save(saveBehavior?: Excel.SaveBehavior)](/javascript/api/excel/excel.workbook#save-savebehavior-)|Save current workbook.|
+|[Workbook](/javascript/api/excel/excel.workbook)|[showPivotFieldList](/javascript/api/excel/excel.workbook#showpivotfieldlist)|Specifies whether the PivotTable's field list pane is shown at the workbook level.|
 ||[use1904DateSystem](/javascript/api/excel/excel.workbook#use1904datesystem)|True if the workbook uses the 1904 date system.|
 |[Worksheet](/javascript/api/excel/excel.worksheet)|[customProperties](/javascript/api/excel/excel.worksheet#customproperties)|Gets a collection of worksheet-level custom properties.|
 ||[onFiltered](/javascript/api/excel/excel.worksheet#onfiltered)|Occurs when filter is applied on a specific worksheet.|
-||[onRowHiddenChanged](/javascript/api/excel/excel.worksheet#onrowhiddenchanged)|Occurs when the hidden state of one or more rows has changed on a specific worksheet.|
-|[WorksheetCalculatedEventArgs](/javascript/api/excel/excel.worksheetcalculatedeventargs)|[address](/javascript/api/excel/excel.worksheetcalculatedeventargs#address)|The address of the range that completed calculation.|
 |[WorksheetCollection](/javascript/api/excel/excel.worksheetcollection)|[addFromBase64(base64File: string, sheetNamesToInsert?: string[], positionType?: Excel.WorksheetPositionType, relativeTo?: Worksheet \| string)](/javascript/api/excel/excel.worksheetcollection#addfrombase64-base64file--sheetnamestoinsert--positiontype--relativeto-)|Inserts the specified worksheets of a workbook into the current workbook.|
 ||[onFiltered](/javascript/api/excel/excel.worksheetcollection#onfiltered)|Occurs when any worksheet's filter is applied in the workbook.|
-||[onRowHiddenChanged](/javascript/api/excel/excel.worksheetcollection#onrowhiddenchanged)|Occurs when the hidden state of one or more rows has changed on a specific worksheet.|
-|[WorksheetCustomProperty](/javascript/api/excel/excel.worksheetcustomproperty)|[key](/javascript/api/excel/excel.worksheetcustomproperty#key)|Gets the key of the custom property. Read only.|
-||[value](/javascript/api/excel/excel.worksheetcustomproperty#value)|Gets the value of the custom property. Read only.|
-|[WorksheetCustomPropertyCollection](/javascript/api/excel/excel.worksheetcustompropertycollection)|[getCount()](/javascript/api/excel/excel.worksheetcustompropertycollection#getcount--)|Gets the number of custom properties on this worksheet.|
+|[WorksheetCustomProperty](/javascript/api/excel/excel.worksheetcustomproperty)|[delete()](/javascript/api/excel/excel.worksheetcustomproperty#delete--)|Deletes the custom property.|
+||[key](/javascript/api/excel/excel.worksheetcustomproperty#key)|Gets the key of the custom property. Custom property keys are case-insensitive.|
+||[value](/javascript/api/excel/excel.worksheetcustomproperty#value)|Gets or sets the value of the custom property.|
+|[WorksheetCustomPropertyCollection](/javascript/api/excel/excel.worksheetcustompropertycollection)|[add(key: string, value: string)](/javascript/api/excel/excel.worksheetcustompropertycollection#add-key--value-)|Adds a new custom property that maps to the provided key. This overwrites existing custom properties with that key.|
+||[getCount()](/javascript/api/excel/excel.worksheetcustompropertycollection#getcount--)|Gets the number of custom properties on this worksheet.|
 ||[getItem(key: string)](/javascript/api/excel/excel.worksheetcustompropertycollection#getitem-key-)|Gets a custom property object by its key, which is case-insensitive. Throws if the custom property does not exist.|
 ||[getItemOrNullObject(key: string)](/javascript/api/excel/excel.worksheetcustompropertycollection#getitemornullobject-key-)|Gets a custom property object by its key, which is case-insensitive. Returns a null object if the custom property does not exist.|
 ||[items](/javascript/api/excel/excel.worksheetcustompropertycollection#items)|Gets the loaded child items in this collection.|
 |[WorksheetFilteredEventArgs](/javascript/api/excel/excel.worksheetfilteredeventargs)|[type](/javascript/api/excel/excel.worksheetfilteredeventargs#type)|Gets the type of the event. See Excel.EventType for details.|
 ||[worksheetId](/javascript/api/excel/excel.worksheetfilteredeventargs#worksheetid)|Gets the id of the worksheet in which the filter is applied.|
-|[WorksheetRowHiddenChangedEventArgs](/javascript/api/excel/excel.worksheetrowhiddenchangedeventargs)|[address](/javascript/api/excel/excel.worksheetrowhiddenchangedeventargs#address)|Gets the range address that represents the changed area of a specific worksheet.|
-||[changeType](/javascript/api/excel/excel.worksheetrowhiddenchangedeventargs#changetype)|Gets the type of change that represents how the event was triggered. See `Excel.RowHiddenChangeType` for details.|
-||[source](/javascript/api/excel/excel.worksheetrowhiddenchangedeventargs#source)|Gets the source of the event. See Excel.EventSource for details.|
-||[type](/javascript/api/excel/excel.worksheetrowhiddenchangedeventargs#type)|Gets the type of the event. See Excel.EventType for details.|
-||[worksheetId](/javascript/api/excel/excel.worksheetrowhiddenchangedeventargs#worksheetid)|Gets the id of the worksheet in which the data changed.|
 
 ## See also
 

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -546,6 +546,9 @@
       - name: ExcelApi online-only requirement set
         href: reference/requirement-sets/excel-api-online-requirement-set.md
         displayName: Excel
+      - name: ExcelApi 1.11 requirement set
+        href: reference/requirement-sets/excel-api-1-11-requirement-set.md
+        displayName: Excel
       - name: ExcelApi 1.10 requirement set
         href: reference/requirement-sets/excel-api-1-10-requirement-set.md
         displayName: Excel


### PR DESCRIPTION
This PR:
- Adds a page for ExcelApi 1.11.
- Updates the Excel Preview APIs with the current difference between preview and release.
- Updates the ExcelApiOnline 1.1 page to reflect the current differences between 1.11 and Online.
- Updates the requirement set overview to give the build numbers for ExcelApi 1.11 (based on https://github.com/OfficeDev/Office-Js-Requirement-Sets/pull/57).
- Updates the iOS build numbers (based on https://github.com/OfficeDev/Office-Js-Requirement-Sets/pull/56).
- Removes any preview or online-only tags from article sections that no longer apply.