### PR TITLE
[getting started] (Development overview) Remove reference to "Core concepts"

### DIFF
--- a/docs/overview/core-concepts-office-add-ins.md
+++ b/docs/overview/core-concepts-office-add-ins.md
@@ -3,7 +3,7 @@ layout: LandingPage
 ms.topic: landing-page
 title: Development lifecycle overview
 description: 'Learn about the planning, developing, testing, and publishing lifecycle events.'
-ms.date: 09/01/2020
+ms.date: 05/25/2021
 localization_priority: Priority
 ---
 
@@ -11,7 +11,7 @@ localization_priority: Priority
 
 All Office Add-ins are built upon the Office Add-ins platform. They share a common framework through which certain capabilities can be implemented. This means that regardless of whether you're creating an add-in for Excel, Outlook, or another Office application, you can implement features such as dialog boxes, add-in commands, task panes, and single sign-on (SSO).
 
-For any add-in you build, you'll need to understand important concepts like Office application and platform availability, Office JavaScript API programming patterns, how to specify an add-in's settings and capabilities in the manifest file, how to test, debug, and publish an add-in, and more. You'll find this information here in the **Core concepts** section of the documentation. Review this documentation before exploring the application-specific documentation that corresponds to the add-in you're building (for example, [Excel](../excel/index.yml)).
+For any add-in you build, you need to understand important concepts like Office application and platform availability, Office JavaScript API programming patterns, how to specify an add-in's settings and capabilities in the manifest file, how to test, debug, and publish an add-in, and more. Review the documentation listed in the following table. That gives you a good foundation for the application-specific documentation that corresponds to the add-in you're building, such as [Excel](../excel/index.yml).
 
 |               |               |
 | ------------- | ------------- |


### PR DESCRIPTION
This section was referring to a TOC section that no longer exists. Hopefully, this makes it more clear that the reader is supposed to read the rest of the links later in the page.