### PR TITLE
Update CF req set overview page

### DIFF
--- a/docs/excel/custom-functions-requirement-sets.md
+++ b/docs/excel/custom-functions-requirement-sets.md
@@ -13,9 +13,7 @@ localization_priority: Normal
 |  Requirement set  |  Office on Windows<br>(connected to a Microsoft 365 subscription)  |  Office on iPad<br>(connected to a Microsoft 365 subscription)  |  Office on Mac<br>(connected to a Microsoft 365 subscription)  | Office on the web |
 |:-----|-----|:-----|:-----|:-----|:-----|
 | CustomFunctionsRuntime 1.1 | 16.0.12527.20092 or later | Not supported | 16.34 or later | May 2019 |
-|:-----|-----|:-----|:-----|:-----|:-----|
 | CustomFunctionsRuntime 1.2 | 16.0.12527.20194 or later | Not supported | 16.34.20020900 or later | January 2019 |
-|:-----|-----|:-----|:-----|:-----|:-----|
 | CustomFunctionsRuntime 1.3 | 16.0.13127.20296 or later | Not supported | 16.40.20081000 or later | July 2020 |
 
 > [!NOTE]

--- a/docs/excel/custom-functions-requirement-sets.md
+++ b/docs/excel/custom-functions-requirement-sets.md
@@ -13,7 +13,7 @@ localization_priority: Normal
 |  Requirement set  |  Office on Windows<br>(connected to a Microsoft 365 subscription)  |  Office on iPad<br>(connected to a Microsoft 365 subscription)  |  Office on Mac<br>(connected to a Microsoft 365 subscription)  | Office on the web |
 |:-----|-----|:-----|:-----|:-----|:-----|
 | CustomFunctionsRuntime 1.1 | 16.0.12527.20092 or later | Not supported | 16.34 or later | May 2019 |
-| CustomFunctionsRuntime 1.2 | 16.0.12527.20194 or later | Not supported | 16.34.20020900 or later | January 2019 |
+| CustomFunctionsRuntime 1.2 | 16.0.12527.20194 or later | Not supported | 16.34.20020900 or later | January 2020 |
 | CustomFunctionsRuntime 1.3 | 16.0.13127.20296 or later | Not supported | 16.40.20081000 or later | July 2020 |
 
 > [!NOTE]

--- a/docs/excel/custom-functions-requirement-sets.md
+++ b/docs/excel/custom-functions-requirement-sets.md
@@ -12,9 +12,10 @@ localization_priority: Normal
 
 |  Requirement set  |  Office on Windows<br>(connected to a Microsoft 365 subscription)  |  Office on iPad<br>(connected to a Microsoft 365 subscription)  |  Office on Mac<br>(connected to a Microsoft 365 subscription)  | Office on the web |
 |:-----|-----|:-----|:-----|:-----|:-----|
-| CustomFunctionsRuntime 1.1 | 16.0.12527.20092 or later | Not supported | 16.34 or later | May 2019 |
-| CustomFunctionsRuntime 1.2 | 16.0.12527.20194 or later | Not supported | 16.34.20020900 or later | January 2020 |
 | CustomFunctionsRuntime 1.3 | 16.0.13127.20296 or later | Not supported | 16.40.20081000 or later | July 2020 |
+| CustomFunctionsRuntime 1.2 | 16.0.12527.20194 or later | Not supported | 16.34.20020900 or later | January 2020 |
+| CustomFunctionsRuntime 1.1 | 16.0.12527.20092 or later | Not supported | 16.34 or later | May 2019 |
+
 
 > [!NOTE]
 > Excel custom functions are not supported on Office 2019 or earlier (one-time purchase).

--- a/docs/excel/custom-functions-requirement-sets.md
+++ b/docs/excel/custom-functions-requirement-sets.md
@@ -1,7 +1,7 @@
 ---
 title: Custom Functions requirement sets
 description: 'Details about the Custom Functions requirement sets for Excel JavaScript API.'
-ms.date: 09/09/2020
+ms.date: 09/14/2020
 ms.prod: excel
 localization_priority: Normal
 ---
@@ -16,13 +16,12 @@ localization_priority: Normal
 | CustomFunctionsRuntime 1.2 | 16.0.12527.20194 or later | Not supported | 16.34.20020900 or later | January 2020 |
 | CustomFunctionsRuntime 1.1 | 16.0.12527.20092 or later | Not supported | 16.34 or later | May 2019 |
 
-
 > [!NOTE]
 > Excel custom functions are not supported on Office 2019 or earlier (one-time purchase).
 
 ## CustomFunctionsRuntime 1.1, 1.2, and 1.3
 
-The CustomFunctionsRuntime 1.1 is the first version of the API. Version 1.2 adds the `CustomFunctions.Error` object to support error handling. Version 1.3 adds [XLL streaming](make-custom-functions-compatible-with-xll-udf.md#custom-function-behavior-for-xll-compatible-functions) support and new `ErrorCode` options to the [CustomFunctions.Error](/javascript/api/custom-functions-runtime/customfunctions.error) object. 
+The CustomFunctionsRuntime 1.1 is the first version of the API. Requirement set 1.2 adds the `CustomFunctions.Error` object to support error handling. Requirement set 1.3 adds [XLL streaming](make-custom-functions-compatible-with-xll-udf.md#custom-function-behavior-for-xll-compatible-functions) support and new `ErrorCode` options to the [CustomFunctions.Error](/javascript/api/custom-functions-runtime/customfunctions.error) object. 
 
 ## See also
 

--- a/docs/excel/custom-functions-requirement-sets.md
+++ b/docs/excel/custom-functions-requirement-sets.md
@@ -19,6 +19,10 @@ localization_priority: Normal
 > [!NOTE]
 > Excel custom functions are not supported on Office 2019 or earlier (one-time purchase).
 
+## CustomFunctionsRuntime 1.1, 1.2, and 1.3
+
+CustomFunctionsRuntime 1.1 is the first version of the API. Version 1.2 adds custom error message support, and version 1.3 adds [XLL streaming](/make-custom-functions-compatible-with-xll-udf#custom-function-behavior-for-xll-compatible-functions) support and additional error handling features. 
+
 ## See also
 
 - [Custom Functions Reference Documentation](/javascript/api/custom-functions-runtime)

--- a/docs/excel/custom-functions-requirement-sets.md
+++ b/docs/excel/custom-functions-requirement-sets.md
@@ -21,7 +21,7 @@ localization_priority: Normal
 
 ## CustomFunctionsRuntime 1.1, 1.2, and 1.3
 
-The CustomFunctionsRuntime 1.1 is the first version of the API. Version 1.2 adds the `CustomFunctions.Error` object to support error handling. Version 1.3 adds [XLL streaming](/make-custom-functions-compatible-with-xll-udf#custom-function-behavior-for-xll-compatible-functions) support and new `ErrorCode` options to the `CustomFunctions.Error` object. 
+The CustomFunctionsRuntime 1.1 is the first version of the API. Version 1.2 adds the `CustomFunctions.Error` object to support error handling. Version 1.3 adds [XLL streaming](make-custom-functions-compatible-with-xll-udf.md#custom-function-behavior-for-xll-compatible-functions) support and new `ErrorCode` options to the [CustomFunctions.Error](/javascript/api/custom-functions-runtime/customfunctions.error) object. 
 
 ## See also
 

--- a/docs/excel/custom-functions-requirement-sets.md
+++ b/docs/excel/custom-functions-requirement-sets.md
@@ -21,7 +21,7 @@ localization_priority: Normal
 
 ## CustomFunctionsRuntime 1.1, 1.2, and 1.3
 
-CustomFunctionsRuntime 1.1 is the first version of the API. Version 1.2 adds custom error message support, and version 1.3 adds [XLL streaming](/make-custom-functions-compatible-with-xll-udf#custom-function-behavior-for-xll-compatible-functions) support and additional error handling features. 
+The CustomFunctionsRuntime 1.1 is the first version of the API. Version 1.2 adds the `CustomFunctions.Error` object to support error handling. Version 1.3 adds [XLL streaming](/make-custom-functions-compatible-with-xll-udf#custom-function-behavior-for-xll-compatible-functions) support and new `ErrorCode` options to the `CustomFunctions.Error` object. 
 
 ## See also
 

--- a/docs/excel/custom-functions-requirement-sets.md
+++ b/docs/excel/custom-functions-requirement-sets.md
@@ -1,7 +1,7 @@
 ---
 title: Custom Functions requirement sets
 description: 'Details about the Custom Functions requirement sets for Excel JavaScript API.'
-ms.date: 07/10/2020
+ms.date: 09/09/2020
 ms.prod: excel
 localization_priority: Normal
 ---
@@ -12,7 +12,11 @@ localization_priority: Normal
 
 |  Requirement set  |  Office on Windows<br>(connected to a Microsoft 365 subscription)  |  Office on iPad<br>(connected to a Microsoft 365 subscription)  |  Office on Mac<br>(connected to a Microsoft 365 subscription)  | Office on the web |
 |:-----|-----|:-----|:-----|:-----|:-----|
-| CustomFunctionsRuntime 1.1 | 16.0.12527.20092 or later | Not supported | 16.34 or later | May |
+| CustomFunctionsRuntime 1.1 | 16.0.12527.20092 or later | Not supported | 16.34 or later | May 2019 |
+|:-----|-----|:-----|:-----|:-----|:-----|
+| CustomFunctionsRuntime 1.2 | 16.0.12527.20194 or later | Not supported | 16.34.20020900 or later | January 2019 |
+|:-----|-----|:-----|:-----|:-----|:-----|
+| CustomFunctionsRuntime 1.3 | 16.0.13127.20296 or later | Not supported | 16.40.20081000 or later | July 2020 |
 
 > [!NOTE]
 > Excel custom functions are not supported on Office 2019 or earlier (one-time purchase).


### PR DESCRIPTION
This PR adds:  
- Supported builds to the requirement set table. 
- A short paragraph to describe the differences between the versions. 