### PR TITLE
[admin] (TOC links) Adjust CF quick start link and add items yml

### DIFF
--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -1,3 +1,4 @@
+items:
 - name: Office Add-ins Documentation
   href: index.yml
 
@@ -692,7 +693,7 @@
     - name: Tutorials
       items:
       - name: Build your first custom functions add-in
-        href: quickstarts/excel-custom-functions-quickstart-redirect.md
+        href: quickstarts/excel-custom-functions-quickstart.md
         displayName: Excel, Custom Functions
       - name: Custom functions tutorial
         href: tutorials/excel-tutorial-create-custom-functions.md


### PR DESCRIPTION
This changes the TOC to focus on the CF section when the CF quickstart is selected, as opposed to focusing on the overall uick start section.

It also corrects the TOC to not show errors in VSCode.