### PR TITLE
[quick starts] Remove unnecessary npm install step

### DIFF
--- a/docs/includes/quickstart-yo-start-server-excel.md
+++ b/docs/includes/quickstart-yo-start-server-excel.md
@@ -11,12 +11,6 @@ Complete the following steps to start the local web server and sideload your add
 > npm run dev-server
 > ```
 
-- Install the dependencies for you add-in in the root directory of your project.
-
-     ```command&nbsp;line
-    npm install
-    ```
-
 - To test your add-in in Excel, run the following command in the root directory of your project. This starts the local web server (if it's not already running) and opens Excel with your add-in loaded.
 
     ```command&nbsp;line

--- a/docs/quickstarts/excel-custom-functions-quickstart.md
+++ b/docs/quickstarts/excel-custom-functions-quickstart.md
@@ -41,12 +41,6 @@ To start, you'll use the Yeoman generator to create the custom functions project
     cd starcount
     ```
 
-1. Install the dependencies.
-
-     ```command&nbsp;line
-    npm install
-    ```
-
 1. Build the project.
 
     ```command&nbsp;line

--- a/docs/quickstarts/excel-quickstart-vue.md
+++ b/docs/quickstarts/excel-quickstart-vue.md
@@ -194,12 +194,6 @@ The add-in project that you've created with the Yeoman generator contains sample
 
 ## Start the dev server
 
-1. Install the dependencies.
-
-     ```command&nbsp;line
-    npm install
-    ```
-
 1. Start the dev server.
 
    ```command&nbsp;line

--- a/docs/quickstarts/onenote-quickstart.md
+++ b/docs/quickstarts/onenote-quickstart.md
@@ -73,12 +73,6 @@ try {
     cd "My Office Add-in"
     ```
 
-1. Install the dependencies for your project.
-
-     ```command&nbsp;line
-    npm install
-    ```
-
 1. Start the local web server and sideload your add-in.
 
     > [!NOTE]

--- a/docs/quickstarts/outlook-quickstart.md
+++ b/docs/quickstarts/outlook-quickstart.md
@@ -55,12 +55,6 @@ You can create an Office Add-in by using the [Yeoman generator for Office Add-in
     cd "My Office Add-in"
     ```
 
-1. Install the dependencies for your project.
-
-     ```command&nbsp;line
-    npm install
-    ```
-
 ### Explore the project
 
 The add-in project that you've created with the Yeoman generator contains sample code for a very basic task pane add-in.

--- a/docs/quickstarts/powerpoint-quickstart.md
+++ b/docs/quickstarts/powerpoint-quickstart.md
@@ -62,12 +62,6 @@ After you complete the wizard, the generator creates the project and installs su
     > npm run dev-server
     > ```
 
-    - Install the dependencies for you add-in in the root directory of your project.
-
-        ```command&nbsp;line
-        npm install
-        ```
-
     - To test your add-in in PowerPoint, run the following command in the root directory of your project. This starts the local web server (if it's not already running) and opens PowerPoint with your add-in loaded.
 
         ```command&nbsp;line

--- a/docs/quickstarts/project-quickstart.md
+++ b/docs/quickstarts/project-quickstart.md
@@ -91,12 +91,6 @@ Office.context.document.getSelectedTaskAsync(
     cd "My Office Add-in"
     ```
 
-1. Install the dependencies for your project.
-
-     ```command&nbsp;line
-    npm install
-    ```
-
 1. Start the local web server.
 
     > [!NOTE]

--- a/docs/quickstarts/word-quickstart.md
+++ b/docs/quickstarts/word-quickstart.md
@@ -52,12 +52,6 @@ After you complete the wizard, the generator creates the project and installs su
     cd "My Office Add-in"
     ```
 
-1. Install the dependencies for your project.
-
-     ```command&nbsp;line
-    npm install
-    ```
-
 1. Complete the following steps to start the local web server and sideload your add-in.
 
     > [!NOTE]


### PR DESCRIPTION
Thanks to https://github.com/OfficeDev/generator-office/pull/653, the yo office path now runs `npm install`. This means the changes from #2852 are no longer necessary.