### PR TITLE
Update tip using F5 to use Ctrl-F5

### DIFF
--- a/docs/testing/clear-cache.md
+++ b/docs/testing/clear-cache.md
@@ -33,7 +33,7 @@ To remove a sideloaded add-in from Outlook, use the steps outlined in [Sideload 
 Additionally, to clear the Office cache on Windows 10 when the add-in is running in Microsoft Edge, you can use the Microsoft Edge DevTools.
 
 > [!TIP]
-> If you only want the sideloaded add-in to reflect recent changes to its HTML or JavaScript source files, you shouldn't need to clear the cache. Instead, just put focus in the add-in's task pane (by clicking anywhere within the task pane) and then press **F5** to reload the add-in.
+> If you only want the sideloaded add-in to reflect recent changes to its HTML or JavaScript source files, you shouldn't need to clear the cache. Instead, just put focus in the add-in's task pane (by clicking anywhere within the task pane) and then press **Ctrl-F5** to reload the add-in.
 
 > [!NOTE]
 > To clear the Office cache using the following steps, your add-in must have a task pane. If your add-in is a UI-less add-in -- for example, one that uses the [on-send](../outlook/outlook-on-send-addins.md) feature -- you'll need to add a task pane to your add-in that uses the same domain for [SourceLocation](../reference/manifest/sourcelocation.md), before you can use the following steps to clear the cache.

--- a/docs/testing/clear-cache.md
+++ b/docs/testing/clear-cache.md
@@ -33,7 +33,7 @@ To remove a sideloaded add-in from Outlook, use the steps outlined in [Sideload 
 Additionally, to clear the Office cache on Windows 10 when the add-in is running in Microsoft Edge, you can use the Microsoft Edge DevTools.
 
 > [!TIP]
-> If you only want the sideloaded add-in to reflect recent changes to its HTML or JavaScript source files, you shouldn't need to clear the cache. Instead, just put focus in the add-in's task pane (by clicking anywhere within the task pane) and then press **Ctrl-F5** to reload the add-in.
+> If you only want the sideloaded add-in to reflect recent changes to its HTML or JavaScript source files, you shouldn't need to clear the cache. Instead, just put focus in the add-in's task pane (by clicking anywhere within the task pane) and then press **Ctrl+F5** to reload the add-in.
 
 > [!NOTE]
 > To clear the Office cache using the following steps, your add-in must have a task pane. If your add-in is a UI-less add-in -- for example, one that uses the [on-send](../outlook/outlook-on-send-addins.md) feature -- you'll need to add a task pane to your add-in that uses the same domain for [SourceLocation](../reference/manifest/sourcelocation.md), before you can use the following steps to clear the cache.


### PR DESCRIPTION
Pressing F5 with add-in in focus will not reload from source, only from cache.
Pressing Ctrl-F5 will reload from source disregarding cache.

I assume hard reload is the most likely needed scenario, as such I propose replacing F5 with Ctrl-F5.
If this assumption is incorrect or not warranted, adding a sentence describing Ctrl-F5 might be a better solution.