### PR TITLE
KB shortcuts changes

### DIFF
--- a/docs/design/keyboard-shortcuts.md
+++ b/docs/design/keyboard-shortcuts.md
@@ -165,9 +165,11 @@ If there isn't one already, create a JSON file in your project. Be sure the path
     });
     ```
 
-Following the previous steps lets your add-in toggle the visibility of the task pane by pressing **Ctrl+Shift+Up arrow key** and **Ctrl+Shift+Down arrow key**. This is the same behavior as shown in the [Add keyboard shortcuts to an Office Add-in tutorial](../tutorials/keyboard-shortcuts-tutorial.md).
+Following the previous steps lets your add-in toggle the visibility of the task pane by pressing **Ctrl+Shift+Up arrow key** and **Ctrl+Shift+Down arrow key**. This is the same behavior as shown in the [Add keyboard shortcuts to an Office Add-in tutorial](../tutorials/keyboard-shortcuts-tutorial.md) and the [sample excel keyboard shortcuts add-in](https://github.com/OfficeDev/PnP-OfficeAddins/tree/master/Samples/excel-keyboard-shortcuts).
 
-An example of a simple add-in that uses several custom keyboard shortcuts is at [excel-keyboard-shortcuts](https://github.com/OfficeDev/PnP-OfficeAddins/tree/master/Samples/excel-keyboard-shortcuts).
+## Using shortcuts when the focus is in the taskpane
+Currently, the keyboard shortcuts for an Office add-in can only be invoked when the user's focus is in the worksheet. When the user's focus is inside the Office add-in taskpane, none of the add-in's shortcuts will be invoked. As a workaround, the add-in is able to create their own keyboard handler that can invoke certain actions when the user's focus is inside of the add-in UI (such as the task pane).
+
 
 ## Using key combinations that are already used by Office or another add-in
 

--- a/docs/design/keyboard-shortcuts.md
+++ b/docs/design/keyboard-shortcuts.md
@@ -11,10 +11,13 @@ Keyboard shortcuts, also known as key combinations, enable your add-in's users t
 
 [!include[Keyboard shortcut prerequisites](../includes/keyboard-shortcuts-prerequisites.md)]
 
+> [!NOTE]
+> To start with a working version of the add-in with keyboard shortcuts already enabled. Clone and run the [Keyboard Shortcuts PnP](https://github.com/OfficeDev/PnP-OfficeAddins/tree/master/Samples/excel-keyboard-shortcuts) and follow along using the instructions below.
+
 There are three steps to add keyboard shortcuts to an add-in:
 
 1. [Configure the add-in's manifest](#configure-the-manifest).
-1. [Create or edit the extended overrides JSON file](#create-or-edit-the-extended-overrides-json-file) to define actions and their keyboard shortcuts.
+1. [Create or edit the shortcuts JSON file](#create-or-edit-the-shortcuts-json-file) to define actions and their keyboard shortcuts.
 1. [Add one or more runtime calls](#create-a-mapping-of-actions-to-their-functions) of the [Office.actions.associate](/javascript/api/office/office.actions#associate) API to map a function to each action.
 
 > [!NOTE]
@@ -23,7 +26,7 @@ There are three steps to add keyboard shortcuts to an add-in:
 ## Configure the manifest
 
 > [!NOTE]
-> If your add-in's manifest already has an [ExtendedOverrides](../reference/manifest/extendedoverrides.md) element (which would be just below the `<VersionOverrides>` element) then you are already using a feature that leverages extended overrides and you can skip this section. Continue with [Create or edit the extended overrides JSON file](#create-or-edit-the-extended-overrides-json-file).
+> If your add-in's manifest already has an [ExtendedOverrides](../reference/manifest/extendedoverrides.md) element (which would be just below the `<VersionOverrides>` element) then you are already using a feature that leverages extended overrides and you can skip this section. Continue with [Create or edit the shortcuts JSON file](#create-or-edit-the-shortcuts-json-file).
 
 ### Configure the add-in to use a shared runtime
 
@@ -36,11 +39,11 @@ Immediately *below* (not inside) the `<VersionOverrides>` element in the manifes
 ```xml
     ...
     </VersionOverrides>  
-    <ExtendedOverrides Url="https://contoso.com/addin/extendedManifest.json"></ExtendedOverrides>
+    <ExtendedOverrides Url="https://contoso.com/addin/shortcuts.json"></ExtendedOverrides>
 </OfficeApp>
 ```
 
-## Create or edit the extended overrides JSON file
+## Create or edit the shortcuts JSON file
 
 If there isn't one already, create a JSON file in your project. Be sure the path of the file matches the location you specified for the `Url` attribute of the [ExtendedOverrides](../reference/manifest/extendedoverrides.md) element. This file will describe your keyboard shortcuts, and the actions that they will invoke.
 
@@ -103,7 +106,8 @@ If there isn't one already, create a JSON file in your project. Be sure the path
     - The value of the `action` property is a string and must match one of the `id` properties in the action object.
     - The `default` property can be any combination of the characters A - Z, a -z, 0 - 9, and the punctuation marks "-", "_", and "+". (By convention lower case letters are not used in these properties.)
     - The `default` property must contain the name of at least one modifier key (ALT, CTRL, SHIFT) and only one other key.
-    - For Macs, ALT is mapped to the OPTION key and CTRL is mapped to the COMMAND key.
+    - For Macs, we also support the COMMAND modifier key.
+    - ALT is mapped to the OPTION key. and CTRL is mapped to the COMMAND key.
     - When two characters are linked to the same physical key in a standard keyboard, then they are synonyms in the `default` property; for example, ALT+a and ALT+A are the same shortcut, so are CTRL+- and CTRL+\_ because "-" and "_" are the same physical key.
     - The "+" character indicates that the keys on either side of it are pressed simultaneously.
 
@@ -117,22 +121,6 @@ If there isn't one already, create a JSON file in your project. Be sure the path
 
     > [!NOTE]
     > Keytips, also known as sequential key shortcuts, such as the Excel shortcut to choose a fill color **Alt+H, H**, are not supported in Office add-ins.
-
-1. Optionally, you can vary the key combination for Office on the web, Office on Windows, or Office on Mac with additional properties on the `"key"` property. The following is an example. The `"default"` combination is used on any platform that doesn't have it's own specified combination. (Note that on the Mac, you can use "COMMAND" and "OPTION". If your `"default"` contains "CTRL" or "ALT", it is *not* necessary to provide a `"mac"` combination, if the only difference from the `"default"` is the use of "COMMAND" and "OPTION" in place of "CTRL" and "ALT". Office makes this substitution automatically on the Mac.)
-
-    ```json
-        "shortcuts": [
-            {
-                "action": "SHOWTASKPANE",
-                "key": {
-                    "default": "CTRL+SHIFT+UP",
-                    "web": "CTRL+SHIFT+P",
-                    "win32": "CTRL+SHIFT+R",
-                    "mac": "COMMAND+OPTION+SHIFT+S"
-                }
-            }
-        ]
-    ```
 
 ## Create a mapping of actions to their functions
 
@@ -189,7 +177,6 @@ Currently, there is no workaround when two or more add-ins have registered the s
 
 - Use only keyboard shortcuts with the following patterns in your add-in.
 
-    - **Alt+*x***, where *x* is some other key.
     - **Ctrl+Shift+Alt+*x***, where *x* is some other key.
 
 - If you need more keyboard shortcuts, check the [list of Excel keyboard shortcuts](https://support.microsoft.com/office/keyboard-shortcuts-in-excel-1798d9d5-842a-42b8-9c99-9b7213f0040f), and avoid using any of them in your add-in.

--- a/docs/design/keyboard-shortcuts.md
+++ b/docs/design/keyboard-shortcuts.md
@@ -107,7 +107,7 @@ If there isn't one already, create a JSON file in your project. Be sure the path
     - The `default` property can be any combination of the characters A - Z, a -z, 0 - 9, and the punctuation marks "-", "_", and "+". (By convention lower case letters are not used in these properties.)
     - The `default` property must contain the name of at least one modifier key (ALT, CTRL, SHIFT) and only one other key.
     - For Macs, we also support the COMMAND modifier key.
-    - ALT is mapped to the OPTION key. and CTRL is mapped to the COMMAND key.
+    - For Macs, ALT is mapped to the OPTION key. For Windows, COMMAND is mapped to the CTRL key.
     - When two characters are linked to the same physical key in a standard keyboard, then they are synonyms in the `default` property; for example, ALT+a and ALT+A are the same shortcut, so are CTRL+- and CTRL+\_ because "-" and "_" are the same physical key.
     - The "+" character indicates that the keys on either side of it are pressed simultaneously.
 

--- a/docs/tutorials/keyboard-shortcuts-tutorial.md
+++ b/docs/tutorials/keyboard-shortcuts-tutorial.md
@@ -12,10 +12,11 @@ There are three steps to add keyboard shortcuts to an add-in:
 
 > [!div class="checklist"]
 > * Configure the add-in's manifest.
-> * Create the extended overrides JSON file to define actions and their keyboard shortcuts.
+> * Create the shortcuts JSON file to define actions and their keyboard shortcuts.
 > * Map functions to runtime calls with the `associate` method.
 
-This tutorial assumes you're familiar with using the Yo Office generator to create add-in projects. Consider completing the [Excel custom functions tutorial](excel-tutorial-create-custom-functions.md), if you haven't already.
+> [!NOTE]
+> To start with a working version of the add-in with keyboard shortcuts already enabled. Clone and run the [Keyboard Shortcuts PnP](https://github.com/OfficeDev/PnP-OfficeAddins/tree/master/Samples/excel-keyboard-shortcuts) and follow along using the instructions below.
 
 [!include[Keyboard shortcut prerequisites](../includes/keyboard-shortcuts-prerequisites.md)]
 
@@ -32,29 +33,19 @@ Once you have completed the steps in that tutorial, return here to add keyboard 
 ```xml
     ...
     </VersionOverrides>
-    <ExtendedOverrides Url="https://localhost:3000/extendedManifest.json"></ExtendedOverrides>
+    <ExtendedOverrides Url="https://localhost:3000/shortcuts.json"></ExtendedOverrides>
 </OfficeApp>
 ```
 
-## Create the extended overrides JSON file
+## Create the shortcuts JSON file
 
 This file describes your keyboard shortcuts, and the actions they invoke.
 
-1. In the base folder of your project, create a JSON file called **extendedManifest.json**.
-1. Inside the **extendedManifest.json** file, add the following JSON:
+1. In the base folder of your project, create a JSON file called **shortcuts.json**.
+1. Inside the **shortcuts.json** file, the actions array will contain objects that define the actions to be invoked and the shortcuts array will contain objects that map key combinations onto actions. Example:
 
     ```json
     {
-        "actions": [
-        ],
-        "shortcuts": [
-        ]
-    }
-    ```
-
-1. The actions array will contain objects that define the actions to be invoked. Replace the `actions` section of the JSON with the following:
-
-    ```json
         "actions": [
             {
                 "id": "SHOWTASKPANE",
@@ -66,12 +57,7 @@ This file describes your keyboard shortcuts, and the actions they invoke.
                 "type": "ExecuteFunction",
                 "name": "Hide task pane for add-in"
             }
-        ]
-    ```
-
-1. The shortcuts array will contain objects that map key combinations onto actions. Replace the `shortcuts` section of the JSON with the following:
-
-    ```json
+        ],
         "shortcuts": [
             {
                 "action": "SHOWTASKPANE",
@@ -86,6 +72,7 @@ This file describes your keyboard shortcuts, and the actions they invoke.
                 }
             }
         ]
+    }
     ```
 
 ## Create a mapping of actions to their functions


### PR DESCRIPTION

What I added/modified:
1. Changed all instances of 'extended manifest JSON' to 'shortcuts JSON' for simplicity
2. Added links to the PnP sample at the beginning of each article.
3. Added a section for the limitation around the user's focus.
4. Removed per platform customization for public preview docs (will be included as part of GA)
5. For the tutorial, consolidate the entire JSON sample together to make it simpler for developers to copy and paste.
6. Add some keyboard mapping clarifications between Mac and win32.