### PR TITLE
[Script Lab](Fix title on videos)

### DIFF
--- a/docs/develop/develop-overview.md
+++ b/docs/develop/develop-overview.md
@@ -82,7 +82,7 @@ Script Lab is an add-in that enables you to explore the Office JavaScript API an
 
 The following one-minute video shows Script Lab in action.
 
-[![Short video that shows Script Lab running in Excel, Word, and PowerPoint.](../images/screenshot-wide-youtube.png 'Script Lab preview video.')](https://aka.ms/scriptlabvideo)
+[![Short video that shows Script Lab running in Excel, Word, and PowerPoint.](../images/screenshot-wide-youtube.png 'Script Lab preview video')](https://aka.ms/scriptlabvideo)
 
 For more information about Script Lab, see [Explore Office JavaScript APIs using Script Lab](../overview/explore-with-script-lab.md).
 

--- a/docs/overview/explore-with-script-lab.md
+++ b/docs/overview/explore-with-script-lab.md
@@ -17,7 +17,7 @@ Script Lab is a tool for anyone who wants to learn how to develop Office Add-ins
 
 Sounds good so far? Take a look at this one-minute video to see Script Lab in action.
 
-[![Preview video showing Script Lab running in Excel, Word, and PowerPoint.](../images/screenshot-wide-youtube.png 'Script Lab preview video.')](https://aka.ms/scriptlabvideo)
+[![Preview video showing Script Lab running in Excel, Word, and PowerPoint.](../images/screenshot-wide-youtube.png 'Script Lab preview video')](https://aka.ms/scriptlabvideo)
 
 ## Key features
 


### PR DESCRIPTION
Pretty simple fix to remove the period from the titles for the Script Lab videos.