### PR TITLE
[all hosts] (publish) Remove link to M365 Germany

### DIFF
--- a/docs/publish/publish-task-pane-and-content-add-ins-to-an-add-in-catalog.md
+++ b/docs/publish/publish-task-pane-and-content-add-ins-to-an-add-in-catalog.md
@@ -1,7 +1,7 @@
 ---
 title: Publish task pane and content add-ins to a SharePoint app catalog
 description: To make Office Add-ins accessible to users within their organization, administrators can upload Office Add-ins manifest files to the app catalog for their organization.
-ms.date: 10/08/2021
+ms.date: 11/08/2021
 ms.localizationpriority: medium
 ---
 
@@ -38,7 +38,7 @@ Complete the steps in one of the following sections to publish an Office Add-in 
 1. Go to the [Active sites page of the new SharePoint admin center](https://admin.microsoft.com/sharepoint?page=siteManagement&modern=true) and sign in with an account that has [admin permissions](/sharepoint/sharepoint-admin-role) for your organization.
 
     > [!NOTE]
-    > If you have Microsoft 365 Germany, [sign in to the Microsoft 365 admin center](https://go.microsoft.com/fwlink/p/?linkid=848041), then browse to the SharePoint admin center and open the More features page. <br>If you have Microsoft 365 operated by 21Vianet (China), [sign in to the Microsoft 365 admin center](https://go.microsoft.com/fwlink/p/?linkid=850627), then browse to the SharePoint admin center and open the More features page.
+    > If you have Microsoft 365 operated by 21Vianet (China), [sign in to the Microsoft 365 admin center](https://go.microsoft.com/fwlink/p/?linkid=850627), then browse to the SharePoint admin center and open the More features page.
 
 1. Open the app catalog site by selecting its URL in the URL column.
 


### PR DESCRIPTION
Reported as broken link. Removing link altogether since M365 Germany is being decommissioned.