### PR TITLE
Add windows only note to word preview APIs

### DIFF
--- a/docs/includes/word-preview-apis-note.md
+++ b/docs/includes/word-preview-apis-note.md
@@ -1,0 +1,5 @@
+> [!IMPORTANT]
+> Note that the following Word preview APIs are only available on the following platforms.
+> - Office on Windows
+>
+> Word preview APIs are currently not supported on Mac, iOS, or on the Web.

--- a/docs/includes/word-preview-apis-note.md
+++ b/docs/includes/word-preview-apis-note.md
@@ -1,5 +1,5 @@
 > [!IMPORTANT]
 > Note that the following Word preview APIs are only available on the following platforms.
-> - Office on Windows
+> - Word on Windows
 >
 > Word preview APIs are currently not supported on Mac, iOS, or on the Web.

--- a/docs/reference/requirement-sets/word-preview-apis.md
+++ b/docs/reference/requirement-sets/word-preview-apis.md
@@ -10,6 +10,7 @@ localization_priority: Normal
 
 New Word JavaScript APIs are first introduced in "preview" and later become part of a specific, numbered requirement set after sufficient testing occurs and user feedback is acquired.
 
+[!INCLUDE [Information about using Word preview APIs](../../includes/word-preview-apis-note.md)]
 [!INCLUDE [Information about using preview APIs](../../includes/using-preview-apis-host.md)]
 
 ## API list


### PR DESCRIPTION
Word preview APIs are only supported for Windows. Adding a note at the top of the page to clarify that.