### PR TITLE
[Excel] (CustomFunctionRuntime 1.3) Adjust divisionByZero definition per feedback

### DIFF
--- a/docs/excel/custom-functions-errors.md
+++ b/docs/excel/custom-functions-errors.md
@@ -1,5 +1,5 @@
 ---
-ms.date: 09/21/2020
+ms.date: 09/23/2020
 description: 'Handle and return errors like #NULL! from your custom function.'
 title: Handle and return errors from your custom function
 localization_priority: Normal
@@ -33,9 +33,9 @@ function getCity(zipCode: string): string {
 The [CustomFunctions.Error](/javascript/api/custom-functions-runtime/customfunctions.error) object is used to return an error back to the cell. When you create the object, specify which error you want to use by choosing one of the following `ErrorCode` enum values.
 
 
-|ErrorCode enum value  |Excel cell value  |Meaning  |
+|ErrorCode enum value  |Excel cell value  |Description  |
 |---------------|---------|---------|
-|`divisionByZero` | `#DIV/0`  | Be aware that JavaScript allows division by zero so you need to write an error handler carefully to detect this condition. |
+|`divisionByZero` | `#DIV/0`  | The function is attempting to divide by zero. |
 |`invalidName`    | `#NAME?`  | There is a typo in the function name. Note that this error is supported as a custom function input error, but not as a custom function output error. | 
 |`invalidNumber`  | `#NUM!`   | There is a problem with a number in the formula. |
 |`invalidReference` | `#REF!` | The function refers to an invalid cell. Note that this error is supported as a custom function input error, but not as a custom function output error.|


### PR DESCRIPTION
@ElizabethSamuel-MSFT after consulting the original author (David), I've decided to remove the JavaScript note entirely for the divisionByZero error code. The other descriptions in this table define the error codes themselves, and do not include suggestions for how to write the error handler scripts, so it's out of context here to only mention it for this error code. It seems strange to assume that the developer can write the other error handlers, but won't know how to write a handler for division by zero. Based on the JavaScript skill level assumed throughout the rest of this page, I'm inclined to think the developer will be capable of writing a division by zero handler. If you approve, I'll make this change to the type definition file, too. 