### PR TITLE
[PowerPoint] (Requirement sets) PowerPoint preview APIs requirement set page

### DIFF
--- a/docs/reference/requirement-sets/excel-api-requirement-sets.md
+++ b/docs/reference/requirement-sets/excel-api-requirement-sets.md
@@ -1,7 +1,7 @@
 ---
 title: Excel JavaScript API requirement sets
 description: 'Office Add-in requirement set information for Excel builds.'
-ms.date: 09/15/2020
+ms.date: 10/26/2020
 ms.prod: excel
 localization_priority: Priority
 ---
@@ -21,7 +21,7 @@ Excel add-ins run across multiple versions of Office, including Office 2016 or l
 
 |  Requirement set  |  Office on Windows<br>(connected to a Microsoft 365 subscription)  |  Office on iPad<br>(connected to a Microsoft 365 subscription)  |  Office on Mac<br>(connected to a Microsoft 365 subscription)  | Office on the web |
 |:-----|-----|:-----|:-----|:-----|:-----|
-| [Preview](excel-preview-apis.md)  | Please use the latest Office version to try preview APIs (you may need to join the [Office Insider program](https://insider.office.com)) |
+| [Preview](excel-preview-apis.md)  | Please use the latest Office version to try preview APIs (you may need to join the [Office Insider program](https://insider.office.com)). |
 | [ExcelApiOnline](excel-api-online-requirement-set.md) | N/A | N/A | N/A | Latest (see [requirement set page](excel-api-online-requirement-set.md)) |
 | [ExcelApi 1.12](excel-api-1-12-requirement-set.md) | Version 2008 (Build 13127.20408) or later | 16.40 or later | 16.40 or later | September 2020 |
 | [ExcelApi 1.11](excel-api-1-11-requirement-set.md) | Version 2002 (Build 12527.20470) or later | 16.35 or later | 16.33 or later | May 2020 |
@@ -51,7 +51,7 @@ For more information about Office versions and build numbers, see:
 ## How to use Excel requirement sets at runtime and in the manifest
 
 > [!NOTE]
-> This section assumes that you are familiar with the overview of requirement sets at [Office versions and requirement sets](../../develop/office-versions-and-requirement-sets.md) and [Specify Office applications and API requirements](../../develop/specify-office-hosts-and-api-requirements.md).
+> This section assumes you're familiar with the overview of requirement sets at [Office versions and requirement sets](../../develop/office-versions-and-requirement-sets.md) and [Specify Office applications and API requirements](../../develop/specify-office-hosts-and-api-requirements.md).
 
 Requirement sets are named groups of API members. An Office Add-in can perform a runtime check or use requirement sets specified in the manifest to determine whether an Office application supports the APIs that the add-in needs.
 
@@ -61,10 +61,10 @@ The following code sample shows how to determine whether the Office application 
 
 ```js
 if (Office.context.requirements.isSetSupported('ExcelApi', '1.3')) {
-  /// perform actions
+  // Perform actions.
 }
 else {
-  /// provide alternate flow/logic
+  // Provide alternate flow/logic.
 }
 ```
 

--- a/docs/reference/requirement-sets/excel-preview-apis.md
+++ b/docs/reference/requirement-sets/excel-preview-apis.md
@@ -1,7 +1,7 @@
 ---
 title: Excel JavaScript preview APIs
 description: 'Details about upcoming Excel JavaScript APIs.'
-ms.date: 09/15/2020
+ms.date: 10/26/2020
 ms.prod: excel
 localization_priority: Normal
 ---
@@ -21,7 +21,7 @@ The first table provides a concise summary of the APIs, while the subsequent tab
 
 ## API list
 
-The following table lists the Excel JavaScript APIs currently in preview. To see a complete list of all Excel JavaScript APIs (including preview APIs and previously released APIs), see [all Excel JavaScript APIs](/javascript/api/excel?view=excel-js-preview&preserve-view=true).
+The following table lists the Excel JavaScript APIs currently in preview. For a complete list of all Excel JavaScript APIs (including preview APIs and previously released APIs), see [all Excel JavaScript APIs](/javascript/api/excel?view=excel-js-preview&preserve-view=true).
 
 | Class | Fields | Description |
 |:---|:---|:---|

--- a/docs/reference/requirement-sets/powerpoint-api-requirement-sets.md
+++ b/docs/reference/requirement-sets/powerpoint-api-requirement-sets.md
@@ -1,7 +1,7 @@
 ---
 title: PowerPoint JavaScript API requirement sets
 description: 'Learn more about the PowerPoint JavaScript API requirement sets.'
-ms.date: 10/23/2020
+ms.date: 10/26/2020
 ms.prod: powerpoint
 localization_priority: Priority
 ---
@@ -14,7 +14,7 @@ The following table lists the PowerPoint requirement sets, the Office client app
 
 |  Requirement set  |  Office on Windows<br>(connected to a Microsoft 365 subscription)  |  Office on iPad<br>(connected to a Microsoft 365 subscription)  |  Office on Mac<br>(connected to a Microsoft 365 subscription)  | Office on the web |
 |:-----|-----|:-----|:-----|:-----|:-----|
-| [Preview](powerpoint-preview-apis.md)  | Please use the latest Office version to try preview APIs (you may need to join the [Office Insider program](https://insider.office.com)) |
+| [Preview](powerpoint-preview-apis.md)  | Please use the latest Office version to try preview APIs (you may need to join the [Office Insider program](https://insider.office.com)). |
 | PowerPointApi 1.1 | Version 1810 (Build 11001.20074) or later | 2.17 or later | 16.19 or later | October 2018 |
 
 ## Office versions and build numbers
@@ -30,7 +30,7 @@ PowerPoint JavaScript API 1.1 contains a [single API to create a new presentatio
 ## How to use PowerPoint requirement sets at runtime and in the manifest
 
 > [!NOTE]
-> This section assumes that you are familiar with the overview of requirement sets at [Office versions and requirement sets](../../develop/office-versions-and-requirement-sets.md) and [Specify Office applications and API requirements](../../develop/specify-office-hosts-and-api-requirements.md).
+> This section assumes you're familiar with the overview of requirement sets at [Office versions and requirement sets](../../develop/office-versions-and-requirement-sets.md) and [Specify Office applications and API requirements](../../develop/specify-office-hosts-and-api-requirements.md).
 
 Requirement sets are named groups of API members. An Office Add-in can perform a runtime check or use requirement sets specified in the manifest to determine whether an Office application supports the APIs that the add-in needs.
 
@@ -40,10 +40,9 @@ The following code sample shows how to determine whether the Office application 
 
 ```js
 if (Office.context.requirements.isSetSupported('PowerPointApi', '1.1')) {
-  /// perform actions
-}
+  // Perform actions.
 else {
-  /// provide alternate flow/logic
+  // Provide alternate flow/logic.
 }
 ```
 
@@ -51,7 +50,7 @@ else {
 
 You can use the [Requirements element](../manifest/requirements.md) in the add-in manifest to specify the minimal requirement sets and/or API methods that your add-in requires to activate. If the Office application or platform doesn't support the requirement sets or API methods that are specified in the `Requirements` element of the manifest, the add-in won't run in that application or platform, and it won't display in the list of add-ins that are shown in **My Add-ins**. If your add-in requires a specific requirement set for full functionality, but it can provide value even to users on platforms that do not support the requirement set, we recommend that you check for requirement support at runtime as described above, instead of defining requirement set support in the manifest.
 
-The following code sample shows the `Requirements` element in an add-in manifest which specifies that the add-in should load in all Office client applications that support PowerPointApi requirement set version 1.3 or greater.
+The following code sample shows the `Requirements` element in an add-in manifest which specifies that the add-in should load in all Office client applications that support PowerPointApi requirement set version 1.1 or greater.
 
 ```xml
 <Requirements>

--- a/docs/reference/requirement-sets/powerpoint-api-requirement-sets.md
+++ b/docs/reference/requirement-sets/powerpoint-api-requirement-sets.md
@@ -1,7 +1,7 @@
 ---
 title: PowerPoint JavaScript API requirement sets
 description: 'Learn more about the PowerPoint JavaScript API requirement sets.'
-ms.date: 07/10/2020
+ms.date: 10/23/2020
 ms.prod: powerpoint
 localization_priority: Priority
 ---
@@ -14,6 +14,7 @@ The following table lists the PowerPoint requirement sets, the Office client app
 
 |  Requirement set  |  Office on Windows<br>(connected to a Microsoft 365 subscription)  |  Office on iPad<br>(connected to a Microsoft 365 subscription)  |  Office on Mac<br>(connected to a Microsoft 365 subscription)  | Office on the web |
 |:-----|-----|:-----|:-----|:-----|:-----|
+| [Preview](powerpoint-preview-apis.md)  | Please use the latest Office version to try preview APIs (you may need to join the [Office Insider program](https://insider.office.com)) |
 | PowerPointApi 1.1 | Version 1810 (Build 11001.20074) or later | 2.17 or later | 16.19 or later | October 2018 |
 
 ## Office versions and build numbers
@@ -24,26 +25,33 @@ For more information about Office versions and build numbers, see:
 
 ## PowerPoint JavaScript API 1.1
 
-PowerPoint JavaScript API 1.1 contains a single API to create a new presentation. For details about the API, see [JavaScript API for PowerPoint](../../powerpoint/powerpoint-add-ins.md).
+PowerPoint JavaScript API 1.1 contains a [single API to create a new presentation](/javascript/api/powerpoint#powerpoint-createpresentation-base64file-). For details about the API, see [Create a presentation](../../powerpoint/powerpoint-add-ins.md#create-a-presentation).
 
-## Runtime requirement support check
+## How to use PowerPoint requirement sets at runtime and in the manifest
 
-At runtime, add-ins can check if a particular application supports an API requirement set by doing the following.
+> [!NOTE]
+> This section assumes that you are familiar with the overview of requirement sets at [Office versions and requirement sets](../../develop/office-versions-and-requirement-sets.md) and [Specify Office applications and API requirements](../../develop/specify-office-hosts-and-api-requirements.md).
+
+Requirement sets are named groups of API members. An Office Add-in can perform a runtime check or use requirement sets specified in the manifest to determine whether an Office application supports the APIs that the add-in needs.
+
+### Checking for requirement set support at runtime
+
+The following code sample shows how to determine whether the Office application where the add-in is running supports the specified API requirement set.
 
 ```js
 if (Office.context.requirements.isSetSupported('PowerPointApi', '1.1')) {
-  // Perform actions.
+  /// perform actions
 }
 else {
-  // Provide alternate flow/logic.
+  /// provide alternate flow/logic
 }
 ```
 
-## Manifest-based requirement support check
+### Defining requirement set support in the manifest
 
-Use the `Requirements` element in the add-in manifest to specify critical requirement sets or API members that your add-in must use. If the Office application or platform doesn't support the requirement sets or API members specified in the `Requirements` element, the add-in won't run in that application or platform, and won't display in My Add-ins.
+You can use the [Requirements element](../manifest/requirements.md) in the add-in manifest to specify the minimal requirement sets and/or API methods that your add-in requires to activate. If the Office application or platform doesn't support the requirement sets or API methods that are specified in the `Requirements` element of the manifest, the add-in won't run in that application or platform, and it won't display in the list of add-ins that are shown in **My Add-ins**. If your add-in requires a specific requirement set for full functionality, but it can provide value even to users on platforms that do not support the requirement set, we recommend that you check for requirement support at runtime as described above, instead of defining requirement set support in the manifest.
 
-The following code example shows an add-in that loads in all Office client applications that support the OneNoteApi requirement set, version 1.1.
+The following code sample shows the `Requirements` element in an add-in manifest which specifies that the add-in should load in all Office client applications that support PowerPointApi requirement set version 1.3 or greater.
 
 ```xml
 <Requirements>

--- a/docs/reference/requirement-sets/powerpoint-api-requirement-sets.md
+++ b/docs/reference/requirement-sets/powerpoint-api-requirement-sets.md
@@ -41,7 +41,7 @@ The following code sample shows how to determine whether the Office application 
 ```js
 if (Office.context.requirements.isSetSupported('PowerPointApi', '1.1')) {
   // Perform actions.
-else {
+} else {
   // Provide alternate flow/logic.
 }
 ```

--- a/docs/reference/requirement-sets/powerpoint-preview-apis.md
+++ b/docs/reference/requirement-sets/powerpoint-preview-apis.md
@@ -1,0 +1,43 @@
+---
+title: PowerPoint JavaScript preview APIs
+description: 'Details about upcoming PowerPoint JavaScript APIs.'
+ms.date: 10/23/2020
+ms.prod: powerpoint
+localization_priority: Normal
+---
+
+# PowerPoint JavaScript preview APIs
+
+New PowerPoint JavaScript APIs are first introduced in "preview" and later become part of a specific, numbered requirement set after sufficient testing occurs and user feedback is acquired.
+
+The first table provides a concise summary of the APIs, while the subsequent table gives a detailed list.
+
+[!INCLUDE [Information about using preview APIs](../../includes/using-preview-apis-host.md)]
+
+| Feature area | Description | Relevant objects |
+|:--- |:--- |:--- |
+| Insert and Delete Slides | Allows the insertion of existing slides into the current presentation from another presentation, as well as the ability to delete sildes. | [Slide.delete](/javascript/api/powerpoint/powerpoint.slide#delete--), [Presentation.insertSlidesFromBase64](/javascript/api/powerpoint/powerpoint.presentation#insertslidesfrombase64-base64file--options-)|
+
+## API list
+
+The following table lists the PowerPoint JavaScript APIs currently in preview. To see a complete list of all PowerPoint JavaScript APIs (including preview APIs and previously released APIs), see [all PowerPoint JavaScript APIs](/javascript/api/powerpoint?view=powerpoint-js-preview&preserve-view=true).
+
+| Class | Fields | Description |
+|:---|:---|:---|
+|[InsertSlideOptions](/javascript/api/powerpoint/powerpoint.insertslideoptions)|[formatting](/javascript/api/powerpoint/powerpoint.insertslideoptions#formatting)|Specifies which formatting to use during slide insertion.|
+||[sourceSlideIds](/javascript/api/powerpoint/powerpoint.insertslideoptions#sourceslideids)|Specifies the slides from the source presentation that will be inserted into the current presentation. These slides are represented by their IDs which can be retrieved from a `Slide` object.|
+||[targetSlideId](/javascript/api/powerpoint/powerpoint.insertslideoptions#targetslideid)|Specifies where in the presentation the new slides will be inserted. The new slides will be inserted after the slide with the given slide ID.|
+|[Presentation](/javascript/api/powerpoint/powerpoint.presentation)|[insertSlidesFromBase64(base64File: string, options?: PowerPoint.InsertSlideOptions)](/javascript/api/powerpoint/powerpoint.presentation#insertslidesfrombase64-base64file--options-)|Inserts the specified slides from a presentation into the current presentation.|
+||[slides](/javascript/api/powerpoint/powerpoint.presentation#slides)|Returns an ordered collection of slides in the presentation.|
+|[Slide](/javascript/api/powerpoint/powerpoint.slide)|[delete()](/javascript/api/powerpoint/powerpoint.slide#delete--)|Deletes the slide from the presentation. Does nothing if the slide does not exist.|
+||[id](/javascript/api/powerpoint/powerpoint.slide#id)|Gets the unique ID of the slide.|
+|[SlideCollection](/javascript/api/powerpoint/powerpoint.slidecollection)|[getCount()](/javascript/api/powerpoint/powerpoint.slidecollection#getcount--)|Gets the number of slides in the collection.|
+||[getItem(key: string)](/javascript/api/powerpoint/powerpoint.slidecollection#getitem-key-)|Gets a slide using its unique ID. An exception is thrown if the slide does not exist.|
+||[getItemAt(index: number)](/javascript/api/powerpoint/powerpoint.slidecollection#getitemat-index-)|Gets a slide using its zero-based index in the collection. Slides are stored in the same order as they|
+||[getItemOrNullObject(id: string)](/javascript/api/powerpoint/powerpoint.slidecollection#getitemornullobject-id-)|Gets a slide using its unique ID. Returns an object whose `isNullObject` property is set to `true` if the slide does not exist.|
+||[items](/javascript/api/powerpoint/powerpoint.slidecollection#items)|Gets the loaded child items in this collection.|
+
+## See also
+
+- [PowerPoint JavaScript API Reference Documentation](/javascript/api/powerpoint?view=powerpoint-js-preview&preserve-view=true)
+- [PowerPoint JavaScript API requirement sets](powerpoint-api-requirement-sets.md)

--- a/docs/reference/requirement-sets/powerpoint-preview-apis.md
+++ b/docs/reference/requirement-sets/powerpoint-preview-apis.md
@@ -1,7 +1,7 @@
 ---
 title: PowerPoint JavaScript preview APIs
 description: 'Details about upcoming PowerPoint JavaScript APIs.'
-ms.date: 10/23/2020
+ms.date: 10/26/2020
 ms.prod: powerpoint
 localization_priority: Normal
 ---
@@ -20,20 +20,20 @@ The first table provides a concise summary of the APIs, while the subsequent tab
 
 ## API list
 
-The following table lists the PowerPoint JavaScript APIs currently in preview. To see a complete list of all PowerPoint JavaScript APIs (including preview APIs and previously released APIs), see [all PowerPoint JavaScript APIs](/javascript/api/powerpoint?view=powerpoint-js-preview&preserve-view=true).
+The following table lists the PowerPoint JavaScript APIs currently in preview. For a complete list of all PowerPoint JavaScript APIs (including preview APIs and previously released APIs), see [all PowerPoint JavaScript APIs](/javascript/api/powerpoint?view=powerpoint-js-preview&preserve-view=true).
 
 | Class | Fields | Description |
 |:---|:---|:---|
 |[InsertSlideOptions](/javascript/api/powerpoint/powerpoint.insertslideoptions)|[formatting](/javascript/api/powerpoint/powerpoint.insertslideoptions#formatting)|Specifies which formatting to use during slide insertion.|
 ||[sourceSlideIds](/javascript/api/powerpoint/powerpoint.insertslideoptions#sourceslideids)|Specifies the slides from the source presentation that will be inserted into the current presentation. These slides are represented by their IDs which can be retrieved from a `Slide` object.|
-||[targetSlideId](/javascript/api/powerpoint/powerpoint.insertslideoptions#targetslideid)|Specifies where in the presentation the new slides will be inserted. The new slides will be inserted after the slide with the given slide ID.|
+||[targetSlideId](/javascript/api/powerpoint/powerpoint.insertslideoptions#targetslideid)|Specifies where in the presentation the new slides will be inserted.|
 |[Presentation](/javascript/api/powerpoint/powerpoint.presentation)|[insertSlidesFromBase64(base64File: string, options?: PowerPoint.InsertSlideOptions)](/javascript/api/powerpoint/powerpoint.presentation#insertslidesfrombase64-base64file--options-)|Inserts the specified slides from a presentation into the current presentation.|
 ||[slides](/javascript/api/powerpoint/powerpoint.presentation#slides)|Returns an ordered collection of slides in the presentation.|
 |[Slide](/javascript/api/powerpoint/powerpoint.slide)|[delete()](/javascript/api/powerpoint/powerpoint.slide#delete--)|Deletes the slide from the presentation. Does nothing if the slide does not exist.|
 ||[id](/javascript/api/powerpoint/powerpoint.slide#id)|Gets the unique ID of the slide.|
 |[SlideCollection](/javascript/api/powerpoint/powerpoint.slidecollection)|[getCount()](/javascript/api/powerpoint/powerpoint.slidecollection#getcount--)|Gets the number of slides in the collection.|
 ||[getItem(key: string)](/javascript/api/powerpoint/powerpoint.slidecollection#getitem-key-)|Gets a slide using its unique ID. An exception is thrown if the slide does not exist.|
-||[getItemAt(index: number)](/javascript/api/powerpoint/powerpoint.slidecollection#getitemat-index-)|Gets a slide using its zero-based index in the collection. Slides are stored in the same order as they|
+||[getItemAt(index: number)](/javascript/api/powerpoint/powerpoint.slidecollection#getitemat-index-)|Gets a slide using its zero-based index in the collection.|
 ||[getItemOrNullObject(id: string)](/javascript/api/powerpoint/powerpoint.slidecollection#getitemornullobject-id-)|Gets a slide using its unique ID. Returns an object whose `isNullObject` property is set to `true` if the slide does not exist.|
 ||[items](/javascript/api/powerpoint/powerpoint.slidecollection#items)|Gets the loaded child items in this collection.|
 

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -1070,10 +1070,10 @@
       displayName: PowerPoint
     - name: API requirement sets
       items:
-        name: Overview
+      - name: Overview
         href: reference/requirement-sets/powerpoint-api-requirement-sets.md
         displayName: PowerPoint
-        name: PowerPoint preview APIs
+      - name: PowerPoint preview APIs
         href: reference/requirement-sets/powerpoint-preview-apis.md
         displayName: PowerPoint
     - name: API reference

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -1069,8 +1069,13 @@
       href: reference/overview/powerpoint-add-ins-reference-overview.md
       displayName: PowerPoint
     - name: API requirement sets
-      href: reference/requirement-sets/powerpoint-api-requirement-sets.md
-      displayName: PowerPoint
+      items:
+        name: Overview
+        href: reference/requirement-sets/powerpoint-api-requirement-sets.md
+        displayName: PowerPoint
+        name: PowerPoint preview APIs
+        href: reference/requirement-sets/powerpoint-preview-apis.md
+        displayName: PowerPoint
     - name: API reference
       href: reference/powerpoint-api-reference.md
       displayName: PowerPoint


### PR DESCRIPTION
This PR adds a page for the PowerPointAPI Preview requirement set. It also makes the PPT requirement set overview page match [that of Excel](https://docs.microsoft.com/en-us/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets?view=powerpoint-js-preview) for better consistency across hosts.