### PR TITLE
[all](ToC) TOC update ideas

### DIFF
--- a/docs/overview/learning-path-beginner.md
+++ b/docs/overview/learning-path-beginner.md
@@ -1,17 +1,17 @@
 ---
-title: Start Here! A guide for beginners making Office Add-ins
+title: Beginner's guide
 description:  A recommended path for beginners through the learning resources for Office Add-ins.
 ms.date: 04/16/2020
 ms.custom: scenarios:getting-started
 localization_priority: Priority
 ---
 
-# Start Here! A guide for beginners making Office Add-ins
+# Beginner's guide
 
 Want to get started building your own cross-platform Office extensions? The following steps show you what to read first, what tools to install, and recommended tutorials to complete.
 
 > [!NOTE]
-> If you're experienced in creating VSTO add-ins for Office, we recommend that you immediately turn to [Transition Here! A guide for VSTO add-in creators making Office Web Add-ins](learning-path-transition.md), which is a superset of the information in this article.
+> If you're experienced in creating VSTO add-ins for Office, we recommend that you immediately turn to [VSTO add-in developer's guide](learning-path-transition.md), which is a superset of the information in this article.
 
 ## Step 0: Prerequisites
 

--- a/docs/overview/learning-path-transition.md
+++ b/docs/overview/learning-path-transition.md
@@ -1,12 +1,12 @@
 ---
-title: Transition Here! A guide for VSTO add-in creators making Office Web Add-ins
+title: VSTO add-in developer's guide
 description:  A recommended path for experienced VSTO add-in developers to learning resources for Office Web Add-ins.
 ms.date: 05/10/2020
 ms.custom: scenarios:getting-started
 localization_priority: Priority
 ---
 
-# Transition Here! A guide for VSTO add-in creators making Office Web Add-ins
+# VSTO add-in developer's guide
 
 So, you've made some VSTO add-ins for Office applications that run on Windows and now you're exploring the new way of extending Office that will run on Windows, Mac, and the online version of the Office suite: Office Web Add-ins.
 
@@ -16,7 +16,7 @@ Your understanding of the object models for the Excel, Word, and the other Offic
 - Office Web Add-ins are deployed differently from VSTO add-ins.
 - Office Web Add-ins are web applications that run in a simplified browser window that is embedded in the Office application, so you need to gain a basic understanding of web applications and how they are hosted on web servers or cloud accounts. 
 
-For these reasons, much of this article duplicates our learning path for complete beginners to Office extensions: [Start Here! A guide for beginners making Office Add-ins](learning-path-beginner.md). What we have added are some additional learning resources to help VSTO add-in developers leverage their experience, and also help them reuse their existing code.
+For these reasons, much of this article duplicates our learning path for complete beginners to Office extensions: [Beginner's guide](learning-path-beginner.md). What we have added are some additional learning resources to help VSTO add-in developers leverage their experience, and also help them reuse their existing code.
 
 ## Step 0: Prerequisites
 

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -7,10 +7,10 @@
 
 - name: Get started
   items:
-  - name: Beginners' guide
+  - name: Beginner's guide
     href: overview/learning-path-beginner.md
     displayName: develop
-  - name: VSTO add-in developers guide
+  - name: VSTO add-in developer's guide
     href: overview/learning-path-transition.md
     displayName: develop
   - name: Development process overview

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -13,7 +13,7 @@
   - name: A guide for VSTO add-in developers
     href: overview/learning-path-transition.md
     displayName: develop
-  - name: Office Add-ins development process
+  - name: Development process overview
     href: overview/office-add-ins-fundamentals.md
     displayName: develop
   - name: Quick starts

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -13,7 +13,7 @@
   - name: A guide for VSTO add-in developers
     href: overview/learning-path-transition.md
     displayName: develop
-  - name: Office Add-ins end-to-end development process
+  - name: Office Add-ins development process
     href: overview/office-add-ins-fundamentals.md
     displayName: develop
   - name: Quick starts

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -41,7 +41,7 @@
     href: overview/set-up-your-dev-environment.md
     displayName: Excel, Word, OneNote, Project, PowerPoint, Outlook
 
-- name: Core development concepts
+- name: Development process
   items:
 
   - name: Overview

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -10,7 +10,7 @@
   - name: Beginners' guide
     href: overview/learning-path-beginner.md
     displayName: develop
-  - name: A guide for VSTO add-in developers
+  - name: VSTO add-in developers guide
     href: overview/learning-path-transition.md
     displayName: develop
   - name: Development process overview

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -7,7 +7,7 @@
 
 - name: Get started
   items:
-  - name: A guide for beginners
+  - name: Beginners' guide
     href: overview/learning-path-beginner.md
     displayName: develop
   - name: A guide for VSTO add-in developers

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -7,13 +7,13 @@
 
 - name: Get started
   items:
-  - name: Start Here! A guide for beginners
+  - name: A guide for beginners
     href: overview/learning-path-beginner.md
     displayName: develop
-  - name: Transition Here! A guide for VSTO add-in developers
+  - name: A guide for VSTO add-in developers
     href: overview/learning-path-transition.md
     displayName: develop
-  - name: Building Office Add-ins
+  - name: Office Add-ins end-to-end development process
     href: overview/office-add-ins-fundamentals.md
     displayName: develop
   - name: Quick starts
@@ -41,7 +41,7 @@
     href: overview/set-up-your-dev-environment.md
     displayName: Excel, Word, OneNote, Project, PowerPoint, Outlook
 
-- name: Core concepts
+- name: Core development concepts
   items:
 
   - name: Overview


### PR DESCRIPTION
Link to this branch: https://review.docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins-fundamentals?branch=alison-mk-TOC-ideas

Updated four TOC titles: 
-- removed Start Here! and Transition Here! as discussed in meeting earlier this week, feels awkward plus updated L2 nav will help highlight each learning path 
-- switched "Building Office Add-ins: to "Office Add-ins development process", which to me clarifies that the article is about a broad process, as opposed to specifics for how to build an add-in ("Building Office Add-ins" is so vague to me that I mentally translated it to 'How to build Office Add-ins' and then was confused upon reading the article). 
-- I think 'Core development concepts' adds useful clarity to this node, but honestly I feel less committed to this change than the other 3 