### PR TITLE
[all hosts] (metadata) Set tag to overview

### DIFF
--- a/docs/excel/custom-functions-overview.md
+++ b/docs/excel/custom-functions-overview.md
@@ -2,7 +2,7 @@
 description: 'Create an Excel custom function for your Office Add-in.'
 title: Create custom functions in Excel
 ms.date: 08/04/2021
-ms.topic: conceptual
+ms.topic: overview
 ms.custom: scenarios:getting-started
 ms.localizationpriority: high
 ---

--- a/docs/excel/excel-add-ins-overview.md
+++ b/docs/excel/excel-add-ins-overview.md
@@ -2,7 +2,7 @@
 title: Excel add-ins overview
 description: 'Excel add-in allow you to extend Excel application functionality across multiple platforms including Windows, Mac, iPad, and in a browser.'
 ms.date: 10/14/2020
-ms.topic: conceptual
+ms.topic: overview
 ms.custom: scenarios:getting-started
 ms.localizationpriority: high
 ---

--- a/docs/onenote/onenote-add-ins-programming-overview.md
+++ b/docs/onenote/onenote-add-ins-programming-overview.md
@@ -2,7 +2,7 @@
 title: OneNote JavaScript API programming overview
 description: 'Learn about the OneNote JavaScript API for OneNote add-ins on the web.'
 ms.date: 10/14/2020
-ms.topic: conceptual
+ms.topic: overview
 ms.custom: scenarios:getting-started
 ms.localizationpriority: high
 ---

--- a/docs/outlook/outlook-add-ins-overview.md
+++ b/docs/outlook/outlook-add-ins-overview.md
@@ -2,6 +2,7 @@
 title: Outlook add-ins overview
 description: Outlook add-ins are integrations built by third parties into Outlook by using our web-based platform. 
 ms.date: 07/16/2021
+ms.topic: overview
 ms.custom: scenarios:getting-started
 ms.localizationpriority: high
 ---

--- a/docs/overview/office-add-ins.md
+++ b/docs/overview/office-add-ins.md
@@ -1,8 +1,8 @@
 ---
-title: Office Add-ins platform overview | Microsoft Docs
+title: Office Add-ins platform overview
 description:  Use familiar web technologies such as HTML, CSS, and JavaScript to extend and interact with Word, Excel, PowerPoint, OneNote, Project, and Outlook.
 ms.date: 10/14/2020
-ms.topic: conceptual
+ms.topic: overview
 ms.custom: scenarios:getting-started
 ms.localizationpriority: high
 ---

--- a/docs/powerpoint/powerpoint-add-ins.md
+++ b/docs/powerpoint/powerpoint-add-ins.md
@@ -2,7 +2,7 @@
 title: PowerPoint add-ins
 description: 'Learn how to use PowerPoint add-ins to build engaging solutions for presentations across platforms including Windows, iPad, Mac, and in a browser.'
 ms.date: 10/14/2020
-ms.topic: conceptual
+ms.topic: overview
 ms.custom: scenarios:getting-started
 ms.localizationpriority: high
 ---

--- a/docs/project/project-add-ins.md
+++ b/docs/project/project-add-ins.md
@@ -2,7 +2,7 @@
 title: Task pane add-ins for Project
 description: 'Learn about task pane add-ins for Project.'
 ms.date: 10/14/2019
-ms.topic: conceptual
+ms.topic: overview
 ms.custom: scenarios:getting-started
 ms.localizationpriority: high
 ---

--- a/docs/reference/overview/visio-javascript-reference-overview.md
+++ b/docs/reference/overview/visio-javascript-reference-overview.md
@@ -3,7 +3,7 @@ title: Visio JavaScript API overview
 description: 'Overview of the Visio JavaScript API'
 ms.date: 06/03/2020
 ms.prod: visio
-ms.topic: conceptual
+ms.topic: overview
 ms.custom: scenarios:getting-started
 ms.localizationpriority: high
 ---

--- a/docs/word/word-add-ins-programming-overview.md
+++ b/docs/word/word-add-ins-programming-overview.md
@@ -2,7 +2,7 @@
 title: Word add-ins overview
 description: 'Learn the basics of Word Add-ins.'
 ms.date: 10/14/2020
-ms.topic: conceptual
+ms.topic: overview
 ms.custom: scenarios:getting-started
 ms.localizationpriority: high
 ---


### PR DESCRIPTION
Generally setting ms.topic to "overview" for main page being used as Overview page for each product.