### PR TITLE
[Excel] (Custom Functions) Add @returns to param address sample

### DIFF
--- a/docs/excel/custom-functions-parameter-options.md
+++ b/docs/excel/custom-functions-parameter-options.md
@@ -263,13 +263,13 @@ The following custom function takes in three input parameters, retrieves the `pa
 
 ```js
 /**
- * Return the address of three parameters. 
+ * Return the addresses of three parameters. 
  * @customfunction
  * @param {string} firstParameter First parameter.
  * @param {string} secondParameter Second parameter.
  * @param {string} thirdParameter Third parameter.
  * @param {CustomFunctions.Invocation} invocation Invocation object. 
- * @returns {any[][]} The addresses of the parameters, as a 2-dimensional array. 
+ * @returns {string[][]} The addresses of the parameters, as a 2-dimensional array. 
  * @requiresParameterAddresses
  */
 function getParameterAddresses(firstParameter, secondParameter, thirdParameter, invocation) {

--- a/docs/excel/custom-functions-parameter-options.md
+++ b/docs/excel/custom-functions-parameter-options.md
@@ -269,7 +269,7 @@ The following custom function takes in three input parameters, retrieves the `pa
  * @param {string} secondParameter Second parameter.
  * @param {string} thirdParameter Third parameter.
  * @param {CustomFunctions.Invocation} invocation Invocation object. 
- * @returns {any[][]} The parameter addresses, as a 2-dimensional array. 
+ * @returns {any[][]} The addresses of the parameters, as a 2-dimensional array. 
  * @requiresParameterAddresses
  */
 function getParameterAddresses(firstParameter, secondParameter, thirdParameter, invocation) {

--- a/docs/excel/custom-functions-parameter-options.md
+++ b/docs/excel/custom-functions-parameter-options.md
@@ -267,7 +267,7 @@ The following custom function takes in three input parameters, retrieves the `pa
  * @customfunction
  * @param {string} firstParameter First parameter.
  * @param {string} secondParameter Second parameter.
- * @param {string} thirdParameter Third parameter
+ * @param {string} thirdParameter Third parameter.
  * @param {CustomFunctions.Invocation} invocation Invocation object. 
  * @returns {any[][]} The parameter addresses, as a 2-dimensional array. 
  * @requiresParameterAddresses

--- a/docs/excel/custom-functions-parameter-options.md
+++ b/docs/excel/custom-functions-parameter-options.md
@@ -1,5 +1,5 @@
 ---
-ms.date: 02/04/2021
+ms.date: 03/04/2021
 description: 'Learn how to use different parameters within your custom functions, such as Excel ranges, optional parameters, invocation context, and more.'
 title: Options for Excel custom functions
 localization_priority: Normal
@@ -269,6 +269,7 @@ The following custom function takes in three input parameters, retrieves the `pa
  * @param {string} secondParameter Second parameter.
  * @param {string} thirdParameter Third parameter
  * @param {CustomFunctions.Invocation} invocation Invocation object. 
+ * @returns {any[][]} The parameter addresses, as a 2-dimensional array. 
  * @requiresParameterAddresses
  */
 function getParameterAddresses(firstParameter, secondParameter, thirdParameter, invocation) {


### PR DESCRIPTION
Including the @returns in this sample ensures that the JSON metadata compiles to include dimensionality: "matrix". 