### PR TITLE
[All](security): add note about security prompt on different domains

### DIFF
--- a/docs/concepts/privacy-and-security.md
+++ b/docs/concepts/privacy-and-security.md
@@ -1,7 +1,7 @@
 ---
 title: Privacy and security for Office Add-ins
 description: 'Learn about the privacy and security aspects of the Office Add-ins platform.'
-ms.date: 10/06/2020
+ms.date: 03/19/2021
 localization_priority: Normal
 ---
 

--- a/docs/concepts/privacy-and-security.md
+++ b/docs/concepts/privacy-and-security.md
@@ -81,6 +81,9 @@ This section describes the protection offered by the Office Add-ins platform fro
 
 Office Add-ins are built using web technologies that run in a browser control or **iframe**. Because of this, using add-ins is similar to browsing to web sites on the Internet or intranet. Add-ins can be external to an organization (if you acquire the add-in from AppSource) or internal (if you acquire the add-in from an Exchange Server add-in catalog, SharePoint app catalog, or file share on an organization's network). Add-ins have limited access to the network and most add-ins can read or write to the active document or mail item. The add-in platform applies certain constraints before a user or administrator installs or starts an add-in. But as with any extensibility model, users should be cautious before starting an unknown add-in.
 
+> [!NOTE]
+> Users may see a security prompt to trust the domain the first time an add-in is loaded. This will happen if the add-in's domain host is outside of the domain of Exchange on-premise or Office Online Server.
+
 The add-in platform addresses end users' privacy concerns in the following ways.
 
 - Data communicated with the web server that hosts a content, Outlook or task pane add-in as well as communication between the add-in and any web services it uses must be encrypted using the Secure Socket Layer (SSL) protocol.


### PR DESCRIPTION
Documenting a security prompt you may see if the add-in's host domain is different from Exchange on-premise, or Office Online Server (when loading first time.)