### PR TITLE
[all] (index.yaml) Adding links to main landing page

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -1,7 +1,7 @@
 ### YamlMime:Landing
 
 title: Office Add-ins documentation # < 60 chars
-summary: Use the Office Add-ins platform to build solutions that extend Office applications and interact with content in Office documents. With Office Add-ins, you can use familiar web technologies such as HTML, CSS, and JavaScript to build solutions that can run in Office on the web, Windows, Mac, and iPad. To build your first add-in within a few minutes, check out the Quick starts. To take a deeper dive into add-in development, explore the Tutorials. For an interactive learning experience, try the Microsoft Learn Office Add-in modules, like Introduction to Office client customization with add-ins and Extend Office clients with Office add-ins. # < 160 chars
+summary: Use the Office Add-ins platform to build solutions that extend Office applications and interact with content in Office documents. With Office Add-ins, you can use familiar web technologies such as HTML, CSS, and JavaScript to build solutions that can run in Office on the web, Windows, Mac, and iPad. # < 160 chars
 
 metadata:
   title: Office Add-ins documentation # Required; page title displayed in search results. Include the brand. < 60 chars.

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -38,11 +38,11 @@ landingContent:
             url: project/index.yml
           - text: Word add-ins documentation
             url: word/index.yml
-      - linkListType: concept
+      - linkListType: learn
         links: 
-          - text: Introduction to Office client customization with add-ins
+          - text: Microsoft Learn: Introduction to Office client customization with add-ins
             url: //docs.microsoft.com/en-us/learn/modules/intro-office-add-ins/
-          - text: Extend Office clients with Office add-ins
+          - text: Microsoft Learn: Extend Office clients with Office add-ins
             url: //docs.microsoft.com/en-us/learn/paths/m365-office-add-in-associate/
 
   # Card (optional)

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -41,7 +41,7 @@ landingContent:
       - linkListType: learn
         links: 
           - text: Introduction to Office client customization with add-ins
-            url: //docs.microsoft.com/learn/modules/intro-office-add-ins/
+            url: /learn/modules/intro-office-add-ins/
           - text: Extend Office clients with Office add-ins
             url: //docs.microsoft.com/learn/paths/m365-office-add-in-associate/
 

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -40,10 +40,10 @@ landingContent:
             url: word/index.yml
       - linkListType: learn
         links: 
-          - text: Microsoft Learn Introduction to Office client customization with add-ins
-            url: //docs.microsoft.com/en-us/learn/modules/intro-office-add-ins/
-          - text: Microsoft Learn Extend Office clients with Office add-ins
-            url: //docs.microsoft.com/en-us/learn/paths/m365-office-add-in-associate/
+          - text: Introduction to Office client customization with add-ins
+            url: //docs.microsoft.com/learn/modules/intro-office-add-ins/
+          - text: Extend Office clients with Office add-ins
+            url: //docs.microsoft.com/learn/paths/m365-office-add-in-associate/
 
   # Card (optional)
   - title: Get started

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -22,7 +22,7 @@ landingContent:
     linkLists:
       - linkListType: concept
         links:
-          - text: Core concepts
+          - text: Office Add-ins platform overview
             url: overview/office-add-ins.md
       - linkListType: overview
         links:

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -1,7 +1,8 @@
 ### YamlMime:Landing
 
 title: Office Add-ins documentation # < 60 chars
-summary: Use the Office Add-ins platform to build solutions that extend Office applications and interact with content in Office documents. With Office Add-ins, you can use familiar web technologies such as HTML, CSS, and JavaScript to build solutions that can run in Office on the web, Windows, Mac, and iPad. # < 160 chars
+summary: Use the Office Add-ins platform to build solutions that extend Office applications and interact with content in Office documents. With Office Add-ins, you can use familiar web technologies such as HTML, CSS, and JavaScript to build solutions that can run in Office on the web, Windows, Mac, and iPad. 
+To build your first add-in within a few minutes, check out the Quick starts. To take a deeper dive into add-in development, explore the Tutorials. For an interactive learning experience, try the Microsoft Learn Office Add-in modules: Introduction to Office client customization with add-ins and Extend Office clients with Office add-ins. # < 160 chars
 
 metadata:
   title: Office Add-ins documentation # Required; page title displayed in search results. Include the brand. < 60 chars.

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -1,7 +1,7 @@
 ### YamlMime:Landing
 
 title: Office Add-ins documentation # < 60 chars
-summary: Use the Office Add-ins platform to build solutions that extend Office applications and interact with content in Office documents. With Office Add-ins, you can use familiar web technologies such as HTML, CSS, and JavaScript to build solutions that can run in Office on the web, Windows, Mac, and iPad. To build your first add-in within a few minutes, check out the Quick starts. To take a deeper dive into add-in development, explore the Tutorials. For an interactive learning experience, try the Microsoft Learn Office Add-in modules: Introduction to Office client customization with add-ins and Extend Office clients with Office add-ins. # < 160 chars
+summary: Use the Office Add-ins platform to build solutions that extend Office applications and interact with content in Office documents. With Office Add-ins, you can use familiar web technologies such as HTML, CSS, and JavaScript to build solutions that can run in Office on the web, Windows, Mac, and iPad. To build your first add-in within a few minutes, check out the Quick starts. To take a deeper dive into add-in development, explore the Tutorials. For an interactive learning experience, try the Microsoft Learn Office Add-in modules, like Introduction to Office client customization with add-ins and Extend Office clients with Office add-ins. # < 160 chars
 
 metadata:
   title: Office Add-ins documentation # Required; page title displayed in search results. Include the brand. < 60 chars.

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -43,7 +43,7 @@ landingContent:
           - text: Introduction to Office client customization with add-ins
             url: /learn/modules/intro-office-add-ins/
           - text: Extend Office clients with Office add-ins
-            url: //docs.microsoft.com/learn/paths/m365-office-add-in-associate/
+            url: /learn/paths/m365-office-add-in-associate/
 
   # Card (optional)
   - title: Get started

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -1,8 +1,7 @@
 ### YamlMime:Landing
 
 title: Office Add-ins documentation # < 60 chars
-summary: Use the Office Add-ins platform to build solutions that extend Office applications and interact with content in Office documents. With Office Add-ins, you can use familiar web technologies such as HTML, CSS, and JavaScript to build solutions that can run in Office on the web, Windows, Mac, and iPad. 
-To build your first add-in within a few minutes, check out the Quick starts. To take a deeper dive into add-in development, explore the Tutorials. For an interactive learning experience, try the Microsoft Learn Office Add-in modules: Introduction to Office client customization with add-ins and Extend Office clients with Office add-ins. # < 160 chars
+summary: Use the Office Add-ins platform to build solutions that extend Office applications and interact with content in Office documents. With Office Add-ins, you can use familiar web technologies such as HTML, CSS, and JavaScript to build solutions that can run in Office on the web, Windows, Mac, and iPad. To build your first add-in within a few minutes, check out the Quick starts. To take a deeper dive into add-in development, explore the Tutorials. For an interactive learning experience, try the Microsoft Learn Office Add-in modules: Introduction to Office client customization with add-ins and Extend Office clients with Office add-ins. # < 160 chars
 
 metadata:
   title: Office Add-ins documentation # Required; page title displayed in search results. Include the brand. < 60 chars.

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -10,7 +10,7 @@ metadata:
   ms.topic: landing-page # Required
   author: o365devx #Required; your GitHub user alias, with correct capitalization.
   ms.author: o365devx #Required; microsoft alias of author; optional team alias.
-  ms.date: 07/13/2020 #Required; mm/dd/yyyy format.
+  ms.date: 07/31/2020 #Required; mm/dd/yyyy format.
 
 # linkListType: architecture | concept | deploy | download | get-started | how-to-guide | learn | overview | quickstart | reference | sample | tutorial | video | whats-new
 
@@ -38,6 +38,12 @@ landingContent:
             url: project/index.yml
           - text: Word add-ins documentation
             url: word/index.yml
+      - linkListType: concept
+        links: 
+          - text: Introduction to Office client customization with add-ins
+            url: //docs.microsoft.com/en-us/learn/modules/intro-office-add-ins/
+          - text: Extend Office clients with Office add-ins
+            url: //docs.microsoft.com/en-us/learn/paths/m365-office-add-in-associate/
 
   # Card (optional)
   - title: Get started

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -40,9 +40,9 @@ landingContent:
             url: word/index.yml
       - linkListType: learn
         links: 
-          - text: Microsoft Learn: Introduction to Office client customization with add-ins
+          - text: Microsoft Learn Introduction to Office client customization with add-ins
             url: //docs.microsoft.com/en-us/learn/modules/intro-office-add-ins/
-          - text: Microsoft Learn: Extend Office clients with Office add-ins
+          - text: Microsoft Learn Extend Office clients with Office add-ins
             url: //docs.microsoft.com/en-us/learn/paths/m365-office-add-in-associate/
 
   # Card (optional)

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -24,6 +24,12 @@ landingContent:
         links:
           - text: Office Add-ins platform overview
             url: overview/office-add-ins.md
+      - linkListType: learn
+        links: 
+          - text: Introduction to Office client customization with add-ins
+            url: /learn/modules/intro-office-add-ins/
+          - text: Extend Office clients with Office add-ins
+            url: /learn/paths/m365-office-add-in-associate/
       - linkListType: overview
         links:
           - text: Excel add-ins documentation
@@ -38,12 +44,6 @@ landingContent:
             url: project/index.yml
           - text: Word add-ins documentation
             url: word/index.yml
-      - linkListType: learn
-        links: 
-          - text: Introduction to Office client customization with add-ins
-            url: /learn/modules/intro-office-add-ins/
-          - text: Extend Office clients with Office add-ins
-            url: /learn/paths/m365-office-add-in-associate/
 
   # Card (optional)
   - title: Get started


### PR DESCRIPTION
This PR includes: 
-- my attempt at adding a paragraph to the main landing page (mostly unsuccessful because the page schema is very restrictive -- doesn't allow ":" characters, couldn't figure out how to do a line break, etc). Any suggestions here?? 
-- since the paragraph didn't work, I experimented with adding MS Learn links to the About Office Add-ins card. If we include MS Learn links here, my intuition is that they should open in a new tab, and also that there be some visual indicator that these thinks go to a different section of the site (a small icon?). Not sure how much freedom we have. Open to suggestions here, too! 