### PR TITLE
[admin] (Redirects) Remove unused redirect link

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -17,10 +17,6 @@
         "redirect_url": "/office/dev/add-ins/quickstarts/excel-quickstart-jquery"
       },
       {   
-        "source_path": "docs/quickstarts/excel-custom-functions-quickstart-redirect.md", 
-        "redirect_url": "/office/dev/add-ins/quickstarts/excel-custom-functions-quickstart"
-      },
-      {   
         "source_path": "docs/quickstarts/onenote-quickstart-redirect.md", 
         "redirect_url": "/office/dev/add-ins/quickstarts/onenote-quickstart"
       },


### PR DESCRIPTION
After #2342, there is no longer a need for this redirection link. This PR removes it from the `redirection.json` file.