### PR TITLE
[Developer Experience] (debugging) Update Office debugging command instructions

### DIFF
--- a/docs/testing/debug-desktop-using-edge-chromium.md
+++ b/docs/testing/debug-desktop-using-edge-chromium.md
@@ -1,7 +1,7 @@
 ---
 title: Debug add-ins on Windows using Microsoft Edge WebView2 (Chromium-based)
 description: 'Learn how to debug Office Add-ins that use Microsoft Edge WebView2 (Chromium-based) by using the Debugger for Microsoft Edge extension in VS Code.'
-ms.date: 10/05/2021
+ms.date: 11/01/2021
 ms.localizationpriority: high
 ---
 # Debug add-ins on Windows using Edge Chromium WebView2
@@ -19,8 +19,12 @@ Office Add-ins running on Windows can use the Debugger for Microsoft Edge extens
 
 1. Create a project using the [Yeoman generator for Office Add-ins](https://github.com/OfficeDev/generator-office). You can use any one of our quick start guides, such as the [Outlook add-in quickstart](../quickstarts/outlook-quickstart.md), in order to do this.
 
-    > [!TIP]
-    > If you aren't using a Yeoman generator based add-in, you may be prompted to adjust a registry key. While in the root folder of your project, run the following in the command line:  `office-add-in-debugging start <your manifest path>`
+   > [!TIP]
+   > If you aren't using a Yeoman generator based add-in, you may be prompted to adjust a registry key. While in the root folder of your project, run the following in the command line.
+   >
+   > ``` command&nbsp;line
+   > npx office-addin-debugging start <your manifest path>
+   > ```
 
 1. Open your project in VS Code. Within VS Code, select **Ctrl+Shift+X** to open the Extensions bar. Search for the "Debugger for Microsoft Edge" extension and install it.
 


### PR DESCRIPTION
Fixes #3031.

This also makes gives the command a copy button, so people can easily paste the code in their command window. 