### PR TITLE
Update language to reflect current menu names and options in VSCode

### DIFF
--- a/docs/excel/custom-functions-debugging.md
+++ b/docs/excel/custom-functions-debugging.md
@@ -72,7 +72,7 @@ You can use VS Code to debug UI-less custom functions in Excel on the Microsoft 
 5. From the Debug options, choose **Office Online (Edge Chromium)**.
 6. Open Excel in the Microsoft Edge browser and create a new workbook.
 7. Choose **Share** in the ribbon and copy the link for the URL for this new workbook.
-8. Press **F5** (or select **Run > Start Debugging** from the menu) to begin debugging. A prompt will appear, which asks for the URL of your document.
+8. Select **F5** (or select **Run > Start Debugging** from the menu) to begin debugging. A prompt will appear, which asks for the URL of your document.
 9. Paste in the URL for your workbook and press Enter.
 
 ### Sideload your add-in

--- a/docs/excel/custom-functions-debugging.md
+++ b/docs/excel/custom-functions-debugging.md
@@ -46,7 +46,7 @@ You can use VS Code to debug UI-less custom functions in Office Excel on the des
 
 4. Choose **View > Run** or enter **Ctrl+Shift+D** to switch to debug view.
 5. From the Run drop-down menu, choose **Excel Desktop (Edge Chromium)**.
-6. Press **F5** (or select **Run -> Start Debugging** from the menu) to begin debugging. A new Excel workbook will open with your add-in already sideloaded and ready to use.
+6. Select **F5** (or select **Run -> Start Debugging** from the menu) to begin debugging. A new Excel workbook will open with your add-in already sideloaded and ready to use.
 
 ### Start debugging
 

--- a/docs/excel/custom-functions-debugging.md
+++ b/docs/excel/custom-functions-debugging.md
@@ -44,9 +44,9 @@ You can use VS Code to debug UI-less custom functions in Office Excel on the des
 
 ### Start the VS Code debugger
 
-4. Choose **View > Debug** or enter **Ctrl+Shift+D** to switch to debug view.
-5. From the Debug options, choose **Excel Desktop**.
-6. Select **F5** (or choose **Debug -> Start Debugging** from the menu) to begin debugging. A new Excel workbook will open with your add-in already sideloaded and ready to use.
+4. Choose **View > Run** or enter **Ctrl+Shift+D** to switch to debug view.
+5. From the Run drop-down menu, choose **Excel Desktop (Edge Chromium)**.
+6. Press **F5** (or select **Run -> Start Debugging** from the menu) to begin debugging. A new Excel workbook will open with your add-in already sideloaded and ready to use.
 
 ### Start debugging
 
@@ -68,11 +68,11 @@ You can use VS Code to debug UI-less custom functions in Excel on the Microsoft 
 
 ### Start the VS Code debugger
 
-4. Choose **View > Debug** or enter **Ctrl+Shift+D** to switch to debug view.
-5. From the Debug options, choose **Office Online (Microsoft Edge)**.
+4. Choose **View > Run** or enter **Ctrl+Shift+D** to switch to debug view.
+5. From the Debug options, choose **Office Online (Edge Chromium)**.
 6. Open Excel in the Microsoft Edge browser and create a new workbook.
 7. Choose **Share** in the ribbon and copy the link for the URL for this new workbook.
-8. Select **F5** (or choose **Debug > Start Debugging** from the menu) to begin debugging. A prompt will appear, which asks for the URL of your document.
+8. Press **F5** (or select **Run > Start Debugging** from the menu) to begin debugging. A prompt will appear, which asks for the URL of your document.
 9. Paste in the URL for your workbook and press Enter.
 
 ### Sideload your add-in


### PR DESCRIPTION
The names of various menus and options in VSCode has changed since this tutorial was written, making it somewhat confusing.  This PR changes that language to match the current version of VSCode.