### PR TITLE
[All Hosts] (manifest) versionoverrides and req set info for runtimes

### DIFF
--- a/docs/develop/add-in-manifests.md
+++ b/docs/develop/add-in-manifests.md
@@ -146,9 +146,9 @@ The following XML manifest example hosts its main add-in page in the `https://ww
 
 The optional [VersionOverrides](../reference/manifest/versionoverrides.md) element deserves special mention. It contains child markup that enables additional add-in features. Some of these are:
 
- - Customizing the Office ribbon and menus
- - Customizing how Office works with the embedded browser runtime in which add-ins run
- - Configuring how the add-in interacts with Azure Active Directory and Microsoft Graph for Single Sign-on
+ - Customizing the Office ribbon and menus.
+ - Customizing how Office works with the embedded browser runtime in which add-ins run.
+ - Configuring how the add-in interacts with Azure Active Directory and Microsoft Graph for Single Sign-on.
 
 Some descendant elements of `VersionOverrides` have values that override values of the parent `OfficeApp` element. For example, the `Hosts` element in `VersionOverrides` overrides the `Hosts` element in `OfficeApp`.
 
@@ -159,17 +159,17 @@ The `VersionOverrides` element has its own schema, actually four of them, depend
 - [Mail 1.0](/openspecs/office_file_formats/ms-owemxml/578d8214-2657-4e6a-8485-25899e772fac)
 - [Mail 1.1](/openspecs/office_file_formats/ms-owemxml/8e722c85-eb78-438c-94a4-edac7e9c533a)
 
-When a `VersionOverrides` element is used, then the `OfficeApp` element must have a `xmlns` attribute that identifies the appropriate schema. The possible values of the attribute are the following.
+When a `VersionOverrides` element is used, then the `OfficeApp` element must have a `xmlns` attribute that identifies the appropriate schema. The possible values of the attribute are the following:
 
 - `http://schemas.microsoft.com/office/taskpaneappversionoverrides`
 - `http://schemas.microsoft.com/office/contentappversionoverrides`
 - `http://schemas.microsoft.com/office/mailappversionoverrides`
 
-The `VersionOverrides` element itself must also have an `xmlns` attribute specifying the schema. The possible values are the three above and the following.
+The `VersionOverrides` element itself must also have an `xmlns` attribute specifying the schema. The possible values are the three above and the following:
 
 - `http://schemas.microsoft.com/office/mailappversionoverrides/1.1`
 
-The `VersionOverrides` element also must have an `xsi:type` attribute that specifies the schema version. The possible values are the following.
+The `VersionOverrides` element also must have an `xsi:type` attribute that specifies the schema version. The possible values are the following:
 
 - `VersionOverridesV1_0`
 - `VersionOverridesV1_1`

--- a/docs/develop/add-in-manifests.md
+++ b/docs/develop/add-in-manifests.md
@@ -191,7 +191,7 @@ The following are examples of `VersionOverrides` used, respectively, in a task p
 </VersionOverrides>
 ```
 
-For an example of a manifest that includes a `VersionOverrides` element, see [Manifest v1.1 XML file examples and schemas](#manifest-v1-1-xml-file-examples-and-schemas).
+For an example of a manifest that includes a `VersionOverrides` element, see [Manifest v1.1 XML file examples and schemas](#manifest-v11-xml-file-examples-and-schemas).
 
 ## Specify domains from which Office.js API calls are made
 

--- a/docs/develop/add-in-manifests.md
+++ b/docs/develop/add-in-manifests.md
@@ -144,7 +144,7 @@ The following XML manifest example hosts its main add-in page in the `https://ww
 
 ## Version overrides in the manifest
 
-The optional [VersionOverrides](../reference/manifest/versionoverrides.md) deserves special mention. It contains child markup that enables additional add-in features. Some of these are:
+The optional [VersionOverrides](../reference/manifest/versionoverrides.md) element deserves special mention. It contains child markup that enables additional add-in features. Some of these are:
 
  - Customizing the Office ribbon and menus
  - Customizing how Office works with the embedded browser runtime in which add-ins run
@@ -191,7 +191,7 @@ The following are examples of `VersionOverrides` used, respectively, in a task p
 </VersionOverrides>
 ```
 
-For an example of a manifest that includes a `VersionOverrides` element, see [Manifest v1.1 XML file examples and schemas](#manifest-v1.1-xml-file-examples-and-schemas).
+For an example of a manifest that includes a `VersionOverrides` element, see [Manifest v1.1 XML file examples and schemas](#manifest-v1_1-xml-file-examples-and-schemas).
 
 ## Specify domains from which Office.js API calls are made
 

--- a/docs/develop/add-in-manifests.md
+++ b/docs/develop/add-in-manifests.md
@@ -1,7 +1,7 @@
 ---
 title: Office Add-ins XML manifest
 description: 'Get an overview of the Office Add-in manifest and its uses.'
-ms.date: 07/08/2020
+ms.date: 09/28/2021
 ms.localizationpriority: high
 ---
 
@@ -9,7 +9,7 @@ ms.localizationpriority: high
 
 The XML manifest file of an Office Add-in describes how your add-in should be activated when an end user installs and uses it with Office documents and applications.
 
-An XML manifest file based on this schema enables an Office Add-in to do the following:
+An XML manifest file enables an Office Add-in to do the following:
 
 * Describe itself by providing an ID, version, description, display name, and default locale.
 
@@ -141,6 +141,57 @@ The following XML manifest example hosts its main add-in page in the `https://ww
   <Permissions>ReadWriteDocument</Permissions>
 </OfficeApp>
 ```
+
+## Version overrides in the manifest
+
+The optional [VersionOverrides](../reference/manifest/versionoverrides.md) deserves special mention. It contains child markup that enables additional add-in features. Some of these are:
+
+ - Customizing the Office ribbon and menus
+ - Customizing how Office works with the embedded browser runtime in which add-ins run
+ - Configuring how the add-in interacts with Azure Active Directory and Microsoft Graph for Single Sign-on
+
+Some descendant elements of `VersionOverrides` have values that override values of the parent `OfficeApp` element. For example, the `Hosts` element in `VersionOverrides` overrides the `Hosts` element in `OfficeApp`.
+
+The `VersionOverrides` element has its own schema, actually four of them, depending on the type of add-in and the features it uses. The schemas are:
+
+- [Task pane 1.0](/openspecs/office_file_formats/ms-owemxml/82e93ec5-de22-42a8-86e3-353c8336aa40)
+- [Content 1.0](/openspecs/office_file_formats/ms-owemxml/c9cb8dca-e9e7-45a7-86b7-f1f0833ce2c7)
+- [Mail 1.0](/openspecs/office_file_formats/ms-owemxml/578d8214-2657-4e6a-8485-25899e772fac)
+- [Mail 1.1](/openspecs/office_file_formats/ms-owemxml/8e722c85-eb78-438c-94a4-edac7e9c533a)
+
+When a `VersionOverrides` element is used, then the `OfficeApp` element must have a `xmlns` attribute that identifies the appropriate schema. The possible values of the attribute are the following.
+
+- `http://schemas.microsoft.com/office/taskpaneappversionoverrides`
+- `http://schemas.microsoft.com/office/contentappversionoverrides`
+- `http://schemas.microsoft.com/office/mailappversionoverrides`
+
+The `VersionOverrides` element itself must also have an `xmlns` attribute specifying the schema. The possible values are the three above and the following.
+
+- `http://schemas.microsoft.com/office/mailappversionoverrides/1.1`
+
+The `VersionOverrides` element also must have an `xsi:type` attribute that specifies the schema version. The possible values are the following.
+
+- `VersionOverridesV1_0`
+- `VersionOverridesV1_1`
+
+The following are examples of `VersionOverrides` used, respectively, in a task pane add-in and a mail add-in. Note that when a mail `VersionOverrides` with version 1.1 is used, it must be the last child of a parent `VersionOverrides` of type 1.0. The values of child elements in the inner `VersionOverrides` override the values of the same-named elements in the parent `VersionOverrides` and the grandparent `OfficeApp` element.
+
+```xml
+<VersionOverrides xmlns="http://schemas.microsoft.com/office/taskpaneappversionoverrides" xsi:type="VersionOverridesV1_0">
+    <!-- child elements omitted -->
+</VersionOverrides>
+```
+
+```xml
+<VersionOverrides xmlns="http://schemas.microsoft.com/office/mailappversionoverrides" xsi:type="VersionOverridesV1_0">
+  <!-- other child elements omitted -->
+  <VersionOverrides xmlns="http://schemas.microsoft.com/office/mailappversionoverrides/1.1" xsi:type="VersionOverridesV1_1">
+    <!-- child elements omitted -->
+  </VersionOverrides>
+</VersionOverrides>
+```
+
+For an example of a manifest that includes a `VersionOverrides` element, see [Manifest v1.1 XML file examples and schemas](#manifest-v1.1-xml-file-examples-and-schemas).
 
 ## Specify domains from which Office.js API calls are made
 

--- a/docs/develop/add-in-manifests.md
+++ b/docs/develop/add-in-manifests.md
@@ -191,7 +191,7 @@ The following are examples of `VersionOverrides` used, respectively, in a task p
 </VersionOverrides>
 ```
 
-For an example of a manifest that includes a `VersionOverrides` element, see [Manifest v1.1 XML file examples and schemas](#manifest-v1_1-xml-file-examples-and-schemas).
+For an example of a manifest that includes a `VersionOverrides` element, see [Manifest v1.1 XML file examples and schemas](#manifest-v1-1-xml-file-examples-and-schemas).
 
 ## Specify domains from which Office.js API calls are made
 

--- a/docs/reference/manifest/runtime.md
+++ b/docs/reference/manifest/runtime.md
@@ -11,7 +11,7 @@ Configures your add-in to use a shared JavaScript runtime so that various compon
 
 **Add-in type:** Task pane, Mail
 
-**Valid only in these VersionOverride schemas:**:
+**Valid only in these VersionOverrides schemas**:
 
  - Task pane 1.0
  - Mail 1.1

--- a/docs/reference/manifest/runtime.md
+++ b/docs/reference/manifest/runtime.md
@@ -1,7 +1,7 @@
 ---
 title: Runtime in the manifest file
 description: The Runtime element configures your add-in to use a shared JavaScript runtime for its various components, for example, ribbon, task pane, custom functions.
-ms.date: 05/19/2021
+ms.date: 09/28/2021
 ms.localizationpriority: medium
 ---
 
@@ -10,6 +10,17 @@ ms.localizationpriority: medium
 Configures your add-in to use a shared JavaScript runtime so that various components all run in the same runtime. Child of the [`<Runtimes>`](runtimes.md) element.
 
 **Add-in type:** Task pane, Mail
+
+**Valid only in these VersionOverride schemas:**:
+
+ - Task pane 1.0
+ - Mail 1.1
+
+For more information, see [Version overrides in the manifest](../develop/add-in-manifests.md#version-overrides-in-the-manifest).
+
+**Associated with these requirement sets**:
+
+- [SharedRuntime 1.1](../requirement-sets/shared-runtime-requirement-sets.md) (Only when used in a task pane add-in.)
 
 [!include[Runtimes support](../../includes/runtimes-note.md)]
 

--- a/docs/reference/manifest/runtime.md
+++ b/docs/reference/manifest/runtime.md
@@ -16,7 +16,7 @@ Configures your add-in to use a shared JavaScript runtime so that various compon
  - Task pane 1.0
  - Mail 1.1
 
-For more information, see [Version overrides in the manifest](../develop/add-in-manifests.md#version-overrides-in-the-manifest).
+For more information, see [Version overrides in the manifest](../../develop/add-in-manifests.md#version-overrides-in-the-manifest).
 
 **Associated with these requirement sets**:
 

--- a/docs/reference/manifest/runtimes.md
+++ b/docs/reference/manifest/runtimes.md
@@ -15,7 +15,7 @@ Specifies the runtime of your add-in. Child of the [`<Host>`](host.md) element.
 
 **Add-in type:** Task pane, Mail
 
-**Valid only in these VersionOverride schemas:**:
+**Valid only in these VersionOverrides schemas**:
 
  - Task pane 1.0
  - Mail 1.1

--- a/docs/reference/manifest/runtimes.md
+++ b/docs/reference/manifest/runtimes.md
@@ -1,7 +1,7 @@
 ---
 title: Runtimes in the manifest file 
 description: The Runtimes element specifies your add-in's runtime.
-ms.date: 05/14/2021
+ms.date: 09/28/2021
 
 ms.localizationpriority: medium
 ---
@@ -14,6 +14,17 @@ Specifies the runtime of your add-in. Child of the [`<Host>`](host.md) element.
 > When running in Office on Windows, an add-in that has a `<Runtimes>` element in its manifest does not necessarily run in the same webview control as it otherwise would. For more information about how the versions of Windows and Office determine what webview control is normally used, see [Browsers used by Office Add-ins](../../concepts/browsers-used-by-office-web-add-ins.md). If the conditions described there for using Microsoft Edge with WebView2 (Chromium-based) are met, then the add-in uses that browser whether or not it has a `<Runtimes>` element. However, when those conditions are not met, an add-in with a `<Runtimes>` element always uses Internet Explorer 11 regardless of the Windows or Microsoft 365 version.
 
 **Add-in type:** Task pane, Mail
+
+**Valid only in these VersionOverride schemas:**:
+
+ - Task pane 1.0
+ - Mail 1.1
+
+For more information, see [Version overrides in the manifest](../develop/add-in-manifests.md#version-overrides-in-the-manifest).
+
+**Associated with these requirement sets**:
+
+- [SharedRuntime 1.1](../requirement-sets/shared-runtime-requirement-sets.md) (Only when used in a task pane add-in.)
 
 [!include[Runtimes support](../../includes/runtimes-note.md)]
 

--- a/docs/reference/manifest/runtimes.md
+++ b/docs/reference/manifest/runtimes.md
@@ -20,7 +20,7 @@ Specifies the runtime of your add-in. Child of the [`<Host>`](host.md) element.
  - Task pane 1.0
  - Mail 1.1
 
-For more information, see [Version overrides in the manifest](../develop/add-in-manifests.md#version-overrides-in-the-manifest).
+For more information, see [Version overrides in the manifest](../../develop/add-in-manifests.md#version-overrides-in-the-manifest).
 
 **Associated with these requirement sets**:
 


### PR DESCRIPTION
This is the first of what will be a series of PRs adding info to manifest elements about

- Which VersionOverrides schema the elements are valid for.
- Which requirement sets are associated with the elements.

This one also contains a new conceptual section of the manifest overview that describes the `<VersionOverrides>` element. This section will be linked to in all the PRs. 

