### PR TITLE
[admin] TOC update; include add-in types in manifest articles

### DIFF
--- a/docs/reference/manifest/customfunctionssourcelocation.md
+++ b/docs/reference/manifest/customfunctionssourcelocation.md
@@ -1,13 +1,15 @@
 ---
 title: SourceLocation element for custom functions in the manifest file
 description: Defines the location of a resource needed by the Script or Page elements used by custom functions in Excel.
-ms.date: 08/07/2020
+ms.date: 09/24/2021
 ms.localizationpriority: medium
 ---
 
 # SourceLocation element (custom functions)
 
 Defines the location of a resource needed by the Script or Page elements used by custom functions in Excel.
+
+**Add-in type:** Custom function
 
 ## Attributes
 

--- a/docs/reference/manifest/event.md
+++ b/docs/reference/manifest/event.md
@@ -1,7 +1,7 @@
 ---
 title: Event element in the manifest file
 description: Defines an event handler in an add-in.
-ms.date: 05/15/2020
+ms.date: 09/24/2021
 ms.localizationpriority: medium
 ---
 
@@ -11,6 +11,8 @@ Defines an event handler in an add-in.
 
 > [!NOTE]
 > For information about support and usage, see [On-send feature for Outlook add-ins](../../outlook/outlook-on-send-addins.md).
+
+**Add-in type:** Mail
 
 ## Attributes
 

--- a/docs/reference/manifest/extendedpermission.md
+++ b/docs/reference/manifest/extendedpermission.md
@@ -1,7 +1,7 @@
 ---
 title: ExtendedPermission element in the manifest file
 description: Defines an extended permission the add-in needs to access the associated API or feature.
-ms.date: 10/15/2020
+ms.date: 09/24/2021
 ms.localizationpriority: medium
 ---
 
@@ -11,6 +11,8 @@ Defines an extended permission the add-in needs to access the associated API or 
 
 > [!IMPORTANT]
 > Support for this element was introduced in requirement set 1.9. See [clients and platforms](../../reference/requirement-sets/outlook-api-requirement-sets.md#requirement-sets-supported-by-exchange-servers-and-outlook-clients) that support this requirement set.
+
+**Add-in type:** Mail
 
 ## Available extended permissions
 

--- a/docs/reference/manifest/extendedpermissions.md
+++ b/docs/reference/manifest/extendedpermissions.md
@@ -1,7 +1,7 @@
 ---
 title: ExtendedPermissions element in the manifest file
 description: Defines the collection of extended permissions the add-in needs to access associated APIs or features.
-ms.date: 10/15/2020
+ms.date: 09/24/2021
 ms.localizationpriority: medium
 ---
 
@@ -11,6 +11,8 @@ Defines the collection of extended permissions the add-in needs to access associ
 
 > [!IMPORTANT]
 > Support for this element was introduced in requirement set 1.9. See [clients and platforms](../../reference/requirement-sets/outlook-api-requirement-sets.md#requirement-sets-supported-by-exchange-servers-and-outlook-clients) that support this requirement set.
+
+**Add-in type:** Mail
 
 ## Child elements
 

--- a/docs/reference/manifest/mobileformfactor.md
+++ b/docs/reference/manifest/mobileformfactor.md
@@ -1,7 +1,7 @@
 ---
 title: MobileFormFactor element in the manifest file
 description: The MobileFormFactor element specifies the mobile form factor settings for an add-in.
-ms.date: 10/09/2018
+ms.date: 09/24/2021
 ms.localizationpriority: medium
 ---
 
@@ -12,6 +12,8 @@ Specifies the settings for an add-in for the mobile form factor. It contains all
 Each **MobileFormFactor** definition contains the **FunctionFile** element and one or more **ExtensionPoint** elements. For more information, see [FunctionFile element](functionfile.md) and [ExtensionPoint element](extensionpoint.md).
 
 The **MobileFormFactor** element is defined in VersionOverrides schema 1.1. The containing [VersionOverrides](versionoverrides.md) element must have an `xsi:type` attribute value of `VersionOverridesV1_1`.
+
+**Add-in type:** Mail
 
 ## Child elements
 

--- a/docs/reference/manifest/script.md
+++ b/docs/reference/manifest/script.md
@@ -1,13 +1,15 @@
 ---
 title: Script element in the manifest file
 description: The Script element defines script settings a custom function uses in Excel.
-ms.date: 10/09/2018
+ms.date: 09/24/2021
 ms.localizationpriority: medium
 ---
 
 # Script element
 
 Defines script settings used by a custom function in Excel.
+
+**Add-in type:** Custom function
 
 ## Attributes
 

--- a/docs/reference/manifest/supportssharedfolders.md
+++ b/docs/reference/manifest/supportssharedfolders.md
@@ -12,6 +12,8 @@ Defines whether the Outlook add-in is available in shared mailbox (now in previe
 > [!IMPORTANT]
 > Support for this element was introduced in requirement set 1.8. See [clients and platforms](../../reference/requirement-sets/outlook-api-requirement-sets.md#requirement-sets-supported-by-exchange-servers-and-outlook-clients) that support this requirement set.
 
+**Add-in type:** Mail
+
 The following is an example of the **SupportsSharedFolders** element.
 
 ```XML

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -392,10 +392,6 @@ items:
         href: reference/manifest/equivalentaddins.md
       - name: ExtendedOverrides
         href: reference/manifest/extendedoverrides.md
-      - name: ExtendedPermission
-        href: reference/manifest/extendedpermission.md
-      - name: ExtendedPermissions
-        href: reference/manifest/extendedpermissions.md
       - name: FileName
         href: reference/manifest/filename.md
       - name: Form
@@ -480,6 +476,8 @@ items:
           href: reference/manifest/control.md
         - name: CustomTab
           href: reference/manifest/customtab.md
+        - name: DesktopFormFactor
+          href: reference/manifest/desktopformfactor.md
         - name: Enabled
           href: reference/manifest/enabled.md
         - name: EquivalentAddin
@@ -488,10 +486,12 @@ items:
           href: reference/manifest/equivalentaddins.md
         - name: Event
           href: reference/manifest/event.md
+        - name: ExtendedPermission
+          href: reference/manifest/extendedpermission.md
+        - name: ExtendedPermissions
+          href: reference/manifest/extendedpermissions.md
         - name: ExtensionPoint
           href: reference/manifest/extensionpoint.md
-        - name: DesktopFormFactor
-          href: reference/manifest/desktopformfactor.md
         - name: FunctionFile
           href: reference/manifest/functionfile.md
         - name: GetStarted
@@ -1013,8 +1013,6 @@ items:
     - name: API reference - latest release
       href: reference/outlook-api-reference-1-10.md
       displayName: Outlook
-  - name: Concepts
-    items: 
     - name: Outlook add-in design guidelines
       href: outlook/outlook-addin-design.md
     - name: Add-in commands


### PR DESCRIPTION
TOC: Remove Outlook Concepts subfolder to make organization consistent with other hosts; some alphabetizing in manifest versionoverrides section; move extendedpermissions nodes to under versionoverrides
Manifest section: Add supported add-in types to various articles (not a comprehensive update)