### PR TITLE
[quickstarts] Add npm install steps to all quick starts

### DIFF
--- a/docs/includes/quickstart-yo-start-server-excel.md
+++ b/docs/includes/quickstart-yo-start-server-excel.md
@@ -11,6 +11,12 @@ Complete the following steps to start the local web server and sideload your add
 > npm run dev-server
 > ```
 
+- Install the dependencies for you add-in in the root directory of your project.
+
+     ```command&nbsp;line
+    npm install
+    ```
+
 - To test your add-in in Excel, run the following command in the root directory of your project. This starts the local web server (if it's not already running) and opens Excel with your add-in loaded.
 
     ```command&nbsp;line

--- a/docs/quickstarts/excel-custom-functions-quickstart.md
+++ b/docs/quickstarts/excel-custom-functions-quickstart.md
@@ -1,5 +1,5 @@
 ---
-ms.date: 11/09/2020
+ms.date: 08/04/2021
 description: Developing custom functions in Excel quick start guide.
 title: Custom functions quick start
 ms.prod: excel
@@ -39,6 +39,12 @@ To start, you'll use the Yeoman generator to create the custom functions project
 
     ```command&nbsp;line
     cd starcount
+    ```
+
+1. Install the dependencies.
+
+     ```command&nbsp;line
+    npm install
     ```
 
 1. Build the project.

--- a/docs/quickstarts/excel-quickstart-angular.md
+++ b/docs/quickstarts/excel-quickstart-angular.md
@@ -1,7 +1,7 @@
 ---
 title: Use Angular to build an Excel task pane add-in
 description: Learn how to build a simple Excel task pane add-in by using the Office JS API and Angular.
-ms.date: 07/07/2021
+ms.date: 08/04/2021
 ms.prod: excel
 localization_priority: Priority
 ---

--- a/docs/quickstarts/excel-quickstart-jquery.md
+++ b/docs/quickstarts/excel-quickstart-jquery.md
@@ -1,7 +1,7 @@
 ---
 title: Build your first Excel task pane add-in
 description: Learn how to build a simple Excel task pane add-in by using the Office JS API.
-ms.date: 07/06/2021
+ms.date: 08/04/2021
 ms.prod: excel
 localization_priority: Priority
 ---

--- a/docs/quickstarts/excel-quickstart-react.md
+++ b/docs/quickstarts/excel-quickstart-react.md
@@ -1,7 +1,7 @@
 ---
 title: Use React to build an Excel task pane add-in
 description: Learn how to build a simple Excel task pane add-in by using the Office JS API and React.
-ms.date: 07/07/2021
+ms.date: 08/04/2021
 ms.prod: excel
 localization_priority: Priority
 ---

--- a/docs/quickstarts/excel-quickstart-vue.md
+++ b/docs/quickstarts/excel-quickstart-vue.md
@@ -1,7 +1,7 @@
 ---
 title: Use Vue to build an Excel task pane add-in
 description: Learn how to build a simple Excel task pane add-in by using the Office JS API and Vue.
-ms.date: 07/07/2021
+ms.date: 08/04/2021
 ms.prod: excel
 localization_priority: Priority
 ---
@@ -193,6 +193,12 @@ The add-in project that you've created with the Yeoman generator contains sample
    ```
 
 ## Start the dev server
+
+1. Install the dependencies.
+
+     ```command&nbsp;line
+    npm install
+    ```
 
 1. Start the dev server.
 

--- a/docs/quickstarts/onenote-quickstart.md
+++ b/docs/quickstarts/onenote-quickstart.md
@@ -1,7 +1,7 @@
 ---
 title: Build your first OneNote task pane add-in
 description: Learn how to build a simple OneNote task pane add-in by using the Office JS API.
-ms.date: 07/06/2021
+ms.date: 08/04/2021
 ms.prod: onenote
 localization_priority: Priority
 ---
@@ -73,7 +73,13 @@ try {
     cd "My Office Add-in"
     ```
 
-2. Start the local web server and sideload your add-in.
+1. Install the dependencies for your project.
+
+     ```command&nbsp;line
+    npm install
+    ```
+
+1. Start the local web server and sideload your add-in.
 
     > [!NOTE]
     > Office Add-ins should use HTTPS, not HTTP, even when you are developing. If you are prompted to install a certificate after you run one of the following commands, accept the prompt to install the certificate that the Yeoman generator provides. You may also have to run your command prompt or terminal as an administrator for the changes to be made.
@@ -91,9 +97,9 @@ try {
     npm run start:web
     ```
 
-3. In [OneNote on the web](https://www.onenote.com/notebooks), open a notebook and create a new page.
+1. In [OneNote on the web](https://www.onenote.com/notebooks), open a notebook and create a new page.
 
-4. Choose **Insert > Office Add-ins** to open the Office Add-ins dialog.
+1. Choose **Insert > Office Add-ins** to open the Office Add-ins dialog.
 
     - If you're signed in with your consumer account, select the **MY ADD-INS** tab, and then choose **Upload My Add-in**.
 
@@ -103,11 +109,11 @@ try {
 
     ![Screenshot of the Office Add-ins dialog showing the MY ADD-INS tab.](../images/onenote-office-add-ins-dialog.png)
 
-5. In the Upload Add-in dialog, browse to **manifest.xml** in your project folder, and then choose **Upload**.
+1. In the Upload Add-in dialog, browse to **manifest.xml** in your project folder, and then choose **Upload**.
 
-6. From the **Home** tab, choose the **Show Taskpane** button in the ribbon. The add-in task pane opens in an iFrame next to the OneNote page.
+1. From the **Home** tab, choose the **Show Taskpane** button in the ribbon. The add-in task pane opens in an iFrame next to the OneNote page.
 
-7. At the bottom of the task pane, choose the **Run** link to set the page title and add an outline to the body of the page.
+1. At the bottom of the task pane, choose the **Run** link to set the page title and add an outline to the body of the page.
 
     ![Screenshot showing the add-in built from this walkthrough: Show Taskpane ribbon button and task pane in OneNote.](../images/onenote-first-add-in-4.png)
 

--- a/docs/quickstarts/outlook-quickstart.md
+++ b/docs/quickstarts/outlook-quickstart.md
@@ -1,7 +1,7 @@
 ---
 title: Build your first Outlook add-in
 description: Learn how to build a simple Outlook task pane add-in by using the Office JS API.
-ms.date: 06/10/2021
+ms.date: 08/04/2021
 ms.prod: outlook
 localization_priority: Priority
 ---
@@ -53,6 +53,12 @@ You can create an Office Add-in by using the [Yeoman generator for Office Add-in
 
     ```command&nbsp;line
     cd "My Office Add-in"
+    ```
+
+1. Install the dependencies for your project.
+
+     ```command&nbsp;line
+    npm install
     ```
 
 ### Explore the project

--- a/docs/quickstarts/powerpoint-quickstart.md
+++ b/docs/quickstarts/powerpoint-quickstart.md
@@ -1,7 +1,7 @@
 ---
 title: Build your first PowerPoint task pane add-in
 description: Learn how to build a simple PowerPoint task pane add-in by using the Office JS API.
-ms.date: 10/14/2020
+ms.date: 08/04/2021
 ms.prod: powerpoint
 localization_priority: Priority
 ---
@@ -61,6 +61,12 @@ After you complete the wizard, the generator creates the project and installs su
     > ```command&nbsp;line
     > npm run dev-server
     > ```
+
+    - Install the dependencies for you add-in in the root directory of your project.
+
+        ```command&nbsp;line
+        npm install
+        ```
 
     - To test your add-in in PowerPoint, run the following command in the root directory of your project. This starts the local web server (if it's not already running) and opens PowerPoint with your add-in loaded.
 

--- a/docs/quickstarts/project-quickstart.md
+++ b/docs/quickstarts/project-quickstart.md
@@ -1,7 +1,7 @@
 ---
 title: Build your first Project task pane add-in
 description: Learn how to build a simple Project task pane add-in by using the Office JS API.
-ms.date: 06/07/2021
+ms.date: 08/04/2021
 ms.prod: project
 localization_priority: Priority
 ---
@@ -91,7 +91,13 @@ Office.context.document.getSelectedTaskAsync(
     cd "My Office Add-in"
     ```
 
-2. Start the local web server.
+1. Install the dependencies for your project.
+
+     ```command&nbsp;line
+    npm install
+    ```
+
+1. Start the local web server.
 
     > [!NOTE]
     > Office Add-ins should use HTTPS, not HTTP, even when you are developing. If you are prompted to install a certificate after you run the following command, accept the prompt to install the certificate that the Yeoman generator provides.
@@ -102,13 +108,13 @@ Office.context.document.getSelectedTaskAsync(
     npm run dev-server
     ```
 
-3. In Project, create a simple project plan.
+1. In Project, create a simple project plan.
 
-4. Load your add-in in Project by following the instructions in [Sideload Office Add-ins on Windows](../testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins.md).
+1. Load your add-in in Project by following the instructions in [Sideload Office Add-ins on Windows](../testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins.md).
 
-5. Select a single task within the project.
+1. Select a single task within the project.
 
-6. At the bottom of the task pane, choose the **Run** link to rename the selected task and add notes to the selected task.
+1. At the bottom of the task pane, choose the **Run** link to rename the selected task and add notes to the selected task.
 
     ![Screenshot of the Project application with the task pane add-in loaded.](../images/project-quickstart-addin-1.png)
 

--- a/docs/quickstarts/sso-quickstart-customize.md
+++ b/docs/quickstarts/sso-quickstart-customize.md
@@ -1,7 +1,7 @@
 ---
 title: Customize your Node.js SSO-enabled add-in
 description: Learn about customizing the SSO-enabled add-in that you created with the Yeoman generator.
-ms.date: 02/01/2021
+ms.date: 08/04/2021
 ms.prod: non-product-specific
 localization_priority: Normal
 ---

--- a/docs/quickstarts/word-quickstart.md
+++ b/docs/quickstarts/word-quickstart.md
@@ -1,7 +1,7 @@
 ---
 title: Build your first Word task pane add-in
 description: Learn how to build a simple Word task pane add-in by using the Office JS API.
-ms.date: 10/14/2020
+ms.date: 08/04/2021
 ms.prod: word
 localization_priority: Priority
 ---
@@ -52,7 +52,13 @@ After you complete the wizard, the generator creates the project and installs su
     cd "My Office Add-in"
     ```
 
-2. Complete the following steps to start the local web server and sideload your add-in.
+1. Install the dependencies for your project.
+
+     ```command&nbsp;line
+    npm install
+    ```
+
+1. Complete the following steps to start the local web server and sideload your add-in.
 
     > [!NOTE]
     > Office Add-ins should use HTTPS, not HTTP, even when you are developing. If you are prompted to install a certificate after you run one of the following commands, accept the prompt to install the certificate that the Yeoman generator provides.
@@ -78,11 +84,11 @@ After you complete the wizard, the generator creates the project and installs su
 
         To use your add-in, open a new document in Word on the web and then sideload your add-in by following the instructions in [Sideload Office Add-ins in Office on the web](../testing/sideload-office-add-ins-for-testing.md#sideload-an-office-add-in-in-office-on-the-web).
 
-3. In Word, open a new document, choose the **Home** tab, and then choose the **Show Taskpane** button in the ribbon to open the add-in task pane.
+1. In Word, open a new document, choose the **Home** tab, and then choose the **Show Taskpane** button in the ribbon to open the add-in task pane.
 
     ![Screenshot showing the Word application with the Show Taskpane button highlighted.](../images/word-quickstart-addin-2b.png)
 
-4. At the bottom of the task pane, choose the **Run** link to add the text "Hello World" to the document in blue font.
+1. At the bottom of the task pane, choose the **Run** link to add the text "Hello World" to the document in blue font.
 
     ![Screenshot of the Word application with the task pane add-in loaded.](../images/word-quickstart-addin-1c.png)
 


### PR DESCRIPTION
Fixes #2826.

This PR updates the quick starts to include an `npm install` step missing in the latest versions of yo office.