### PR TITLE
Excel object model

### DIFF
--- a/docs/excel/excel-add-ins-blank-null-values.md
+++ b/docs/excel/excel-add-ins-blank-null-values.md
@@ -1,0 +1,63 @@
+---
+title: Blank and null values in Excel Add-ins
+description: 'Learn how to work with blank an null values in Excel object model methods and properties.'
+ms.date: 09/03/2020
+localization_priority: Normal
+---
+
+
+## Blank and null values in Excel Add-in
+
+`null` and empty strings have special implications in the Excel JavaScript APIs. They're used to represent empty cells, no formatting, or default values. This section details the use of `null` and empty string when getting and setting properties.
+
+### null input in 2-D Array
+
+In Excel, a range is represented by a 2-D array, where the first dimension is rows and the second dimension is columns. To set values, number format, or formula for only specific cells within a range, specify the values, number format, or formula for those cells in the 2-D array, and specify `null` for all other cells in the 2-D array.
+
+For example, to update the number format for only one cell within a range, and retain the existing number format for all other cells in the range, specify the new number format for the cell to update, and specify `null` for all other cells. The following code snippet sets a new number format for the fourth cell in the range, and leaves the number format unchanged for the first three cells in the range.
+
+```js
+range.values = [['Eurasia', '29.96', '0.25', '15-Feb' ]];
+range.numberFormat = [[null, null, null, 'm/d/yyyy;@']];
+```
+
+### null input for a property
+
+`null` is not a valid input for single property. For example, the following code snippet is not valid, as the `values` property of the range cannot be set to `null`.
+
+```js
+range.values = null;
+```
+
+Likewise, the following code snippet is not valid, as `null` is not a valid value for the `color` property.
+
+```js
+range.format.fill.color =  null;
+```
+
+### null property values in the response
+
+Formatting properties such as `size` and `color` will contain `null` values in the response when different values exist in the specified range. For example, if you retrieve a range and load its `format.font.color` property:
+
+* If all cells in the range have the same font color, `range.format.font.color` specifies that color.
+* If multiple font colors are present within the range, `range.format.font.color` is `null`.
+
+### Blank input for a property
+
+When you specify a blank value for a property (i.e., two quotation marks with no space in-between `''`), it will be interpreted as an instruction to clear or reset the property. For example:
+
+* If you specify a blank value for the `values` property of a range, the content of the range is cleared.
+* If you specify a blank value for the `numberFormat` property, the number format is reset to `General`.
+* If you specify a blank value for the `formula` property and `formulaLocale` property, the formula values are cleared.
+
+### Blank property values in the response
+
+For read operations, a blank property value in the response (i.e., two quotation marks with no space in-between `''`) indicates that cell contains no data or value. In the first example below, the first and last cell in the range contain no data. In the second example, the first two cells in the range do not contain a formula.
+
+```js
+range.values = [['', 'some', 'data', 'in', 'other', 'cells', '']];
+```
+
+```js
+range.formula = [['', '', '=Rand()']];
+```

--- a/docs/excel/excel-add-ins-blank-null-values.md
+++ b/docs/excel/excel-add-ins-blank-null-values.md
@@ -1,12 +1,12 @@
 ---
-title: Blank and null values in Excel Add-ins
+title: Blank and null values in Excel add-ins
 description: 'Learn how to work with blank an null values in Excel object model methods and properties.'
 ms.date: 09/03/2020
 localization_priority: Normal
 ---
 
 
-# Blank and null values in Excel Add-in
+# Blank and null values in Excel add-ins
 
 `null` and empty strings have special implications in the Excel JavaScript APIs. They're used to represent empty cells, no formatting, or default values. This section details the use of `null` and empty string when getting and setting properties.
 
@@ -26,13 +26,13 @@ range.numberFormat = [[null, null, null, 'm/d/yyyy;@']];
 `null` is not a valid input for single property. For example, the following code snippet is not valid, as the `values` property of the range cannot be set to `null`.
 
 ```js
-range.values = null;
+range.values = null; // This is not a valid snippet. 
 ```
 
 Likewise, the following code snippet is not valid, as `null` is not a valid value for the `color` property.
 
 ```js
-range.format.fill.color =  null;
+range.format.fill.color =  null;  // This is not a valid snippet. 
 ```
 
 ## null property values in the response

--- a/docs/excel/excel-add-ins-blank-null-values.md
+++ b/docs/excel/excel-add-ins-blank-null-values.md
@@ -6,11 +6,11 @@ localization_priority: Normal
 ---
 
 
-## Blank and null values in Excel Add-in
+# Blank and null values in Excel Add-in
 
 `null` and empty strings have special implications in the Excel JavaScript APIs. They're used to represent empty cells, no formatting, or default values. This section details the use of `null` and empty string when getting and setting properties.
 
-### null input in 2-D Array
+## null input in 2-D Array
 
 In Excel, a range is represented by a 2-D array, where the first dimension is rows and the second dimension is columns. To set values, number format, or formula for only specific cells within a range, specify the values, number format, or formula for those cells in the 2-D array, and specify `null` for all other cells in the 2-D array.
 
@@ -21,7 +21,7 @@ range.values = [['Eurasia', '29.96', '0.25', '15-Feb' ]];
 range.numberFormat = [[null, null, null, 'm/d/yyyy;@']];
 ```
 
-### null input for a property
+## null input for a property
 
 `null` is not a valid input for single property. For example, the following code snippet is not valid, as the `values` property of the range cannot be set to `null`.
 
@@ -35,14 +35,14 @@ Likewise, the following code snippet is not valid, as `null` is not a valid valu
 range.format.fill.color =  null;
 ```
 
-### null property values in the response
+## null property values in the response
 
 Formatting properties such as `size` and `color` will contain `null` values in the response when different values exist in the specified range. For example, if you retrieve a range and load its `format.font.color` property:
 
 * If all cells in the range have the same font color, `range.format.font.color` specifies that color.
 * If multiple font colors are present within the range, `range.format.font.color` is `null`.
 
-### Blank input for a property
+## Blank input for a property
 
 When you specify a blank value for a property (i.e., two quotation marks with no space in-between `''`), it will be interpreted as an instruction to clear or reset the property. For example:
 
@@ -50,7 +50,7 @@ When you specify a blank value for a property (i.e., two quotation marks with no
 * If you specify a blank value for the `numberFormat` property, the number format is reset to `General`.
 * If you specify a blank value for the `formula` property and `formulaLocale` property, the formula values are cleared.
 
-### Blank property values in the response
+## Blank property values in the response
 
 For read operations, a blank property value in the response (i.e., two quotation marks with no space in-between `''`) indicates that cell contains no data or value. In the first example below, the first and last cell in the range contain no data. In the second example, the first two cells in the range do not contain a formula.
 

--- a/docs/excel/excel-add-ins-charts.md
+++ b/docs/excel/excel-add-ins-charts.md
@@ -212,4 +212,4 @@ These parameters determine the size of the image. Images are always proportional
 
 ## See also
 
-- [Fundamental programming concepts with the Excel JavaScript API](excel-add-ins-core-concepts.md)
+- [Excel JavaScript object model in Office Add-ins](excel-add-ins-core-concepts.md)

--- a/docs/excel/excel-add-ins-comments.md
+++ b/docs/excel/excel-add-ins-comments.md
@@ -199,6 +199,6 @@ Excel.run(function (context) {
 
 ## See also
 
-- [Fundamental programming concepts with the Excel JavaScript API](excel-add-ins-core-concepts.md)
+- [Excel JavaScript object model in Office Add-ins](excel-add-ins-core-concepts.md)
 - [Work with workbooks using the Excel JavaScript API](excel-add-ins-workbooks.md)
 - [Insert comments and notes in Excel](https://support.office.com/article/insert-comments-and-notes-in-excel-bdcc9f5d-38e2-45b4-9a92-0b2b5c7bf6f8)

--- a/docs/excel/excel-add-ins-conditional-formatting.md
+++ b/docs/excel/excel-add-ins-conditional-formatting.md
@@ -331,7 +331,7 @@ await context.sync();
 
 ## See also
 
-- [Fundamental programming concepts with the Excel JavaScript API](../excel/excel-add-ins-core-concepts.md)
+- [Excel JavaScript object model in Office Add-ins](../excel/excel-add-ins-core-concepts.md)
 - [Work with ranges using the Excel JavaScript API](../excel/excel-add-ins-ranges.md)
 - [ConditionalFormat Object (JavaScript API for Excel)](/javascript/api/excel/excel.conditionalformat)
 - [Add, change, or clear conditional formats](https://support.office.com/article/add-change-or-clear-conditional-formats-8a1cc355-b113-41b7-a483-58460332a1af)

--- a/docs/excel/excel-add-ins-core-concepts.md
+++ b/docs/excel/excel-add-ins-core-concepts.md
@@ -1,7 +1,7 @@
 ---
-title: Fundamental programming concepts with the Excel JavaScript API
-description: 'Use the Excel JavaScript API to build add-ins for Excel.'
-ms.date: 07/28/2020
+title: Excel object model
+description: 'Learn the key object types in the Excel JavaScript APIs and how to use them to build add-ins for Excel.'
+ms.date: 09/03/2020
 localization_priority: Priority
 ---
 
@@ -29,15 +29,14 @@ The following image illustrates when you might use the Excel JavaScript API or t
 
 ![Image of the differences between the Excel JS API and Common APIs](../images/excel-js-api-common-api.png)
 
-## Object model
+## Excel-specific object model
 
 To understand the Excel APIs, you must understand how the components of a workbook are related to one another.
 
 * A **Workbook** contains one or more **Worksheets**.
-* A **Worksheet** gives access to cells through **Range** objects.
+* A **Worksheet** contains collections of those data objects that are present in the individual sheet, and gives access to cells through **Range** objects.
 * A **Range** represents a group of contiguous cells.
 * **Ranges** are used to create and place **Tables**, **Charts**, **Shapes**, and other data visualization or organization objects.
-* A **Worksheet** contains collections of those data objects that are present in the individual sheet.
 * **Workbooks** contain collections of some of those data objects (such as **Tables**) for the entire **Workbook**.
 
 ### Ranges
@@ -94,6 +93,8 @@ This sample creates the following data in the current worksheet:
 
 ![A sales record showing value rows, a formula column, and formatted headers.](../images/excel-overview-range-sample.png)
 
+For more information, see [Work with ranges using the Excel JavaScript API](excel-add-ins-ranges.md).
+
 ### Charts, tables, and other data objects
 
 The Excel JavaScript APIs can create and manipulate the data structures and visualizations within Excel. Tables and charts are two of the more commonly used objects, but the APIs support PivotTables, shapes, images, and more.
@@ -116,6 +117,8 @@ Using this sample code on the worksheet with the previous data creates the follo
 
 ![A table made from the previous sales record.](../images/excel-overview-table-sample.png)
 
+For more information, see [Work with tables using the Excel JavaScript API](excel-add-ins-tables.md).
+
 #### Creating a chart
 
 Create charts to visualize the data in a range. The APIs support dozens of chart varieties, each of which can be customized to suit your needs.
@@ -135,113 +138,7 @@ Running this sample on the worksheet with the previous table creates the followi
 
 ![A column chart showing quantities of three items from the previous sales record.](../images/excel-overview-chart-sample.png)
 
-## Run options
-
-`Excel.run` has an overload that takes in a [RunOptions](/javascript/api/excel/excel.runoptions) object. This contains a set of properties that affect platform behavior when the function runs. The following property is currently supported:
-
-* `delayForCellEdit`: Determines whether Excel delays the batch request until the user exits cell edit mode. When **true**, the batch request is delayed and runs when the user exits cell edit mode. When **false**, the batch request automatically fails if the user is in cell edit mode (causing an error to reach the user). The default behavior with no `delayForCellEdit` property specified is equivalent to when it is **false**.
-
-```js
-Excel.run({ delayForCellEdit: true }, function (context) { ... })
-```
-
-## null or blank property values
-
-`null` and empty strings have special implications in the Excel JavaScript APIs. They're used to represent empty cells, no formatting, or default values. This section details the use of `null` and empty string when getting and setting properties.
-
-### null input in 2-D Array
-
-In Excel, a range is represented by a 2-D array, where the first dimension is rows and the second dimension is columns. To set values, number format, or formula for only specific cells within a range, specify the values, number format, or formula for those cells in the 2-D array, and specify `null` for all other cells in the 2-D array.
-
-For example, to update the number format for only one cell within a range, and retain the existing number format for all other cells in the range, specify the new number format for the cell to update, and specify `null` for all other cells. The following code snippet sets a new number format for the fourth cell in the range, and leaves the number format unchanged for the first three cells in the range.
-
-```js
-range.values = [['Eurasia', '29.96', '0.25', '15-Feb' ]];
-range.numberFormat = [[null, null, null, 'm/d/yyyy;@']];
-```
-
-### null input for a property
-
-`null` is not a valid input for single property. For example, the following code snippet is not valid, as the `values` property of the range cannot be set to `null`.
-
-```js
-range.values = null;
-```
-
-Likewise, the following code snippet is not valid, as `null` is not a valid value for the `color` property.
-
-```js
-range.format.fill.color =  null;
-```
-
-### null property values in the response
-
-Formatting properties such as `size` and `color` will contain `null` values in the response when different values exist in the specified range. For example, if you retrieve a range and load its `format.font.color` property:
-
-* If all cells in the range have the same font color, `range.format.font.color` specifies that color.
-* If multiple font colors are present within the range, `range.format.font.color` is `null`.
-
-### Blank input for a property
-
-When you specify a blank value for a property (i.e., two quotation marks with no space in-between `''`), it will be interpreted as an instruction to clear or reset the property. For example:
-
-* If you specify a blank value for the `values` property of a range, the content of the range is cleared.
-* If you specify a blank value for the `numberFormat` property, the number format is reset to `General`.
-* If you specify a blank value for the `formula` property and `formulaLocale` property, the formula values are cleared.
-
-### Blank property values in the response
-
-For read operations, a blank property value in the response (i.e., two quotation marks with no space in-between `''`) indicates that cell contains no data or value. In the first example below, the first and last cell in the range contain no data. In the second example, the first two cells in the range do not contain a formula.
-
-```js
-range.values = [['', 'some', 'data', 'in', 'other', 'cells', '']];
-```
-
-```js
-range.formula = [['', '', '=Rand()']];
-```
-
-## Requirement sets
-
-Requirement sets are named groups of API members. An Office Add-in can perform a runtime check or use requirement sets specified in the manifest to determine whether an Office application supports the APIs that the add-in needs. To identify the specific requirement sets that are available on each supported platform, see [Excel JavaScript API requirement sets](../reference/requirement-sets/excel-api-requirement-sets.md).
-
-### Checking for requirement set support at runtime
-
-The following code sample shows how to determine whether the Office application where the add-in is running supports the specified API requirement set.
-
-```js
-if (Office.context.requirements.isSetSupported('ExcelApi', '1.3')) {
-  /// perform actions
-}
-else {
-  /// provide alternate flow/logic
-}
-```
-
-### Defining requirement set support in the manifest
-
-You can use the [Requirements element](../reference/manifest/requirements.md) in the add-in manifest to specify the minimal requirement sets and/or API methods that your add-in requires to activate. If the Office application or platform doesn't support the requirement sets or API methods that are specified in the `Requirements` element of the manifest, the add-in won't run in that application or platform, and it won't display in the list of add-ins that are shown in **My Add-ins**.
-
-The following code sample shows the `Requirements` element in an add-in manifest which specifies that the add-in should load in all Office client applications that support ExcelApi requirement set version 1.3 or greater.
-
-```xml
-<Requirements>
-   <Sets DefaultMinVersion="1.3">
-      <Set Name="ExcelApi" MinVersion="1.3"/>
-   </Sets>
-</Requirements>
-```
-
-> [!NOTE]
-> To make your add-in available on all platforms of an Office application, such as Excel on the web, Windows, and iPad, we recommend that you check for requirement support at runtime instead of defining requirement set support in the manifest.
-
-### Requirement sets for the Office.js Common API
-
-For information about Common API requirement sets, see [Office Common API requirement sets](../reference/requirement-sets/office-add-in-requirement-sets.md).
-
-## Handle errors
-
-When an API error occurs, the API returns an `error` object that contains a code and a message. For detailed information about error handling, including a list of API errors, see [Error handling](excel-add-ins-error-handling.md).
+For more information, see [Work with charts using the Excel JavaScript API](excel-add-ins-charts.md).
 
 ## See also
 

--- a/docs/excel/excel-add-ins-core-concepts.md
+++ b/docs/excel/excel-add-ins-core-concepts.md
@@ -1,11 +1,11 @@
 ---
-title: Excel object model
+title: Excel JavaScript object model in Office Add-ins
 description: 'Learn the key object types in the Excel JavaScript APIs and how to use them to build add-ins for Excel.'
 ms.date: 09/03/2020
 localization_priority: Priority
 ---
 
-# Fundamental programming concepts with the Excel JavaScript API
+# Excel JavaScript object model in Office Add-ins
 
 This article describes how to use the [Excel JavaScript API](../reference/overview/excel-add-ins-reference-overview.md) to build add-ins for Excel 2016 or later. It introduces core concepts that are fundamental to using the API and provides guidance for performing specific tasks such as reading or writing to a large range, updating all cells in range, and more.
 

--- a/docs/excel/excel-add-ins-data-validation.md
+++ b/docs/excel/excel-add-ins-data-validation.md
@@ -218,6 +218,6 @@ It isn't necessary that the range you clear is exactly the same range as a range
 
 ## See also
 
-- [Fundamental programming concepts with the Excel JavaScript API](excel-add-ins-core-concepts.md)
+- [Excel JavaScript object model in Office Add-ins](excel-add-ins-core-concepts.md)
 - [DataValidation Object (JavaScript API for Excel)](/javascript/api/excel/excel.datavalidation)
 - [Range Object (JavaScript API for Excel)](/javascript/api/excel/excel.range)

--- a/docs/excel/excel-add-ins-delay-in-cell-edit.md
+++ b/docs/excel/excel-add-ins-delay-in-cell-edit.md
@@ -6,7 +6,7 @@ localization_priority: Normal
 ---
 
 
-## Delay execution while cell is being edited
+# Delay execution while cell is being edited
 
 `Excel.run` has an overload that takes in a [Excel.RunOptions](/javascript/api/excel/excel.runoptions) object. This contains a set of properties that affect platform behavior when the function runs. The following property is currently supported:
 

--- a/docs/excel/excel-add-ins-delay-in-cell-edit.md
+++ b/docs/excel/excel-add-ins-delay-in-cell-edit.md
@@ -1,0 +1,17 @@
+---
+title: Delay execution while cell is being edited
+description: 'Learn how to delay the execution of the Excel.run method when a cell is being edited.'
+ms.date: 09/03/2020
+localization_priority: Normal
+---
+
+
+## Delay execution while cell is being edited
+
+`Excel.run` has an overload that takes in a [Excel.RunOptions](/javascript/api/excel/excel.runoptions) object. This contains a set of properties that affect platform behavior when the function runs. The following property is currently supported:
+
+* `delayForCellEdit`: Determines whether Excel delays the batch request until the user exits cell edit mode. When **true**, the batch request is delayed and runs when the user exits cell edit mode. When **false**, the batch request automatically fails if the user is in cell edit mode (causing an error to reach the user). The default behavior with no `delayForCellEdit` property specified is equivalent to when it is **false**.
+
+```js
+Excel.run({ delayForCellEdit: true }, function (context) { ... })
+```

--- a/docs/excel/excel-add-ins-error-handling.md
+++ b/docs/excel/excel-add-ins-error-handling.md
@@ -11,7 +11,7 @@ localization_priority: Normal
 When you build an add-in using the Excel JavaScript API, be sure to include error handling logic to account for runtime errors. Doing so is critical, due to the asynchronous nature of the API.
 
 > [!NOTE]
-> For more information about the `sync()` method and the asynchronous nature of Excel JavaScript API, see [Fundamental programming concepts with the Excel JavaScript API](excel-add-ins-core-concepts.md).
+> For more information about the `sync()` method and the asynchronous nature of Excel JavaScript API, see [Excel JavaScript object model in Office Add-ins](excel-add-ins-core-concepts.md).
 
 ## Best practices
 
@@ -72,5 +72,5 @@ The following table is a list of errors that the API may return.
 
 ## See also
 
-- [Fundamental programming concepts with the Excel JavaScript API](excel-add-ins-core-concepts.md)
+- [Excel JavaScript object model in Office Add-ins](excel-add-ins-core-concepts.md)
 - [OfficeExtension.Error object (JavaScript API for Excel)](/javascript/api/office/officeextension.error?view=excel-js-preview)

--- a/docs/excel/excel-add-ins-events.md
+++ b/docs/excel/excel-add-ins-events.md
@@ -163,4 +163,4 @@ Excel.run(function (context) {
 
 ## See also
 
-- [Fundamental programming concepts with the Excel JavaScript API](excel-add-ins-core-concepts.md)
+- [Excel JavaScript object model in Office Add-ins](excel-add-ins-core-concepts.md)

--- a/docs/excel/excel-add-ins-overview.md
+++ b/docs/excel/excel-add-ins-overview.md
@@ -119,5 +119,5 @@ Get started by [creating your first Excel add-in](../quickstarts/excel-quickstar
 
 - [Office Add-ins platform overview](../overview/office-add-ins.md)
 - [Developing Office Add-ins](../develop/develop-overview.md)
-- [Fundamental programming concepts with the Excel JavaScript API](excel-add-ins-core-concepts.md)
+- [Excel JavaScript object model in Office Add-ins](excel-add-ins-core-concepts.md)
 - [Excel JavaScript API reference](../reference/overview/excel-add-ins-reference-overview.md)

--- a/docs/excel/excel-add-ins-pivottables.md
+++ b/docs/excel/excel-add-ins-pivottables.md
@@ -410,5 +410,5 @@ Excel.run(function (context) {
 
 ## See also
 
-- [Fundamental programming concepts with the Excel JavaScript API](excel-add-ins-core-concepts.md)
+- [Excel JavaScript object model in Office Add-ins](excel-add-ins-core-concepts.md)
 - [Excel JavaScript API Reference](/javascript/api/excel)

--- a/docs/excel/excel-add-ins-ranges-advanced.md
+++ b/docs/excel/excel-add-ins-ranges-advanced.md
@@ -356,5 +356,5 @@ You can also find the cell responsible for spilling into a given cell by using t
 ## See also
 
 - [Work with ranges using the Excel JavaScript API](excel-add-ins-ranges.md)
-- [Fundamental programming concepts with the Excel JavaScript API](excel-add-ins-core-concepts.md)
+- [Excel JavaScript object model in Office Add-ins](excel-add-ins-core-concepts.md)
 - [Work with multiple ranges simultaneously in Excel add-ins](excel-add-ins-multiple-ranges.md)

--- a/docs/excel/excel-add-ins-ranges.md
+++ b/docs/excel/excel-add-ins-ranges.md
@@ -592,4 +592,4 @@ When the `find` method is called on a range representing a single cell, the enti
 ## See also
 
 - [Work with ranges using the Excel JavaScript API (advanced)](excel-add-ins-ranges-advanced.md)
-- [Fundamental programming concepts with the Excel JavaScript API](excel-add-ins-core-concepts.md)
+- [Excel JavaScript object model in Office Add-ins](excel-add-ins-core-concepts.md)

--- a/docs/excel/excel-add-ins-tables.md
+++ b/docs/excel/excel-add-ins-tables.md
@@ -493,4 +493,4 @@ Excel.run(function (context) {
 
 ## See also
 
-- [Fundamental programming concepts with the Excel JavaScript API](excel-add-ins-core-concepts.md)
+- [Excel JavaScript object model in Office Add-ins](excel-add-ins-core-concepts.md)

--- a/docs/excel/excel-add-ins-workbooks.md
+++ b/docs/excel/excel-add-ins-workbooks.md
@@ -356,6 +356,6 @@ context.workbook.close(Excel.CloseBehavior.save);
 
 ## See also
 
-- [Fundamental programming concepts with the Excel JavaScript API](excel-add-ins-core-concepts.md)
+- [Excel JavaScript object model in Office Add-ins](excel-add-ins-core-concepts.md)
 - [Work with worksheets using the Excel JavaScript API](excel-add-ins-worksheets.md)
 - [Work with ranges using the Excel JavaScript API](excel-add-ins-ranges.md)

--- a/docs/excel/excel-add-ins-worksheet-functions.md
+++ b/docs/excel/excel-add-ins-worksheet-functions.md
@@ -440,6 +440,6 @@ The following built-in Excel worksheet functions can be called using the Excel J
 
 ## See also
 
-- [Fundamental programming concepts with the Excel JavaScript API](excel-add-ins-core-concepts.md)
+- [Excel JavaScript object model in Office Add-ins](excel-add-ins-core-concepts.md)
 - [Functions Class (JavaScript API for Excel)](/javascript/api/excel/excel.functions)
 - [Workbook Functions Object (JavaScript API for Excel)](/javascript/api/excel/excel.workbook#functions)

--- a/docs/excel/excel-add-ins-worksheets.md
+++ b/docs/excel/excel-add-ins-worksheets.md
@@ -490,4 +490,4 @@ Excel.run(function (context) {
 
 ## See also
 
-- [Fundamental programming concepts with the Excel JavaScript API](excel-add-ins-core-concepts.md)
+- [Excel JavaScript object model in Office Add-ins](excel-add-ins-core-concepts.md)

--- a/docs/excel/performance.md
+++ b/docs/excel/performance.md
@@ -106,6 +106,6 @@ Excel.run(async (ctx) => {
 
 ## See also
 
-* [Fundamental programming concepts with the Excel JavaScript API](excel-add-ins-core-concepts.md)
+* [Excel JavaScript object model in Office Add-ins](excel-add-ins-core-concepts.md)
 * [Resource limits and performance optimization for Office Add-ins](../concepts/resource-limits-and-performance-optimization.md)
 * [Worksheet Functions Object (JavaScript API for Excel)](/javascript/api/excel/excel.functions)

--- a/docs/quickstarts/excel-quickstart-angular.md
+++ b/docs/quickstarts/excel-quickstart-angular.md
@@ -70,6 +70,6 @@ Congratulations, you've successfully created an Excel task pane add-in using Ang
 
 * [Office Add-ins platform overview](../overview/office-add-ins.md)
 * [Developing Office Add-ins](../develop/develop-overview.md)
-* [Fundamental programming concepts with the Excel JavaScript API](../excel/excel-add-ins-core-concepts.md)
+* [Excel JavaScript object model in Office Add-ins](../excel/excel-add-ins-core-concepts.md)
 * [Excel add-in code samples](https://developer.microsoft.com/office/gallery/?filterBy=Samples,Excel)
 * [Excel JavaScript API reference](../reference/overview/excel-add-ins-reference-overview.md)

--- a/docs/quickstarts/excel-quickstart-jquery.md
+++ b/docs/quickstarts/excel-quickstart-jquery.md
@@ -217,6 +217,6 @@ Congratulations, you've successfully created an Excel task pane add-in! Next, le
 
 * [Office Add-ins platform overview](../overview/office-add-ins.md)
 * [Developing Office Add-ins](../develop/develop-overview.md)
-* [Fundamental programming concepts with the Excel JavaScript API](../excel/excel-add-ins-core-concepts.md)
+* [Excel JavaScript object model in Office Add-ins](../excel/excel-add-ins-core-concepts.md)
 * [Excel add-in code samples](https://developer.microsoft.com/office/gallery/?filterBy=Samples,Excel)
 * [Excel JavaScript API reference](../reference/overview/excel-add-ins-reference-overview.md)

--- a/docs/quickstarts/excel-quickstart-react.md
+++ b/docs/quickstarts/excel-quickstart-react.md
@@ -69,6 +69,6 @@ Congratulations, you've successfully created an Excel task pane add-in using Rea
 ## See also
 
 * [Excel add-in tutorial](../tutorials/excel-tutorial-create-table.md)
-* [Fundamental programming concepts with the Excel JavaScript API](../excel/excel-add-ins-core-concepts.md)
+* [Excel JavaScript object model in Office Add-ins](../excel/excel-add-ins-core-concepts.md)
 * [Excel add-in code samples](https://developer.microsoft.com/office/gallery/?filterBy=Samples,Excel)
 * [Excel JavaScript API reference](../reference/overview/excel-add-ins-reference-overview.md)

--- a/docs/quickstarts/excel-quickstart-vue.md
+++ b/docs/quickstarts/excel-quickstart-vue.md
@@ -222,6 +222,6 @@ Congratulations, you've successfully created an Excel task pane add-in using Vue
 
 * [Office Add-ins platform overview](../overview/office-add-ins.md)
 * [Developing Office Add-ins](../develop/develop-overview.md)
-* [Fundamental programming concepts with the Excel JavaScript API](../excel/excel-add-ins-core-concepts.md)
+* [Excel JavaScript object model in Office Add-ins](../excel/excel-add-ins-core-concepts.md)
 * [Excel add-in code samples](https://developer.microsoft.com/office/gallery/?filterBy=Samples,Excel)
 * [Excel JavaScript API reference](../reference/overview/excel-add-ins-reference-overview.md)

--- a/docs/reference/overview/excel-add-ins-reference-overview.md
+++ b/docs/reference/overview/excel-add-ins-reference-overview.md
@@ -16,9 +16,9 @@ An Excel add-in interacts with objects in Excel by using the Office JavaScript A
 
 This section of the documentation focuses on the Excel JavaScript API, which you'll use to develop the majority of functionality in add-ins that target Excel on the web or Excel 2016 or later. For information about the Common API, see [Common JavaScript API object model](../../develop/office-javascript-api-object-model.md).
 
-## Learn programming concepts
+## Learn object model concepts
 
-See [Fundamental programming concepts with the Excel JavaScript API](../../excel/excel-add-ins-core-concepts.md) for information about important programming concepts.
+See [Excel JavaScript object model in Office Add-ins](../../excel/excel-add-ins-core-concepts.md) for information about important object model concepts.
 
 For hands-on experience using the Excel JavaScript API to access objects in Excel, complete the [Excel add-in tutorial](../../tutorials/excel-tutorial.md).
 

--- a/docs/reference/requirement-sets/excel-api-requirement-sets.md
+++ b/docs/reference/requirement-sets/excel-api-requirement-sets.md
@@ -50,7 +50,7 @@ For more information about Office versions and build numbers, see:
 ## How to use Excel requirement sets at runtime and in the manifest
 
 > [!NOTE]
-> This section assumes that you are familiar with the overview of requirement sets at [Office versions and requirement sets](../../develop/office-versions-and-requirement-sets.md) and [Specify Office applications and API requirements](../develop/specify-office-hosts-and-api-requirements.md).
+> This section assumes that you are familiar with the overview of requirement sets at [Office versions and requirement sets](../../develop/office-versions-and-requirement-sets.md) and [Specify Office applications and API requirements](../../develop/specify-office-hosts-and-api-requirements.md).
 
 Requirement sets are named groups of API members. An Office Add-in can perform a runtime check or use requirement sets specified in the manifest to determine whether an Office application supports the APIs that the add-in needs.
 
@@ -69,7 +69,7 @@ else {
 
 ### Defining requirement set support in the manifest
 
-You can use the [Requirements element](../reference/manifest/requirements.md) in the add-in manifest to specify the minimal requirement sets and/or API methods that your add-in requires to activate. If the Office application or platform doesn't support the requirement sets or API methods that are specified in the `Requirements` element of the manifest, the add-in won't run in that application or platform, and it won't display in the list of add-ins that are shown in **My Add-ins**. If your add-in requires a specific requirement set for full functionality, but it can provide value even to users on platforms that do not support the requirement set, we recommend that you check for requirement support at runtime as described above, instead of defining requirement set support in the manifest.
+You can use the [Requirements element](../manifest/requirements.md) in the add-in manifest to specify the minimal requirement sets and/or API methods that your add-in requires to activate. If the Office application or platform doesn't support the requirement sets or API methods that are specified in the `Requirements` element of the manifest, the add-in won't run in that application or platform, and it won't display in the list of add-ins that are shown in **My Add-ins**. If your add-in requires a specific requirement set for full functionality, but it can provide value even to users on platforms that do not support the requirement set, we recommend that you check for requirement support at runtime as described above, instead of defining requirement set support in the manifest.
 
 The following code sample shows the `Requirements` element in an add-in manifest which specifies that the add-in should load in all Office client applications that support ExcelApi requirement set version 1.3 or greater.
 

--- a/docs/reference/requirement-sets/excel-api-requirement-sets.md
+++ b/docs/reference/requirement-sets/excel-api-requirement-sets.md
@@ -1,7 +1,7 @@
 ---
 title: Excel JavaScript API requirement sets
 description: 'Office Add-in requirement set information for Excel builds.'
-ms.date: 07/10/2020
+ms.date: 09/03/2020
 ms.prod: excel
 localization_priority: Priority
 ---
@@ -47,10 +47,41 @@ For more information about Office versions and build numbers, see:
 
 [!INCLUDE [Links to get Office versions and how to find Office client version](../../includes/links-get-office-versions-builds.md)]
 
+## How to use Excel requirement sets at runtime and in the manifest
+
+> [!NOTE]
+> This section assumes that you are familiar with the overview of requirement sets at [Office versions and requirement sets](../../develop/office-versions-and-requirement-sets.md) and [Specify Office applications and API requirements](../develop/specify-office-hosts-and-api-requirements.md).
+
+Requirement sets are named groups of API members. An Office Add-in can perform a runtime check or use requirement sets specified in the manifest to determine whether an Office application supports the APIs that the add-in needs.
+
+### Checking for requirement set support at runtime
+
+The following code sample shows how to determine whether the Office application where the add-in is running supports the specified API requirement set.
+
+```js
+if (Office.context.requirements.isSetSupported('ExcelApi', '1.3')) {
+  /// perform actions
+}
+else {
+  /// provide alternate flow/logic
+}
+```
+
+### Defining requirement set support in the manifest
+
+You can use the [Requirements element](../reference/manifest/requirements.md) in the add-in manifest to specify the minimal requirement sets and/or API methods that your add-in requires to activate. If the Office application or platform doesn't support the requirement sets or API methods that are specified in the `Requirements` element of the manifest, the add-in won't run in that application or platform, and it won't display in the list of add-ins that are shown in **My Add-ins**. If your add-in requires a specific requirement set for full functionality, but it can provide value even to users on platforms that do not support the requirement set, we recommend that you check for requirement support at runtime as described above, instead of defining requirement set support in the manifest.
+
+The following code sample shows the `Requirements` element in an add-in manifest which specifies that the add-in should load in all Office client applications that support ExcelApi requirement set version 1.3 or greater.
+
+```xml
+<Requirements>
+   <Sets DefaultMinVersion="1.3">
+      <Set Name="ExcelApi" MinVersion="1.3"/>
+   </Sets>
+</Requirements>
+```
+
 ## See also
 
 - [Excel JavaScript API Reference Documentation](/javascript/api/excel)
-- [Office versions and requirement sets](../../develop/office-versions-and-requirement-sets.md)
-- [Specify Office applications and API requirements](../../develop/specify-office-hosts-and-api-requirements.md)
 - [Office Add-ins XML manifest](../../develop/add-in-manifests.md)
-- [Office Online Server overview](/officeonlineserver/office-online-server-overview)

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -592,7 +592,7 @@
     - name: Excel object model
       href: excel/excel-add-ins-core-concepts.md
       displayName: Excel
-    - name: Blank and null values in Excel Add-in
+    - name: Blank and null values in Excel add-ins
       href: excel/excel-add-ins-blank-null-values.md
       displayName: Excel
     - name: Calling built-in functions

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -589,8 +589,11 @@
     - name: API reference
       href: reference/excel-api-reference.md
       displayName: Excel
-    - name: Fundamental programming concepts
+    - name: Excel object model
       href: excel/excel-add-ins-core-concepts.md
+      displayName: Excel
+    - name: Blank and null values in Excel Add-in
+      href: excel/excel-add-ins-blank-null-values.md
       displayName: Excel
     - name: Calling built-in functions
       href: excel/excel-add-ins-worksheet-functions.md
@@ -612,6 +615,9 @@
       displayName: Excel
     - name: Data validation
       href: excel/excel-add-ins-data-validation.md
+      displayName: Excel
+    - name: Delay execution while cell is being edited
+      href: excel/excel-add-ins-delay-in-cell-edit.md
       displayName: Excel
     - name: Error handling
       href: excel/excel-add-ins-error-handling.md

--- a/docs/tutorials/excel-tutorial.md
+++ b/docs/tutorials/excel-tutorial.md
@@ -1017,4 +1017,4 @@ In this tutorial, you've created an Excel task pane add-in that interacts with t
 
 * [Office Add-ins platform overview](../overview/office-add-ins.md)
 * [Developing Office Add-ins](../develop/develop-overview.md)
-* [Fundamental programming concepts with the Excel JavaScript API](../excel/excel-add-ins-core-concepts.md)
+* [Excel JavaScript object model in Office Add-ins](../excel/excel-add-ins-core-concepts.md)


### PR DESCRIPTION
Split up the Excel fundamental concepts article:
1. Move Run options to its own article "Delay ..."
2. Move blank or null values section to it's own article "Blank ..."
3. Move requirement sets section to the existing Excel requirements article
4. Rename fundamental concepts article "Excel object model".