### PR TITLE
[manifest] (Version) Update to match schema allowances

### DIFF
--- a/docs/reference/manifest/version.md
+++ b/docs/reference/manifest/version.md
@@ -1,23 +1,26 @@
 ---
 title: Version element in the manifest file
 description: The Version element specifies your Office Add-in version.
-ms.date: 10/09/2018
+ms.date: 02/05/2021
 localization_priority: Normal
 ---
 
 # Version element
 
-Specifies the version of your Office Add-in.
+Specifies the version of your Office Add-in. The version number can be 1, 2, 3, or 4 parts (i.e., n, n.n, n.n.n, or n.n.n.n).
 
 **Add-in type:** Content, Task pane, Mail
 
 ## Syntax
 
 ```XML
-<Version>n .n .n .n</Version>
+<Version>n(.n.n.n)</Version>
 ```
 
 ## Contained in
 
 [OfficeApp](officeapp.md)
 
+## Remarks
+
+Each part of the version number can be a maximum of 5 digits.

--- a/docs/reference/manifest/version.md
+++ b/docs/reference/manifest/version.md
@@ -14,7 +14,7 @@ Specifies the version of your Office Add-in. The version number can be 1, 2, 3, 
 ## Syntax
 
 ```XML
-<Version>n(.n.n.n)</Version>
+<Version>n[.n.n.n]</Version>
 ```
 
 ## Contained in


### PR DESCRIPTION
The schema has a pattern of `<xs:pattern value="([0-9]{1,5})(\.[0-9]{1,5}){0,3}?"/>`. This allows formats like
- 1
- 1.2
- 1.2.3
- 1.2.3.4

Additionally, each part of the version number can only be 5 digits long.