### PR TITLE
[Excel] Update conceptual docs following CDN transfer

### DIFF
--- a/docs/excel/excel-data-types-concepts.md
+++ b/docs/excel/excel-data-types-concepts.md
@@ -24,7 +24,7 @@ This article describes how to use the [Excel JavaScript API](../reference/overvi
 
 ## Core concepts
 
-Use the [`Range.valuesAsJSON`](/javascript/api/excel/excel.range#valuesAsJson) property to work with data type values. This property is similar to [Range.values](/javascript/api/excel/excel.range#values), but `Range.values` only returns the four basic types: string, number, boolean, or error values. `Range.valuesAsJSON` can return expanded information about the four basic types, and this property can return data types such as formatted number values, entities, and web images.
+Use the [`Range.valuesAsJson`](/javascript/api/excel/excel.range#valuesAsJson) property to work with data type values. This property is similar to [Range.values](/javascript/api/excel/excel.range#values), but `Range.values` only returns the four basic types: string, number, boolean, or error values. `Range.valuesAsJson` can return expanded information about the four basic types, and this property can return data types such as formatted number values, entities, and web images.
 
 ### JSON schema
 

--- a/docs/excel/excel-data-types-concepts.md
+++ b/docs/excel/excel-data-types-concepts.md
@@ -1,7 +1,7 @@
 ---
 title: Excel JavaScript API data types core concepts
 description: 'Learn the core concepts for using Excel data types in your Office Add-in.'
-ms.date: 11/08/2021
+ms.date: 12/08/2021
 ms.topic: conceptual
 ms.prod: excel
 ms.custom: scenarios:getting-started
@@ -11,16 +11,20 @@ ms.localizationpriority: high
 # Excel data types core concepts (preview)
 
 > [!NOTE]
-> Data types APIs are currently only available in public preview. Preview APIs are subject to change and are not intended for use in a production environment. Do not use preview APIs in a production environment or within business-critical documents.
-
-> [!IMPORTANT]
-> Some of the data types concepts described in this article, such as `Range.valuesAsJSON` are in active development and are not yet available in public preview. This article is intended as a conceptual introduction. Concepts described in this article that are not yet in public preview will be released to preview soon.
+> Data types APIs are currently only available in public preview. Preview APIs are subject to change and are not intended for use in a production environment. We recommend that you try them out in test and development environments only. Do not use preview APIs in a production environment or within business-critical documents.
+>
+> To use preview APIs:
+>
+> - You must reference the **beta** library on the CDN (https://appsforoffice.microsoft.com/lib/beta/hosted/office.js). The [type definition file](https://appsforoffice.microsoft.com/lib/beta/hosted/office.d.ts) for TypeScript compilation and IntelliSense is found at the CDN and [DefinitelyTyped](https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/master/types/office-js-preview/index.d.ts). You can install these types with `npm install --save-dev @types/office-js-preview`. For additional information, see the [@microsoft/office-js](https://www.npmjs.com/package/@microsoft/office-js) NPM package readme.
+> - You may need to join the [Office Insider program](https://insider.office.com) for access to more recent Office builds.
+>
+> To try out data types in Office on Windows, you must have an Excel build number greater than or equal to 16.0.14626.10000. To try out data types in Office on Mac you must have an Excel build number greater than or equal to 16.55.21102600.
 
 This article describes how to use the [Excel JavaScript API](../reference/overview/excel-add-ins-reference-overview.md) to work with data types. It introduces core concepts that are fundamental to data type development.
 
 ## Core concepts
 
-Use the `Range.valuesAsJSON` property to work with data type values. This property is similar to [Range.values](/javascript/api/excel/excel.range#values), but `Range.values` only returns the four basic types: string, number, boolean, or error values. `Range.valuesAsJSON` can return expanded information about the four basic types, and this property can return data types such as formatted number values, entities, and web images.
+Use the [`Range.valuesAsJSON`](/javascript/api/excel/excel.range#valuesAsJson) property to work with data type values. This property is similar to [Range.values](/javascript/api/excel/excel.range#values), but `Range.values` only returns the four basic types: string, number, boolean, or error values. `Range.valuesAsJSON` can return expanded information about the four basic types, and this property can return data types such as formatted number values, entities, and web images.
 
 ### JSON schema
 

--- a/docs/excel/excel-data-types-concepts.md
+++ b/docs/excel/excel-data-types-concepts.md
@@ -18,7 +18,7 @@ ms.localizationpriority: high
 > - You must reference the **beta** library on the CDN (https://appsforoffice.microsoft.com/lib/beta/hosted/office.js). The [type definition file](https://appsforoffice.microsoft.com/lib/beta/hosted/office.d.ts) for TypeScript compilation and IntelliSense is found at the CDN and [DefinitelyTyped](https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/master/types/office-js-preview/index.d.ts). You can install these types with `npm install --save-dev @types/office-js-preview`. For additional information, see the [@microsoft/office-js](https://www.npmjs.com/package/@microsoft/office-js) NPM package readme.
 > - You may need to join the [Office Insider program](https://insider.office.com) for access to more recent Office builds.
 >
-> To try out data types in Office on Windows, you must have an Excel build number greater than or equal to 16.0.14626.10000. To try out data types in Office on Mac you must have an Excel build number greater than or equal to 16.55.21102600.
+> To try out data types in Office on Windows, you must have an Excel build number greater than or equal to 16.0.14626.10000. To try out data types in Office on Mac, you must have an Excel build number greater than or equal to 16.55.21102600.
 
 This article describes how to use the [Excel JavaScript API](../reference/overview/excel-add-ins-reference-overview.md) to work with data types. It introduces core concepts that are fundamental to data type development.
 

--- a/docs/excel/excel-data-types-overview.md
+++ b/docs/excel/excel-data-types-overview.md
@@ -18,7 +18,7 @@ ms.localizationpriority: high
 > - You must reference the **beta** library on the CDN (https://appsforoffice.microsoft.com/lib/beta/hosted/office.js). The [type definition file](https://appsforoffice.microsoft.com/lib/beta/hosted/office.d.ts) for TypeScript compilation and IntelliSense is found at the CDN and [DefinitelyTyped](https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/master/types/office-js-preview/index.d.ts). You can install these types with `npm install --save-dev @types/office-js-preview`. For additional information, see the [@microsoft/office-js](https://www.npmjs.com/package/@microsoft/office-js) NPM package readme.
 > - You may need to join the [Office Insider program](https://insider.office.com) for access to more recent Office builds.
 >
-> To try out data types in Office on Windows, you must have an Excel build number greater than or equal to 16.0.14626.10000. To try out data types in Office on Mac you must have an Excel build number greater than or equal to 16.55.21102600.
+> To try out data types in Office on Windows, you must have an Excel build number greater than or equal to 16.0.14626.10000. To try out data types in Office on Mac, you must have an Excel build number greater than or equal to 16.55.21102600.
 
 Data types in the Excel JavaScript API enable add-in developers to organize complex data structures as objects, such as formatted number values, web images, and entity values.
 

--- a/docs/excel/excel-data-types-overview.md
+++ b/docs/excel/excel-data-types-overview.md
@@ -1,7 +1,7 @@
 ---
 title: Overview of data types in Excel add-ins
 description: 'Data types in the Excel JavaScript API enable Office Add-in developers to work with formatted number values, web images, entity values, arrays within entity values, and enhanced errors as data types.'
-ms.date: 11/03/2021
+ms.date: 12/08/2021
 ms.topic: conceptual
 ms.prod: excel
 ms.custom: scenarios:getting-started
@@ -11,10 +11,14 @@ ms.localizationpriority: high
 # Overview of data types in Excel add-ins (preview)
 
 > [!NOTE]
-> Data types APIs are currently only available in public preview. Preview APIs are subject to change and are not intended for use in a production environment. Do not use preview APIs in a production environment or within business-critical documents.
-
-> [!IMPORTANT]
-> Some of the data types APIs, such as `Range.valuesAsJSON` are in active development and are not yet available in public preview. This article is intended as a conceptual introduction. Concepts described in this article that are not yet in public preview will be released to preview soon.
+> Data types APIs are currently only available in public preview. Preview APIs are subject to change and are not intended for use in a production environment. We recommend that you try them out in test and development environments only. Do not use preview APIs in a production environment or within business-critical documents.
+>
+> To use preview APIs:
+>
+> - You must reference the **beta** library on the CDN (https://appsforoffice.microsoft.com/lib/beta/hosted/office.js). The [type definition file](https://appsforoffice.microsoft.com/lib/beta/hosted/office.d.ts) for TypeScript compilation and IntelliSense is found at the CDN and [DefinitelyTyped](https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/master/types/office-js-preview/index.d.ts). You can install these types with `npm install --save-dev @types/office-js-preview`. For additional information, see the [@microsoft/office-js](https://www.npmjs.com/package/@microsoft/office-js) NPM package readme.
+> - You may need to join the [Office Insider program](https://insider.office.com) for access to more recent Office builds.
+>
+> To try out data types in Office on Windows, you must have an Excel build number greater than or equal to 16.0.14626.10000. To try out data types in Office on Mac you must have an Excel build number greater than or equal to 16.55.21102600.
 
 Data types in the Excel JavaScript API enable add-in developers to organize complex data structures as objects, such as formatted number values, web images, and entity values.
 
@@ -30,6 +34,6 @@ Data types enhance the power of custom functions. Custom functions accept data t
 
 ## See also
 
-* [Excel data types core concepts](excel-data-types-concepts.md)
-* [Excel JavaScript API reference](../reference/overview/excel-add-ins-reference-overview.md)
-* [Custom functions and data types overview](custom-functions-data-types-overview.md)
+- [Excel data types core concepts](excel-data-types-concepts.md)
+- [Excel JavaScript API reference](../reference/overview/excel-add-ins-reference-overview.md)
+- [Custom functions and data types overview](custom-functions-data-types-overview.md)

--- a/docs/reference/requirement-sets/excel-api-1-14-requirement-set.md
+++ b/docs/reference/requirement-sets/excel-api-1-14-requirement-set.md
@@ -1,7 +1,7 @@
 ---
 title: Excel JavaScript API requirement set 1.14
 description: 'Details about the ExcelApi 1.14 requirement set.'
-ms.date: 12/02/2021
+ms.date: 12/08/2021
 ms.prod: excel
 ms.localizationpriority: medium
 ---
@@ -15,7 +15,7 @@ The ExcelApi 1.14 added objects to control the data table feature of a chart, a 
 | [Chart data tables](../../excel/excel-add-ins-charts.md#add-and-format-a-chart-data-table) | Control appearance, formatting, and visibility of data tables on charts. | [Chart](/javascript/api/excel/excel.chart), [ChartDataTable](/javascript/api/excel/excel.chartdatatable), [ChartDataTableFormat](/javascript/api/excel/excel.chartdatatableformat) |
 | [Formula precedents](../../excel/excel-add-ins-ranges-precedents-dependents.md#get-the-precedents-of-a-formula) | Return all the precedent cells of a formula. | [Range](/javascript/api/excel/excel.range) |
 | Queries | Retrieve Power Query attributes like name, refresh date, and query count. | [Query](/javascript/api/excel/excel.query), [QueryCollection](/javascript/api/excel/excel.querycollection)|
-| Worksheet protection events | Track changes to the protection state of a worksheet and the source of those changes. | [WorksheetProtectionChangedEventArgs](/javascript/api/excel/excel.worksheetprotectionchangedeventargs), [Worksheet](/javascript/api/excel/excel.worksheet), [WorksheetCollection](/javascript/api/excel/excel.worksheetcollection) |
+| [Worksheet protection events](../../excel/excel-add-ins-worksheets.md#detect-changes-to-the-worksheet-protection-state) | Track changes to the protection state of a worksheet and the source of those changes. | [WorksheetProtectionChangedEventArgs](/javascript/api/excel/excel.worksheetprotectionchangedeventargs), [Worksheet](/javascript/api/excel/excel.worksheet), [WorksheetCollection](/javascript/api/excel/excel.worksheetcollection) |
 
 ## API list
 

--- a/docs/reference/requirement-sets/excel-preview-apis.md
+++ b/docs/reference/requirement-sets/excel-preview-apis.md
@@ -1,7 +1,7 @@
 ---
 title: Excel JavaScript preview APIs
 description: 'Details about upcoming Excel JavaScript APIs.'
-ms.date: 11/02/2021
+ms.date: 12/08/2021
 ms.prod: excel
 ms.localizationpriority: medium
 ---
@@ -66,6 +66,17 @@ The following table lists the Excel JavaScript APIs currently in preview. For a 
 ||[errorSubType](/javascript/api/excel/excel.calcerrorcellvalue#errorSubType)|Represents the type of `CalcErrorCellValue`.|
 ||[errorType](/javascript/api/excel/excel.calcerrorcellvalue#errorType)|Represents the type of `ErrorCellValue`.|
 ||[type](/javascript/api/excel/excel.calcerrorcellvalue#type)|Represents the type of this cell value.|
+|[CardLayoutListSection](/javascript/api/excel/excel.cardlayoutlistsection)|[layout](/javascript/api/excel/excel.cardlayoutlistsection#layout)|Represents the type of layout for this section.|
+|[CardLayoutPropertyReference](/javascript/api/excel/excel.cardlayoutpropertyreference)|[property](/javascript/api/excel/excel.cardlayoutpropertyreference#property)|The name of the property referenced by the card layout.|
+|[CardLayoutSectionStandardProperties](/javascript/api/excel/excel.cardlayoutsectionstandardproperties)|[collapsed](/javascript/api/excel/excel.cardlayoutsectionstandardproperties#collapsed)|Represents whether this section of the card is initially collapsed.|
+||[collapsible](/javascript/api/excel/excel.cardlayoutsectionstandardproperties#collapsible)|Represents whether this section of the card is collapsible.|
+||[properties](/javascript/api/excel/excel.cardlayoutsectionstandardproperties#properties)|Represents the names of the properties in this section.|
+||[title](/javascript/api/excel/excel.cardlayoutsectionstandardproperties#title)|Represents the title of this section of the card.|
+|[CardLayoutStandardProperties](/javascript/api/excel/excel.cardlayoutstandardproperties)|[mainImage](/javascript/api/excel/excel.cardlayoutstandardproperties#mainImage)|Specifies a property which will be used as the main image of the card.|
+||[sections](/javascript/api/excel/excel.cardlayoutstandardproperties#sections)|Represents the sections of the card.|
+||[subTitle](/javascript/api/excel/excel.cardlayoutstandardproperties#subTitle)|Represents a specification of which property contains the subtitle of the card.|
+||[title](/javascript/api/excel/excel.cardlayoutstandardproperties#title)|Represents the title of the card or the specification of which property contains the title of the card.|
+|[CardLayoutTableSection](/javascript/api/excel/excel.cardlayouttablesection)|[layout](/javascript/api/excel/excel.cardlayouttablesection#layout)|Represents the type of layout for this section.|
 |[CellValueAttributionAttributes](/javascript/api/excel/excel.cellvalueattributionattributes)|[licenseAddress](/javascript/api/excel/excel.cellvalueattributionattributes#licenseAddress)|Represents a URL to a license or source that describes how this property can be used.|
 ||[licenseText](/javascript/api/excel/excel.cellvalueattributionattributes#licenseText)|Represents a name for the license that governs this property.|
 ||[sourceAddress](/javascript/api/excel/excel.cellvalueattributionattributes#sourceAddress)|Represents a URL to the source of the `CellValue`.|
@@ -136,10 +147,11 @@ The following table lists the Excel JavaScript APIs currently in preview. For a 
 |[EmptyCellValue](/javascript/api/excel/excel.emptycellvalue)|[basicType](/javascript/api/excel/excel.emptycellvalue#basicType)|Represents the value that would be returned by `Range.valueTypes` for a cell with this value.|
 ||[basicValue](/javascript/api/excel/excel.emptycellvalue#basicValue)|Represents the value that would be returned by `Range.values` for a cell with this value.|
 ||[type](/javascript/api/excel/excel.emptycellvalue#type)|Represents the type of this cell value.|
+|[EntityCardLayout](/javascript/api/excel/excel.entitycardlayout)|[layout](/javascript/api/excel/excel.entitycardlayout#layout)|Represent the type of this layout.|
 |[EntityCellValue](/javascript/api/excel/excel.entitycellvalue)|[basicType](/javascript/api/excel/excel.entitycellvalue#basicType)|Represents the value that would be returned by `Range.valueTypes` for a cell with this value.|
 ||[basicValue](/javascript/api/excel/excel.entitycellvalue#basicValue)|Represents the value that would be returned by `Range.values` for a cell with this value.|
-||[properties: {            [key: string]: CellValue & {                propertyMetadata](/javascript/api/excel/excel.entitycellvalue#properties)|Represents the properties of this entity and their metadata.|
-||[propertyMetadata](/javascript/api/excel/excel.entitycellvalue#propertyMetadata)||
+||[cardLayout](/javascript/api/excel/excel.entitycellvalue#cardLayout)|Represents the layout of this entity in card view.|
+||[properties: {            [key: string]](/javascript/api/excel/excel.entitycellvalue#properties)|Represents the properties of this entity and their metadata.|
 ||[text](/javascript/api/excel/excel.entitycellvalue#text)|Represents the text shown when a cell with this value is rendered.|
 ||[type](/javascript/api/excel/excel.entitycellvalue#type)|Represents the type of this cell value.|
 |[FieldErrorCellValue](/javascript/api/excel/excel.fielderrorcellvalue)|[basicType](/javascript/api/excel/excel.fielderrorcellvalue#basicType)|Represents the value that would be returned by `Range.valueTypes` for a cell with this value.|
@@ -189,6 +201,8 @@ The following table lists the Excel JavaScript APIs currently in preview. For a 
 ||[basicValue](/javascript/api/excel/excel.nameerrorcellvalue#basicValue)|Represents the value that would be returned by `Range.values` for a cell with this value.|
 ||[errorType](/javascript/api/excel/excel.nameerrorcellvalue#errorType)|Represents the type of `ErrorCellValue`.|
 ||[type](/javascript/api/excel/excel.nameerrorcellvalue#type)|Represents the type of this cell value.|
+|[NamedItem](/javascript/api/excel/excel.nameditem)|[valueAsJson](/javascript/api/excel/excel.nameditem#valueAsJson)|A JSON representation of the values in this named item.|
+|[NamedItemArrayValues](/javascript/api/excel/excel.nameditemarrayvalues)|[valuesAsJson](/javascript/api/excel/excel.nameditemarrayvalues#valuesAsJson)|A JSON representation of the values in the cells in this range.|
 |[NamedSheetViewCollection](/javascript/api/excel/excel.namedsheetviewcollection)|[getItemOrNullObject(key: string)](/javascript/api/excel/excel.namedsheetviewcollection#getItemOrNullObject_key_)|Gets a sheet view using its name.|
 |[NotAvailableErrorCellValue](/javascript/api/excel/excel.notavailableerrorcellvalue)|[basicType](/javascript/api/excel/excel.notavailableerrorcellvalue#basicType)|Represents the value that would be returned by `Range.valueTypes` for a cell with this value.|
 ||[basicValue](/javascript/api/excel/excel.notavailableerrorcellvalue#basicValue)|Represents the value that would be returned by `Range.values` for a cell with this value.|
@@ -209,6 +223,8 @@ The following table lists the Excel JavaScript APIs currently in preview. For a 
 ||[getDataSourceType()](/javascript/api/excel/excel.pivottable#getDataSourceType__)|Gets the type of the data source for the PivotTable.|
 |[PivotTableScopedCollection](/javascript/api/excel/excel.pivottablescopedcollection)|[getFirstOrNullObject()](/javascript/api/excel/excel.pivottablescopedcollection#getFirstOrNullObject__)|Gets the first PivotTable in the collection.|
 |[Range](/javascript/api/excel/excel.range)|[getDependents()](/javascript/api/excel/excel.range#getDependents__)|Returns a `WorkbookRangeAreas` object that represents the range containing all the dependents of a cell in the same worksheet or in multiple worksheets.|
+||[valuesAsJson](/javascript/api/excel/excel.range#valuesAsJson)|A JSON representation of the values in the cells in this range.|
+|[RangeView](/javascript/api/excel/excel.rangeview)|[valuesAsJson](/javascript/api/excel/excel.rangeview#valuesAsJson)|A JSON representation of the values in the cells in this range.|
 |[RefErrorCellValue](/javascript/api/excel/excel.referrorcellvalue)|[basicType](/javascript/api/excel/excel.referrorcellvalue#basicType)|Represents the value that would be returned by `Range.valueTypes` for a cell with this value.|
 ||[basicValue](/javascript/api/excel/excel.referrorcellvalue#basicValue)|Represents the value that would be returned by `Range.values` for a cell with this value.|
 ||[errorSubType](/javascript/api/excel/excel.referrorcellvalue#errorSubType)|Represents the type of `RefErrorCellValue`.|
@@ -243,9 +259,11 @@ The following table lists the Excel JavaScript APIs currently in preview. For a 
 ||[setStyle(style: string \| TableStyle \| BuiltInTableStyle)](/javascript/api/excel/excel.table#setStyle_style_)|Sets the style applied to the table.|
 ||[tableStyle](/javascript/api/excel/excel.table#tableStyle)|The style applied to the table.|
 |[TableCollection](/javascript/api/excel/excel.tablecollection)|[onFiltered](/javascript/api/excel/excel.tablecollection#onFiltered)|Occurs when a filter is applied on any table in a workbook, or a worksheet.|
+|[TableColumn](/javascript/api/excel/excel.tablecolumn)|[valuesAsJson](/javascript/api/excel/excel.tablecolumn#valuesAsJson)|A JSON representation of the values in the cells in this table column.|
 |[TableFilteredEventArgs](/javascript/api/excel/excel.tablefilteredeventargs)|[tableId](/javascript/api/excel/excel.tablefilteredeventargs#tableId)|Gets the ID of the table in which the filter is applied.|
 ||[type](/javascript/api/excel/excel.tablefilteredeventargs#type)|Gets the type of the event.|
 ||[worksheetId](/javascript/api/excel/excel.tablefilteredeventargs#worksheetId)|Gets the ID of the worksheet which contains the table.|
+|[TableRow](/javascript/api/excel/excel.tablerow)|[valuesAsJson](/javascript/api/excel/excel.tablerow#valuesAsJson)|A JSON representation of the values in the cells in this table row.|
 |[ValueErrorCellValue](/javascript/api/excel/excel.valueerrorcellvalue)|[basicType](/javascript/api/excel/excel.valueerrorcellvalue#basicType)|Represents the value that would be returned by `Range.valueTypes` for a cell with this value.|
 ||[basicValue](/javascript/api/excel/excel.valueerrorcellvalue#basicValue)|Represents the value that would be returned by `Range.values` for a cell with this value.|
 ||[errorSubType](/javascript/api/excel/excel.valueerrorcellvalue#errorSubType)|Represents the type of `ValueErrorCellValue`.|


### PR DESCRIPTION
This PR: 
- Adjusts the Preview note on two Data Types articles because the missing data types API (Range.valuesAsJson) has now reached beta release 
- Updates the Preview APIs intro table based on the recent CDN transfer
- Updates the ExcelApi 1.14 intro table with link to new conceptual docs 