### PR TITLE
[All hosts](commands) Update getting started info

### DIFF
--- a/docs/design/add-in-commands.md
+++ b/docs/design/add-in-commands.md
@@ -1,16 +1,13 @@
 ---
 title: Basic concepts for add-in commands
 description: 'Learn how to add custom ribbon buttons and menu items to Office as part of an Office Add-in.'
-ms.date: 10/08/2021
+ms.date: 12/13/2021
 ms.localizationpriority: high
 ---
-
 
 # Add-in commands for Excel, PowerPoint, and Word
 
 Add-in commands are UI elements that extend the Office UI and start actions in your add-in. You can use add-in commands to add a button on the ribbon or an item to a context menu. When users select an add-in command, they initiate actions such as running JavaScript code, or showing a page of the add-in in a task pane. Add-in commands help users find and use your add-in, which can help increase your add-in's adoption and reuse, and improve customer retention.
-
-For an overview of the feature, see the video [Add-in Commands in the Office app ribbon](https://channel9.msdn.com/events/Build/2016/P551).
 
 > [!NOTE]
 > SharePoint catalogs do not support add-in commands. You can deploy add-in commands via [Integrated Apps](/microsoft-365/admin/manage/test-and-deploy-microsoft-365-apps) or [AppSource](/office/dev/store/submit-to-appsource-via-partner-center), or use [sideloading](../testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins.md) to deploy your add-in command for testing.

--- a/docs/develop/create-addin-commands.md
+++ b/docs/develop/create-addin-commands.md
@@ -31,7 +31,7 @@ The following image is an overview of add-in commands elements in the manifest.
 
 ## Step 1: Create the project
 
-We recommend you create a project by following one of the quick starts such as [Build an Excel task pane add-in](../quickstarts/excel-quickstart-jquery.md). Each quick start for Excel, Word, or PowerPoint will generate a project that already contains an add-in command (button) to show the task pane. Ensure that you have read  [Add-in commands for Excel, Word and PowerPoint](../design/add-in-commands.md) before using add-in commands.
+We recommend you create a project by following one of the quick starts such as [Build an Excel task pane add-in](../quickstarts/excel-quickstart-jquery.md). Each quick start for Excel, Word, and PowerPoint generates a project that already contains an add-in command (button) to show the task pane. Ensure that you have read [Add-in commands for Excel, Word and PowerPoint](../design/add-in-commands.md) before using add-in commands.
 
 ## Step 2: Create a task pane add-in
 

--- a/docs/develop/create-addin-commands.md
+++ b/docs/develop/create-addin-commands.md
@@ -1,7 +1,7 @@
 ---
 title: Create add-in commands in your manifest for Excel, PowerPoint, and Word
 description: 'Use VersionOverrides in your manifest to define add-in commands for Excel, PowerPoint, and Word. Use add-in commands to create UI elements, add buttons or lists, and perform actions.'
-ms.date: 07/08/2021
+ms.date: 12/13/2021
 ms.localizationpriority: medium
 ---
 
@@ -29,9 +29,9 @@ The following image is an overview of add-in commands elements in the manifest.
 
 ![Overview of add-in commands elements in the manifest. The top node here is VersionOverrides with children Hosts and Resources. Under Hosts are Host then DesktopFormFactor. Under DesktopFormFactor are FunctionFile and ExtensionPoint. Under ExtensionPoint are CustomTab or OfficeTab and Office Menu. Under CustomTab or Office Tab are Group then Control then Action. Under Office Menu are Control then Action. Under Resources (child of VersionOverrides) are Images, Urls, ShortStrings, and LongStrings.](../images/version-overrides.png)
 
-## Step 1: Start from a sample
+## Step 1: Create the project
 
-We strongly recommend that you start from one of the samples we provide in  [Office Add-in Commands Samples](https://github.com/OfficeDev/Office-Add-in-Command-Sample). Optionally, you can create your own manifest by following the steps in this guide. You can validate your manifest using the XSD file in the Office Add-in Commands Samples site. Ensure that you have read  [Add-in commands for Excel, Word and PowerPoint](../design/add-in-commands.md) before using add-in commands.
+We recommend you create a project by following one of the quick starts such as [Build an Excel task pane add-in](../quickstarts/excel-quickstart-jquery.md). Each quick start for Excel, Word, or PowerPoint will generate a project that already contains an add-in command (button) to show the task pane. Ensure that you have read  [Add-in commands for Excel, Word and PowerPoint](../design/add-in-commands.md) before using add-in commands.
 
 ## Step 2: Create a task pane add-in
 
@@ -438,3 +438,6 @@ In Excel and Word, you can add your add-in commands to the ribbon by using the d
 ## See also
 
 - [Add-in commands for Excel, PowerPoint, and Word](../design/add-in-commands.md)
+- [Sample: Create an Excel add-in with command buttons](https://github.com/OfficeDev/PnP-OfficeAddins/tree/main/Samples/office-add-in-commands/excel)
+- [Sample: Create an Word add-in with command buttons](https://github.com/OfficeDev/PnP-OfficeAddins/tree/main/Samples/office-add-in-commands/word)
+- [Sample: Create an PowerPoint add-in with command buttons](https://github.com/OfficeDev/PnP-OfficeAddins/tree/main/Samples/office-add-in-commands/powerpoint)


### PR DESCRIPTION
This addresses issue #3126 and updates https://docs.microsoft.com/en-us/office/dev/add-ins/develop/create-addin-commands to refer to the quick starts for starting off with a command (as all the yo office projects give you a command for free).

Also removes a broken video link from https://docs.microsoft.com/en-us/office/dev/add-ins/design/add-in-commands that no longer exists.