### PR TITLE
Keyboard shortcuts documentation edits

### DIFF
--- a/docs/design/keyboard-shortcuts.md
+++ b/docs/design/keyboard-shortcuts.md
@@ -46,30 +46,47 @@ Immediately *below* (not inside) the `<VersionOverrides>` element in the manifes
 
 ## Create or edit the extended overrides JSON file
 
-If there isn't one already, create a JSON file at the path that you use in development for the `Url` attribute of the [ExtendedOverrides](../reference/manifest/extendedoverrides.md) element.
+If there isn't one already, create a JSON file at the path that you use in development for the `Url` attribute of the [ExtendedOverrides](../reference/manifest/extendedoverrides.md) element. This file will contain the definitions for our keyboard shortcuts, as well as the actions that will be invoked using the keyboard shortcuts.
 
 1. Be sure there is an outermost pair of braces (`{ }`)in the file.
 1. Just inside this outermost object, add the following JSON markup. Note that the file must be proper JSON, not simple a JavaScript object, so the property names must be within quotation marks.
 
     ```javascript
     {
-        "shortcuts": [
+        "actions": [
+        ],
+        "shortcuts": [
         ]
     }
     ```
 
-1. The shortcuts array will contain objects that map key combinations onto action names. Here is an example. Note the following about this markup:
+1. The actions array will contain objects that define the actions to be invoked. Here is an example. 
+    ```javascript
+    {
+        "actions": [
+            {
+                "id": "SHOWTASKPANE",
+                "type": "ExecuteFunction",
+                "name": "Show taskpane for add-in"
+            },
+            {
+                "id": "HIDETASKPANE",
+                "type": "ExecuteFunction",
+                "name": "Hide taskpane for add-in"
+            }
+        ]
+    }
+    ```
 
-    - The property names you see here, `action`, `key`, and `default` are mandatory.
-    - The value of the `action` property is a string, and the `default` property can be any combination of the characters A - Z, a -z, 0 - 9, and the punctuation marks "-", "_", and "+". (By convention lower case letters are not used in these properties.)
-    - The `default` property must contain the name of at least one modifier key (ALT, CTRL, SHIFT) and at least one other key. 
-    - For Macs, ALT is mapped to the OPTION key and CTRL is mapped to the COMMAND key.
-    - When two characters are linked to the same physical key in a standard keyboard, then they are synonyms in the `default` property; for example, ALT+a and ALT+A are the same shortcut, so are CTRL+- and CTRL+\_ because "-" and "_" are the same physical key.
-    - The "+" character indicates that the keys on either side of it are pressed simultaneously.
-    - In a later step, the actions will themselves be mapped to functions that you write. In this example, you will later map SHOWTASKPANE to a function that calls the `Office.addin.showAsTaskpane` method and HIDETASKPANE to a function that calls the `Office.addin.hide` method. 
 
-    > [!NOTE]
-    > The complete schema for the shortcuts JSON is at [extended-manifest.schema.json](https://developer.microsoft.com/en-us/json-schemas/office-js/extended-manifest.schema.json).
+   Note the following about this markup:
+
+   - The property names `id` and `name` are mandatory.
+   - The `id` property is used by extension points (such as shortcuts in next step) to determine what action to invoke using a keyboard shortcut.
+   - The `name` property must be a user friendly string describing the action. It must be a combination of the characters A - Z, a - z, 0 - 9, and the punctuation marks "-", "_", and "+".
+   - The `type` property is optional, currently only `ExecuteFunction` type is supported.
+
+1. The shortcuts array will contain objects that map key combinations onto actions. Here is an example. 
 
     ```javascript
     {
@@ -89,6 +106,21 @@ If there isn't one already, create a JSON file at the path that you use in devel
         ]
     }
     ```
+
+   Note the following about this markup:
+
+    - The property names `action`, `key`, and `default` are mandatory.
+    - The value of the `action` property is a string and must match one of the `id` properties in the action object.
+    - The `default` property can be any combination of the characters A - Z, a -z, 0 - 9, and the punctuation marks "-", "_", and "+". (By convention lower case letters are not used in these properties.)
+    - The `default` property must contain the name of at least one modifier key (ALT, CTRL, SHIFT) and at least one other key. 
+    - For Macs, ALT is mapped to the OPTION key and CTRL is mapped to the COMMAND key.
+    - When two characters are linked to the same physical key in a standard keyboard, then they are synonyms in the `default` property; for example, ALT+a and ALT+A are the same shortcut, so are CTRL+- and CTRL+\_ because "-" and "_" are the same physical key.
+    - The "+" character indicates that the keys on either side of it are pressed simultaneously.
+    - In a later step, the actions will themselves be mapped to functions that you write. In this example, you will later map SHOWTASKPANE to a function that calls the `Office.addin.showAsTaskpane` method and HIDETASKPANE to a function that calls the `Office.addin.hide` method. 
+
+    > [!NOTE]
+    > The complete schema for the shortcuts JSON is at [extended-manifest.schema.json](https://developer.microsoft.com/en-us/json-schemas/office-js/extended-manifest.schema.json).
+
 
     > [!NOTE]
     > Keytips, also known as sequential key shortcuts, such as the Excel shortcut to choose a fill color **Alt+H, H**, are not supported in Office add-ins.
@@ -121,7 +153,7 @@ If there isn't one already, create a JSON file at the path that you use in devel
     - The second parameter is the function that runs when a user presses the key combination that is mapped to the action in the JSON file.
 
     ```javascript
-    Office.actions.associate('-- action goes here--', function () {
+    Office.actions.associate('-- action ID goes here--', function () {
 
     });
     ```

--- a/docs/design/keyboard-shortcuts.md
+++ b/docs/design/keyboard-shortcuts.md
@@ -23,13 +23,12 @@ Keyboard shortcuts, also known as key combinations, enable your add-in's users t
 >
 > - [SharedRuntime 1.1](../reference/requirement-sets/shared-runtime-requirement-sets.md)
 
-There are three major steps to adding keyboard shortcuts to an add-in:
+There are three steps to add keyboard shortcuts to an add-in:
 
-1. Configure the add-in's manifest.
-1. Create or edit the extended overrides JSON file to define actions and their keyboard shortcuts.
-1. Add one or more runtime calls of the [Office.actions.associate](/javascript/api/office/office.actions#associate) API to map a function to each action.
+1. [Configure the add-in's manifest](#configure-the-manifest).
+1. [Create or edit the extended overrides JSON file](#create-or-edit-the-extended-overrides-json-file) to define actions and their keyboard shortcuts.
+1. [Add one or more runtime calls](#create-a-mapping-of-actions-to-their-functions) of the [Office.actions.associate](/javascript/api/office/office.actions#associate) API to map a function to each action.
 
-Each step is described in more detail below.
 
 ## Configure the manifest
 
@@ -46,7 +45,7 @@ Immediately *below* (not inside) the `<VersionOverrides>` element in the manifes
 
 ## Create or edit the extended overrides JSON file
 
-If there isn't one already, create a JSON file at the path that you use in development for the `Url` attribute of the [ExtendedOverrides](../reference/manifest/extendedoverrides.md) element. This file will contain the definitions for our keyboard shortcuts, as well as the actions that will be invoked using the keyboard shortcuts.
+If there isn't one already, create a JSON file in your project. Be sure the path of the file matches the location you specified for the `Url` attribute of the [ExtendedOverrides](../reference/manifest/extendedoverrides.md) element. This file will describe your keyboard shortcuts, and the actions that they will invoke.
 
 1. Be sure there is an outermost pair of braces (`{ }`)in the file.
 1. Just inside this outermost object, add the following JSON markup. Note that the file must be proper JSON, not simple a JavaScript object, so the property names must be within quotation marks.
@@ -61,30 +60,30 @@ If there isn't one already, create a JSON file at the path that you use in devel
     ```
 
 1. The actions array will contain objects that define the actions to be invoked. Here is an example. 
-    ```javascript
+    ```json
     {
         "actions": [
             {
                 "id": "SHOWTASKPANE",
                 "type": "ExecuteFunction",
-                "name": "Show taskpane for add-in"
+                "name": "Show task pane for add-in"
             },
             {
                 "id": "HIDETASKPANE",
                 "type": "ExecuteFunction",
-                "name": "Hide taskpane for add-in"
+                "name": "Hide task pane for add-in"
             }
         ]
     }
     ```
 
 
-   Note the following about this markup:
+   Use the following guidelines when specifying the JSON to describe your custom keyboard shortcuts:
 
    - The property names `id` and `name` are mandatory.
    - The `id` property is used by extension points (such as shortcuts in next step) to determine what action to invoke using a keyboard shortcut.
    - The `name` property must be a user friendly string describing the action. It must be a combination of the characters A - Z, a - z, 0 - 9, and the punctuation marks "-", "_", and "+".
-   - The `type` property is optional, currently only `ExecuteFunction` type is supported.
+   - The `type` property is optional. Currently only `ExecuteFunction` type is supported.
 
 1. The shortcuts array will contain objects that map key combinations onto actions. Here is an example. 
 
@@ -107,16 +106,16 @@ If there isn't one already, create a JSON file at the path that you use in devel
     }
     ```
 
-   Note the following about this markup:
+  Use the following guidelines when specifying the JSON to describe actions for your keyboard shortcuts:
 
-    - The property names `action`, `key`, and `default` are mandatory.
+    - The property names `action`, `key`, and `default` are required.
     - The value of the `action` property is a string and must match one of the `id` properties in the action object.
     - The `default` property can be any combination of the characters A - Z, a -z, 0 - 9, and the punctuation marks "-", "_", and "+". (By convention lower case letters are not used in these properties.)
     - The `default` property must contain the name of at least one modifier key (ALT, CTRL, SHIFT) and at least one other key. 
     - For Macs, ALT is mapped to the OPTION key and CTRL is mapped to the COMMAND key.
     - When two characters are linked to the same physical key in a standard keyboard, then they are synonyms in the `default` property; for example, ALT+a and ALT+A are the same shortcut, so are CTRL+- and CTRL+\_ because "-" and "_" are the same physical key.
     - The "+" character indicates that the keys on either side of it are pressed simultaneously.
-    - In a later step, the actions will themselves be mapped to functions that you write. In this example, you will later map SHOWTASKPANE to a function that calls the `Office.addin.showAsTaskpane` method and HIDETASKPANE to a function that calls the `Office.addin.hide` method. 
+In a later step, the actions will themselves be mapped to functions that you write. In this example, you will later map SHOWTASKPANE to a function that calls the `Office.addin.showAsTaskpane` method and HIDETASKPANE to a function that calls the `Office.addin.hide` method. 
 
     > [!NOTE]
     > The complete schema for the shortcuts JSON is at [extended-manifest.schema.json](https://developer.microsoft.com/en-us/json-schemas/office-js/extended-manifest.schema.json).
@@ -147,7 +146,7 @@ If there isn't one already, create a JSON file at the path that you use in devel
 
 
 1. Be sure that the HTML file that the `<FunctionFile>` element in the manifest points to has a `<script>` tag that loads a custom JavaScript file.
-1. In the JavaScript file, use calls of the [Office.actions.associate](/javascript/api/office/office.actions#associate) API to map a function to each action that you used in the JSON file. To begin add the following to the file. Note the following about this code:
+1. In the JavaScript file, use the [Office.actions.associate](/javascript/api/office/office.actions#associate) API to map each action that you specified in the JSON file to a JavaScript function. Add the following JavaScript to the file. Note the following about the code:
 
     - The first parameter is one of the actions from the JSON file.
     - The second parameter is the function that runs when a user presses the key combination that is mapped to the action in the JSON file.

--- a/docs/design/keyboard-shortcuts.md
+++ b/docs/design/keyboard-shortcuts.md
@@ -5,7 +5,7 @@ ms.date: 11/06/2020
 localization_priority: Normal
 ---
 
-# Custom keyboard shortcuts in Office Add-ins (preview)
+# Add Custom keyboard shortcuts to your Office Add-ins (preview)
 
 Keyboard shortcuts, also known as key combinations, enable your add-in's users to work more efficiently and they improve the add-in's accessibility for users with disabilities by providing an alternative to the mouse.
 
@@ -50,7 +50,7 @@ If there isn't one already, create a JSON file in your project. Be sure the path
 1. Be sure there is an outermost pair of braces (`{ }`)in the file.
 1. Just inside this outermost object, add the following JSON markup. Note that the file must be proper JSON, not simple a JavaScript object, so the property names must be within quotation marks.
 
-    ```javascript
+    ```json
     {
         "actions": [
         ],
@@ -87,7 +87,7 @@ If there isn't one already, create a JSON file in your project. Be sure the path
 
 1. The shortcuts array will contain objects that map key combinations onto actions. Here is an example. 
 
-    ```javascript
+    ```json
     {
         "shortcuts": [
             {
@@ -111,7 +111,7 @@ If there isn't one already, create a JSON file in your project. Be sure the path
     - The property names `action`, `key`, and `default` are required.
     - The value of the `action` property is a string and must match one of the `id` properties in the action object.
     - The `default` property can be any combination of the characters A - Z, a -z, 0 - 9, and the punctuation marks "-", "_", and "+". (By convention lower case letters are not used in these properties.)
-    - The `default` property must contain the name of at least one modifier key (ALT, CTRL, SHIFT) and at least one other key. 
+    - The `default` property must contain the name of at least one modifier key (ALT, CTRL, SHIFT) and only one other key. 
     - For Macs, ALT is mapped to the OPTION key and CTRL is mapped to the COMMAND key.
     - When two characters are linked to the same physical key in a standard keyboard, then they are synonyms in the `default` property; for example, ALT+a and ALT+A are the same shortcut, so are CTRL+- and CTRL+\_ because "-" and "_" are the same physical key.
     - The "+" character indicates that the keys on either side of it are pressed simultaneously.
@@ -126,7 +126,7 @@ In a later step, the actions will themselves be mapped to functions that you wri
 
 1. Optionally, you can vary the key combination for Office on the web, Office on Windows, or Office on Mac with additional properties on the `"key"` property. The following is an example. The `"default"` combination is used on any platform that doesn't have it's own specified combination. 
 
-    ```javascript
+    ```json
     {
         "shortcuts": [
             {
@@ -145,7 +145,7 @@ In a later step, the actions will themselves be mapped to functions that you wri
 ## Create a mapping of actions to their functions
 
 
-1. Be sure that the HTML file that the `<FunctionFile>` element in the manifest points to has a `<script>` tag that loads a custom JavaScript file.
+1. In your project, open the JavaScript file loaded by your HTML page in the `<FunctionFile>` element.
 1. In the JavaScript file, use the [Office.actions.associate](/javascript/api/office/office.actions#associate) API to map each action that you specified in the JSON file to a JavaScript function. Add the following JavaScript to the file. Note the following about the code:
 
     - The first parameter is one of the actions from the JSON file.

--- a/docs/design/keyboard-shortcuts.md
+++ b/docs/design/keyboard-shortcuts.md
@@ -37,18 +37,24 @@ There are three steps to add keyboard shortcuts to an add-in:
 
 ### Configure the add-in to use a shared runtime
 
-The keyboard shortcuts feature requires that the add-in use a shared runtime. To configure the add-in, see [Configure an add-in to use a shared runtime](../excel/configure-your-add-in-to-use-a-shared-runtime.md).
+Adding custom keyboard shortcuts requires your add-in to use the shared runtime. For more information, [Configure an add-in to use a shared runtime](../excel/configure-your-add-in-to-use-a-shared-runtime.md).
 
 ### Link the mapping file to the manifest
 
-Immediately *below* (not inside) the `<VersionOverrides>` element in the manifest, add an [ExtendedOverrides](../reference/manifest/extendedoverrides.md) element. Set the `Url` attribute to the full URL of a JSON file in your project that you will create in a later step. Example: `https://localhost:3000/add-in/extended-overrides.json`. When you are ready for staging and then production, you will need to change this value. Example: `https://contoso.com/addin/extended-overrides.json`.
+Immediately *below* (not inside) the `<VersionOverrides>` element in the manifest, add an [ExtendedOverrides](../reference/manifest/extendedoverrides.md) element. Set the `Url` attribute to the full URL of a JSON file in your project that you will create in a later step. 
+
+    ```xml
+        ...
+        </VersionOverrides>  
+        <ExtendedOverrides Url="https://contoso.com/addin/extendedManifest.json"></ExtendedOverrides>
+    </OfficeApp>
+    ```
 
 ## Create or edit the extended overrides JSON file
 
 If there isn't one already, create a JSON file in your project. Be sure the path of the file matches the location you specified for the `Url` attribute of the [ExtendedOverrides](../reference/manifest/extendedoverrides.md) element. This file will describe your keyboard shortcuts, and the actions that they will invoke.
 
-1. Be sure there is an outermost pair of braces (`{ }`)in the file.
-1. Just inside this outermost object, add the following JSON markup. Note that the file must be proper JSON, not simple a JavaScript object, so the property names must be within quotation marks.
+1. Inside the JSON file, add the following JSON:
 
     ```json
     {
@@ -81,7 +87,7 @@ If there isn't one already, create a JSON file in your project. Be sure the path
    Use the following guidelines when specifying the JSON to describe your custom keyboard shortcuts:
 
    - The property names `id` and `name` are mandatory.
-   - The `id` property is used by extension points (such as shortcuts in next step) to determine what action to invoke using a keyboard shortcut.
+   - The `id` property is used to uniquely identify the action to invoke using a keyboard shortcut.
    - The `name` property must be a user friendly string describing the action. It must be a combination of the characters A - Z, a - z, 0 - 9, and the punctuation marks "-", "_", and "+".
    - The `type` property is optional. Currently only `ExecuteFunction` type is supported.
 

--- a/docs/design/keyboard-shortcuts.md
+++ b/docs/design/keyboard-shortcuts.md
@@ -41,14 +41,14 @@ Adding custom keyboard shortcuts requires your add-in to use the shared runtime.
 
 ### Link the mapping file to the manifest
 
-Immediately *below* (not inside) the `<VersionOverrides>` element in the manifest, add an [ExtendedOverrides](../reference/manifest/extendedoverrides.md) element. Set the `Url` attribute to the full URL of a JSON file in your project that you will create in a later step. 
+Immediately *below* (not inside) the `<VersionOverrides>` element in the manifest, add an [ExtendedOverrides](../reference/manifest/extendedoverrides.md) element. Set the `Url` attribute to the full URL of a JSON file in your project that you will create in a later step.
 
-    ```xml
-        ...
-        </VersionOverrides>  
-        <ExtendedOverrides Url="https://contoso.com/addin/extendedManifest.json"></ExtendedOverrides>
-    </OfficeApp>
-    ```
+```xml
+    ...
+    </VersionOverrides>  
+    <ExtendedOverrides Url="https://contoso.com/addin/extendedManifest.json"></ExtendedOverrides>
+</OfficeApp>
+```
 
 ## Create or edit the extended overrides JSON file
 

--- a/docs/design/keyboard-shortcuts.md
+++ b/docs/design/keyboard-shortcuts.md
@@ -11,23 +11,23 @@ Keyboard shortcuts, also known as key combinations, enable your add-in's users t
 
 > [!IMPORTANT]
 > Keyboard shortcuts are in preview. Please experiment with them in a development or testing environment but don't add them to a production add-in.
-
-Keyboard shortcuts are only supported on Excel and only on these platforms and builds:
-
-* Excel on Windows: Version 2009 (Build 13231.20262)
-* Excel on Mac: 16.41.20091302
-* Excel on the web
+>
+>  Keyboard shortcuts are only supported on Excel and only on these platforms and builds:
+>
+>* Excel on Windows: Version 2009 (Build 13231.20262)
+>* Excel on Mac: 16.41.20091302
+>* Excel on the web
 
 > [!NOTE]
 > Keyboard shortcuts work only on platforms that support the following requirement sets. For more about requirement sets and how to work with them, see [Specify Office applications and API requirements](../develop/specify-office-hosts-and-api-requirements.md).
 >
 > - [SharedRuntime 1.1](../reference/requirement-sets/shared-runtime-requirement-sets.md)
 
-There are four major steps to adding keyboard shortcuts to an add-in:
+There are three major steps to adding keyboard shortcuts to an add-in:
 
 1. Configure the add-in's manifest.
-1. Create or edit the extended overrides JSON file to map action names to keyboard combinations.
-1. Add one or more runtime calls of the [Office.actions.associate](/javascript/api/office/office.actions#associate) API to map a function to each action name.
+1. Create or edit the extended overrides JSON file to define actions and their keyboard shortcuts.
+1. Add one or more runtime calls of the [Office.actions.associate](/javascript/api/office/office.actions#associate) API to map a function to each action.
 
 Each step is described in more detail below.
 
@@ -61,11 +61,12 @@ If there isn't one already, create a JSON file at the path that you use in devel
 1. The shortcuts array will contain objects that map key combinations onto action names. Here is an example. Note the following about this markup:
 
     - The property names you see here, `action`, `key`, and `default` are mandatory.
-    - The value of the `action` property can be any string, and the `default` property can be any combination of the characters A - Z, a -z, 0 - 9, and the punctuation marks "-", "_", and "+". (By convention lower case letters are not used in these properties.)
-    - The `default` property must contain the name of at least one modifier key (ALT, CTRL, SHIFT) and at least one other key. (An additional modifier key is possible on Mac. See the next step.)
+    - The value of the `action` property is a string (max 128 characters), and the `default` property can be any combination of the characters A - Z, a -z, 0 - 9, and the punctuation marks "-", "_", and "+". (By convention lower case letters are not used in these properties.)
+    - The `default` property must contain the name of at least one modifier key (ALT, CTRL, SHIFT) and at least one other key. 
+    - For Macs, ALT is mapped to the OPTION key and CTRL is mapped to the COMMAND key.
     - When two characters are linked to the same physical key in a standard keyboard, then they are synonyms in the `default` property; for example, ALT+a and ALT+A are the same shortcut, so are CTRL+- and CTRL+\_ because "-" and "_" are the same physical key.
     - The "+" character indicates that the keys on either side of it are pressed simultaneously.
-    - In a later step, the action names will themselves be mapped to functions that you write. In this example, you will later map SHOWTASKPANE to a function that calls the `Office.addin.showAsTaskpane` method and HIDETASKPANE to a function that calls the `Office.addin.hide` method. 
+    - In a later step, the actions will themselves be mapped to functions that you write. In this example, you will later map SHOWTASKPANE to a function that calls the `Office.addin.showAsTaskpane` method and HIDETASKPANE to a function that calls the `Office.addin.hide` method. 
 
     > [!NOTE]
     > The complete schema for the shortcuts JSON is at [extended-manifest.schema.json](https://developer.microsoft.com/en-us/json-schemas/office-js/extended-manifest.schema.json).
@@ -92,7 +93,7 @@ If there isn't one already, create a JSON file at the path that you use in devel
     > [!NOTE]
     > Keytips, also known as sequential key shortcuts, such as the Excel shortcut to choose a fill color **Alt+H, H**, are not supported in Office add-ins.
 
-1. Optionally, you can vary the key combination for Office on the web, Office on Windows, or Office on Mac with additional properties on the `"key"` property. The following is an example. The `"default"` combination is used on any platform that doesn't have it's own specified combination. Note that on Mac, you can use the modifier key COMMAND.
+1. Optionally, you can vary the key combination for Office on the web, Office on Windows, or Office on Mac with additional properties on the `"key"` property. The following is an example. The `"default"` combination is used on any platform that doesn't have it's own specified combination. 
 
     ```javascript
     {
@@ -110,18 +111,17 @@ If there isn't one already, create a JSON file at the path that you use in devel
     }
     ```
 
-## Create a mapping of functions to actions
+## Create a mapping of actions to their callback functions
 
-The last major step is to map your custom functions onto the action names.
 
 1. Be sure that the HTML file that the `<FunctionFile>` element in the manifest points to has a `<script>` tag that loads a custom JavaScript file.
-1. In the JavaScript file, use calls of the [Office.actions.associate](/javascript/api/office/office.actions#associate) API to map a function to each action name that you used in the JSON file. To begin add the following to the file. Note the following about this code:
+1. In the JavaScript file, use calls of the [Office.actions.associate](/javascript/api/office/office.actions#associate) API to map a function to each action that you used in the JSON file. To begin add the following to the file. Note the following about this code:
 
-    - The first parameter is one of the action names from the JSON file.
-    - The second parameter is the function that runs when a user presses the key combination that is mapped to the action name in the JSON file.
+    - The first parameter is one of the actions from the JSON file.
+    - The second parameter is the function that runs when a user presses the key combination that is mapped to the action in the JSON file.
 
     ```javascript
-    Office.actions.associate('-- acton name goes here--', function () {
+    Office.actions.associate('-- action goes here--', function () {
 
     });
     ```

--- a/docs/design/keyboard-shortcuts.md
+++ b/docs/design/keyboard-shortcuts.md
@@ -61,7 +61,7 @@ If there isn't one already, create a JSON file at the path that you use in devel
 1. The shortcuts array will contain objects that map key combinations onto action names. Here is an example. Note the following about this markup:
 
     - The property names you see here, `action`, `key`, and `default` are mandatory.
-    - The value of the `action` property is a string (max 128 characters), and the `default` property can be any combination of the characters A - Z, a -z, 0 - 9, and the punctuation marks "-", "_", and "+". (By convention lower case letters are not used in these properties.)
+    - The value of the `action` property is a string, and the `default` property can be any combination of the characters A - Z, a -z, 0 - 9, and the punctuation marks "-", "_", and "+". (By convention lower case letters are not used in these properties.)
     - The `default` property must contain the name of at least one modifier key (ALT, CTRL, SHIFT) and at least one other key. 
     - For Macs, ALT is mapped to the OPTION key and CTRL is mapped to the COMMAND key.
     - When two characters are linked to the same physical key in a standard keyboard, then they are synonyms in the `default` property; for example, ALT+a and ALT+A are the same shortcut, so are CTRL+- and CTRL+\_ because "-" and "_" are the same physical key.
@@ -111,7 +111,7 @@ If there isn't one already, create a JSON file at the path that you use in devel
     }
     ```
 
-## Create a mapping of actions to their callback functions
+## Create a mapping of actions to their functions
 
 
 1. Be sure that the HTML file that the `<FunctionFile>` element in the manifest points to has a `<script>` tag that loads a custom JavaScript file.
@@ -167,7 +167,7 @@ Currently, there is no workaround when two or more add-ins have registered the s
 
 - Use only keyboard shortcuts with the following patterns in your add-in.
 
-    - **Alt-*n***, where *n* is a numeral from 1 to 9.
+    - **Alt+*n***, where *n* is a numeral from 1 to 9.
     - **Ctrl+Shift+Alt+*n***, where *n* is a numeral from 1 to 9.
 
 - If you need more keyboard shortcuts, check the [list of Excel keyboard shortcuts](https://support.microsoft.com/office/keyboard-shortcuts-in-excel-1798d9d5-842a-42b8-9c99-9b7213f0040f), and avoid using any of them in your add-in.


### PR DESCRIPTION
Here are the changes I made:
1. Add "actions" object to the JSON file (this resulted in a few changes to verbiage changing "action name" to "action")
2. Include the platform limitations as part of !Important note (to match custom functions documentation)
3. Move the example JSON before the notes regarding the example
4. Small spelling/wording fixes