### PR TITLE
Update container folder name to reflect latest Office changes.

### DIFF
--- a/docs/testing/sideload-an-office-add-in-on-ipad-and-mac.md
+++ b/docs/testing/sideload-an-office-add-in-on-ipad-and-mac.md
@@ -81,7 +81,7 @@ To see how your add-in will run in Office on iOS, you can sideload your add-in's
 
     - For Word:  `/Users/<username>/Library/Containers/Microsoft Word/Data/Documents/wef`
     - For Excel:  `/Users/<username>/Library/Containers/Microsoft Excel/Data/Documents/wef`
-    - For PowerPoint: `/Users/<username>/Library/Containers/Microsoft Powerpoint/Data/Documents/wef`
+    - For PowerPoint: `/Users/<username>/Library/Containers/Microsoft PowerPoint/Data/Documents/wef`
 
 2. Open the folder in **Finder** using the command `open .` (including the period or dot). Copy your add-in's manifest file to this folder.
 

--- a/docs/testing/sideload-an-office-add-in-on-ipad-and-mac.md
+++ b/docs/testing/sideload-an-office-add-in-on-ipad-and-mac.md
@@ -79,9 +79,9 @@ To see how your add-in will run in Office on iOS, you can sideload your add-in's
 
 1. Open **Terminal** and go to one of the following folders where you'll save your add-in's manifest file. If the `wef` folder doesn't exist on your computer, create it.
 
-    - For Word:  `/Users/<username>/Library/Containers/com.microsoft.Word/Data/Documents/wef`
-    - For Excel:  `/Users/<username>/Library/Containers/com.microsoft.Excel/Data/Documents/wef`
-    - For PowerPoint: `/Users/<username>/Library/Containers/com.microsoft.Powerpoint/Data/Documents/wef`
+    - For Word:  `/Users/<username>/Library/Containers/Microsoft Word/Data/Documents/wef`
+    - For Excel:  `/Users/<username>/Library/Containers/Microsoft Excel/Data/Documents/wef`
+    - For PowerPoint: `/Users/<username>/Library/Containers/Microsoft Powerpoint/Data/Documents/wef`
 
 2. Open the folder in **Finder** using the command `open .` (including the period or dot). Copy your add-in's manifest file to this folder.
 


### PR DESCRIPTION
Office's containers are now named after the product and not the identifier.