### PR TITLE
[Outlook] (delegate) Update support note

### DIFF
--- a/docs/reference/manifest/supportssharedfolders.md
+++ b/docs/reference/manifest/supportssharedfolders.md
@@ -1,7 +1,7 @@
 ---
 title: SupportsSharedFolders element in the manifest file
 description: The SupportsSharedFolders element defines whether the Outlook add-in is available in delegate scenarios.
-ms.date: 01/14/2020
+ms.date: 10/15/2020
 localization_priority: Normal
 ---
 
@@ -10,8 +10,6 @@ localization_priority: Normal
 Defines whether the Outlook add-in is available in delegate scenarios. The **SupportsSharedFolders** element is a child element of [DesktopFormFactor](desktopformfactor.md). It is set to *false* by default.
 
 > [!IMPORTANT]
-> Only Outlook on the web and Windows support the **SupportsSharedFolders** element.
->
 > Support for this element was introduced in requirement set 1.8. See [clients and platforms](../../reference/requirement-sets/outlook-api-requirement-sets.md#requirement-sets-supported-by-exchange-servers-and-outlook-clients) that support this requirement set.
 
 The following is an example of the **SupportsSharedFolders** element.


### PR DESCRIPTION
Mac supports `SupportsSharedFolders` once again ([PR](https://github.com/OfficeDev/office-js-docs-pr/pull/2150/files)) so requirement set support matches delegate access feature support.