### PR TITLE
[All hosts](Visual Studio) how to fix schema issues in VS for shared runtime

### DIFF
--- a/docs/develop/configure-your-add-in-to-use-a-shared-runtime.md
+++ b/docs/develop/configure-your-add-in-to-use-a-shared-runtime.md
@@ -1,5 +1,5 @@
 ---
-ms.date: 04/08/2021
+ms.date: 06/14/2021
 title: "Configure your Office Add-in to use a shared JavaScript runtime"
 ms.prod: non-product-specific
 description: 'Configure your Office Add-in to use a shared JavaScript runtime to support additional ribbon, task pane, and custom function features.'

--- a/docs/develop/configure-your-add-in-to-use-a-shared-runtime.md
+++ b/docs/develop/configure-your-add-in-to-use-a-shared-runtime.md
@@ -26,6 +26,9 @@ Do one of the following:
 
 The generator will create the project and install supporting Node components.
 
+> [!NOTE]
+> You can also use the steps in this article to update an existing Visual Studio project to use the shared runtime. However, you may need to update the XML schemas for the manifest. For more information, see [Troubleshoot development errors with Office Add-ins](../testing/troubleshoot-development-errors.md#manifest-schema-validation-errors-in-visual-studio-projects).
+
 ## Configure the manifest
 
 Follow these steps for a new or existing project to configure it to use a shared runtime. These steps assume you have generated your project using the [Yeoman generator for Office Add-ins](https://github.com/OfficeDev/generator-office).
@@ -35,11 +38,15 @@ Follow these steps for a new or existing project to configure it to use a shared
 1. If you generated an Excel add-in, update the requirements section to use the [shared runtime](../reference/requirement-sets/shared-runtime-requirement-sets.md) instead of the custom function runtime. The XML should appear as follows.
 
     ```xml
+    <Hosts>
+      <Host Name="Workbook"/>
+    </Hosts>
     <Requirements>
-    <Sets DefaultMinVersion="1.1">
-      <Set Name="SharedRuntime" MinVersion="1.1"/>
-    </Sets>
+      <Sets DefaultMinVersion="1.1">
+        <Set Name="SharedRuntime" MinVersion="1.1"/>
+      </Sets>
     </Requirements>
+    <DefaultSettings>
     ```
 
 1. Find the `<VersionOverrides>` section and add the following `<Runtimes>` section just inside the `<Host ...>` tag. The lifetime needs to be **long** so that your add-in code can run even when the task pane is closed. The `resid` value is **Taskpane.Url**, which references the **taskpane.html** file location specified in the ` <bt:Urls>` section near the bottom of the **manifest.xml** file.
@@ -48,7 +55,6 @@ Follow these steps for a new or existing project to configure it to use a shared
    <VersionOverrides ...>
      <Hosts>
        <Host ...>
-       ...
        <Runtimes>
          <Runtime resid="Taskpane.Url" lifetime="long" />
        </Runtimes>

--- a/docs/testing/troubleshoot-development-errors.md
+++ b/docs/testing/troubleshoot-development-errors.md
@@ -85,7 +85,7 @@ If you are using newer features that require changes to the manifest file, you m
 
 **The element 'Host' in namespace 'http://schemas.microsoft.com/office/taskpaneappversionoverrides' has invalid child element 'Runtimes' in namespace 'http://schemas.microsoft.com/office/taskpaneappversionoverrides'**
 
-If this occurs, you can update the XSD files that Visual Studio uses to the latest versions. The latest schema versions are at [[MS-OWEMXML]: Appendix A: Full XML Schema](https://docs.microsoft.com/openspecs/office_file_formats/ms-owemxml/c6a06390-34b8-4b42-82eb-b28be12494a8).
+If this occurs, you can update the XSD files that Visual Studio uses to the latest versions. The latest schema versions are at [[MS-OWEMXML]: Appendix A: Full XML Schema](/openspecs/office_file_formats/ms-owemxml/c6a06390-34b8-4b42-82eb-b28be12494a8).
 
 ### Locate the XSD files
 
@@ -97,7 +97,7 @@ If this occurs, you can update the XSD files that Visual Studio uses to the late
 ### Update the XSD files
 
 1. Open the XSD file you want to update in a text editor. The schema name from the validation error will correlate to the XSD file name. For example, open **TaskPaneAppVersionOverridesV1_0.xsd**.
-1. Locate the updated schema at [[MS-OWEMXML]: Appendix A: Full XML Schema](https://docs.microsoft.com/openspecs/office_file_formats/ms-owemxml/c6a06390-34b8-4b42-82eb-b28be12494a8). For example, TaskPaneAppVersionOverridesV1_0 is at [taskpaneappversionoverrides Schema](https://docs.microsoft.com/openspecs/office_file_formats/ms-owemxml/82e93ec5-de22-42a8-86e3-353c8336aa40).
+1. Locate the updated schema at [[MS-OWEMXML]: Appendix A: Full XML Schema](/openspecs/office_file_formats/ms-owemxml/c6a06390-34b8-4b42-82eb-b28be12494a8). For example, TaskPaneAppVersionOverridesV1_0 is at [taskpaneappversionoverrides Schema](/openspecs/office_file_formats/ms-owemxml/82e93ec5-de22-42a8-86e3-353c8336aa40).
 1. Copy the text into your text editor.
 1. Save the updated XSD file.
 1. Restart Visual Studio to pick up the new XSD file changes.

--- a/docs/testing/troubleshoot-development-errors.md
+++ b/docs/testing/troubleshoot-development-errors.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshoot development errors with Office Add-ins
 description: 'Learn how to troubleshoot development errors in Office Add-ins.'
-ms.date: 01/04/2021
+ms.date: 06/11/2021
 localization_priority: Normal
 ---
 
@@ -78,6 +78,31 @@ See [Troubleshooting Microsoft Edge issues](../concepts/browsers-used-by-office-
 ## Excel add-in throws errors, but not consistently
 
 See [Troubleshoot Excel add-ins](../excel/excel-add-ins-troubleshooting.md) for possible causes.
+
+## Manifest schema validation errors in Visual Studio projects
+
+If you are using newer features that require changes to the manifest file, you may get validation errors in Visual Studio. For example when adding the `<Runtimes>` element to implement the shared JavaScript runtime, you may see the following validation error:
+
+**The element 'Host' in namespace 'http://schemas.microsoft.com/office/taskpaneappversionoverrides' has invalid child element 'Runtimes' in namespace 'http://schemas.microsoft.com/office/taskpaneappversionoverrides'**
+
+If this occurs you can update the XSD files that Visual Studio uses to the latest versions. The latest schema versions are at [[MS-OWEMXML]: Appendix A: Full XML Schema](https://docs.microsoft.com/openspecs/office_file_formats/ms-owemxml/c6a06390-34b8-4b42-82eb-b28be12494a8)
+
+### Locate the XSD files
+
+1. Open your project in Visual Studio.
+1. In **Solution Explorer** open the manifest.xml file. The manifest is typically in the first project under your solution.
+1. Choose **View > Properties Window** (F4).
+1. In the **Properties Window**, choose the ellipsis (...) to open the **XML Schemas** editor. Here you can find the exact folder location of all schema files in use by your project.
+
+### Update the XSD files
+
+1. Open the XSD file you want to update in a text editor. The schema name from the validation error will corelate to the XSD file name. For example, open **TaskPaneAppVersionOverridesV1_0.xsd**.
+1. Locate the updated schema at [[MS-OWEMXML]: Appendix A: Full XML Schema](https://docs.microsoft.com/openspecs/office_file_formats/ms-owemxml/c6a06390-34b8-4b42-82eb-b28be12494a8). For example, TaskPaneAppVersionOverridesV1_0 is at [taskpaneappversionoverrides Schema](https://docs.microsoft.com/openspecs/office_file_formats/ms-owemxml/82e93ec5-de22-42a8-86e3-353c8336aa40).
+1. Copy the text into your text editor.
+1. Save the updated XSD file.
+1. Restart Visual Studio to pick up the new XSD file changes.
+
+You can repeat the previous process for any additional schemas that are out-of-date.
 
 ## See also
 

--- a/docs/testing/troubleshoot-development-errors.md
+++ b/docs/testing/troubleshoot-development-errors.md
@@ -81,22 +81,22 @@ See [Troubleshoot Excel add-ins](../excel/excel-add-ins-troubleshooting.md) for 
 
 ## Manifest schema validation errors in Visual Studio projects
 
-If you are using newer features that require changes to the manifest file, you may get validation errors in Visual Studio. For example when adding the `<Runtimes>` element to implement the shared JavaScript runtime, you may see the following validation error:
+If you are using newer features that require changes to the manifest file, you may get validation errors in Visual Studio. For example, when adding the `<Runtimes>` element to implement the shared JavaScript runtime, you may see the following validation error.
 
 **The element 'Host' in namespace 'http://schemas.microsoft.com/office/taskpaneappversionoverrides' has invalid child element 'Runtimes' in namespace 'http://schemas.microsoft.com/office/taskpaneappversionoverrides'**
 
-If this occurs you can update the XSD files that Visual Studio uses to the latest versions. The latest schema versions are at [[MS-OWEMXML]: Appendix A: Full XML Schema](https://docs.microsoft.com/openspecs/office_file_formats/ms-owemxml/c6a06390-34b8-4b42-82eb-b28be12494a8)
+If this occurs, you can update the XSD files that Visual Studio uses to the latest versions. The latest schema versions are at [[MS-OWEMXML]: Appendix A: Full XML Schema](https://docs.microsoft.com/openspecs/office_file_formats/ms-owemxml/c6a06390-34b8-4b42-82eb-b28be12494a8).
 
 ### Locate the XSD files
 
 1. Open your project in Visual Studio.
-1. In **Solution Explorer** open the manifest.xml file. The manifest is typically in the first project under your solution.
-1. Choose **View > Properties Window** (F4).
-1. In the **Properties Window**, choose the ellipsis (...) to open the **XML Schemas** editor. Here you can find the exact folder location of all schema files in use by your project.
+1. In **Solution Explorer**, open the manifest.xml file. The manifest is typically in the first project under your solution.
+1. Choose **View** > **Properties Window** (F4).
+1. In the **Properties Window**, choose the ellipsis (...) to open the **XML Schemas** editor. Here you can find the exact folder location of all schema files your project uses.
 
 ### Update the XSD files
 
-1. Open the XSD file you want to update in a text editor. The schema name from the validation error will corelate to the XSD file name. For example, open **TaskPaneAppVersionOverridesV1_0.xsd**.
+1. Open the XSD file you want to update in a text editor. The schema name from the validation error will correlate to the XSD file name. For example, open **TaskPaneAppVersionOverridesV1_0.xsd**.
 1. Locate the updated schema at [[MS-OWEMXML]: Appendix A: Full XML Schema](https://docs.microsoft.com/openspecs/office_file_formats/ms-owemxml/c6a06390-34b8-4b42-82eb-b28be12494a8). For example, TaskPaneAppVersionOverridesV1_0 is at [taskpaneappversionoverrides Schema](https://docs.microsoft.com/openspecs/office_file_formats/ms-owemxml/82e93ec5-de22-42a8-86e3-353c8336aa40).
 1. Copy the text into your text editor.
 1. Save the updated XSD file.


### PR DESCRIPTION
You can update a Visual Studio project to use shared runtime, but you can get validation errors in the manifest because Visual Studio 2019 ships with a slightly older version of the XSD files. I added a troubleshooting section on how to update your XSD files. This really would apply for any newer feature we release that requires new elements in the manifest.