### PR TITLE
[Office](shared runtime) Remove IE runtime note

### DIFF
--- a/docs/reference/manifest/runtimes.md
+++ b/docs/reference/manifest/runtimes.md
@@ -8,9 +8,6 @@ localization_priority: Normal
 
 Specifies the runtime of your add-in. Child of the [`<Host>`](host.md) element.
 
-> [!NOTE]
-> When running in Office on Windows, your add-in uses the Internet Explorer 11 browser.
-
 In Excel, this element enables the ribbon, task pane, and custom functions to use the same runtime. For more information, see [Configure your Excel add-in to use a shared JavaScript runtime](../../excel/configure-your-add-in-to-use-a-shared-runtime.md).
 
 In Outlook, this element enables event-based add-in activation. For more information, see [Configure your Outlook add-in for event-based activation](../../outlook/autolaunch.md).


### PR DESCRIPTION
Removing a confusing note that implied shared runtime only runs on IE in Office on Windows.