### PR TITLE
[Visio] (apis) clarify limitations on when it can be used

### DIFF
--- a/docs/reference/overview/visio-javascript-reference-overview.md
+++ b/docs/reference/overview/visio-javascript-reference-overview.md
@@ -10,7 +10,9 @@ localization_priority: Priority
 
 # Visio JavaScript API overview
 
-You can use the Visio JavaScript APIs to embed Visio diagrams in SharePoint Online. An embedded Visio diagram is a diagram that is stored in a SharePoint document library and displayed on a SharePoint page. To embed a Visio diagram, display it in an HTML `<iframe>` element. Then you can use Visio JavaScript APIs to programmatically work with the embedded diagram.
+You can use the Visio JavaScript APIs to embed Visio diagrams in *classic* SharePoint pages in SharePoint Online. (This extensibility feature is not supported in on-premise SharePoint or on SharePoint Framework pages.)
+
+An embedded Visio diagram is a diagram that is stored in a SharePoint document library and displayed on a SharePoint page. To embed a Visio diagram, display it in an HTML `<iframe>` element. Then you can use Visio JavaScript APIs to programmatically work with the embedded diagram.
 
 ![Visio diagram in iframe on SharePoint page along with script editor web part](../images/visio-api-block-diagram.png)
 


### PR DESCRIPTION
Fixes [2364](https://github.com/OfficeDev/office-js-docs-pr/issues/2364)

NOTE to reviewers: SharePoint is still using "SharePoint Online", not "SharePoint on the web". 