### PR TITLE
[All hosts](Web Storage API) add note on Web Storage API availibility

### DIFF
--- a/docs/develop/persisting-add-in-state-and-settings.md
+++ b/docs/develop/persisting-add-in-state-and-settings.md
@@ -18,7 +18,7 @@ To do that, you can:
 
 - Use techniques provided by the underlying browser control: browser cookies, or HTML5 web storage ([localStorage](https://developer.mozilla.org/docs/Web/API/Window/localStorage) or [sessionStorage](https://developer.mozilla.org/docs/Web/API/Window/sessionStorage)).
     > [!NOTE]
-    > Some browsers, or the user's browser settings may block browser-based storage techniques. You should test for availability as documented in [Using the Web Storage API](https://developer.mozilla.org/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API).
+    > Some browsers or the user's browser settings may block browser-based storage techniques. You should test for availability as documented in [Using the Web Storage API](https://developer.mozilla.org/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API).
 
 This article focuses on how to use the Office JavaScript API to persist add-in state to the current document. If you need to persist state across documents, such as tracking user preferences across any documents they open, you will need to use a different approach. For example, you could use [SSO](sso-in-office-add-ins.md#using-the-sso-token-as-an-identity) to obtain the user identity, and then save the user ID and their settings to an online database.
 

--- a/docs/develop/persisting-add-in-state-and-settings.md
+++ b/docs/develop/persisting-add-in-state-and-settings.md
@@ -1,7 +1,7 @@
 ---
 title: Persisting add-in state and settings
 description: 'Learn to persist data in Office Add-in web applications running in the stateless environment of a browser control.'
-ms.date: 03/23/2021
+ms.date: 12/15/2021
 ms.localizationpriority: medium
 ---
 
@@ -18,7 +18,7 @@ To do that, you can:
 
 - Use techniques provided by the underlying browser control: browser cookies, or HTML5 web storage ([localStorage](https://developer.mozilla.org/docs/Web/API/Window/localStorage) or [sessionStorage](https://developer.mozilla.org/docs/Web/API/Window/sessionStorage)).
     > [!NOTE]
-    > The user can block browser-based storage techniques depending on the settings they choose.
+    > Some browsers, or the user's browser settings may block browser-based storage techniques. You should test for availability as documented in [Using the Web Storage API](https://developer.mozilla.org/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API).
 
 This article focuses on how to use the Office JavaScript API to persist add-in state to the current document. If you need to persist state across documents, such as tracking user preferences across any documents they open, you will need to use a different approach. For example, you could use [SSO](sso-in-office-add-ins.md#using-the-sso-token-as-an-identity) to obtain the user identity, and then save the user ID and their settings to an online database.
 


### PR DESCRIPTION
This updates the note that Web Storage API (localStorage/sessionStorage) may not be available on some browsers or based on user settings.
Fixes #3066 