### PR TITLE
[DevX] (Edge Debugger) Point links to current iteration of the Edge debugger extension

### DIFF
--- a/docs/excel/custom-functions-debugging.md
+++ b/docs/excel/custom-functions-debugging.md
@@ -1,7 +1,7 @@
 ---
 title: UI-less custom functions debugging
 description: Learn how to debug your Excel custom functions that don't use a task pane.
-ms.date: 07/08/2021
+ms.date: 01/07/2022
 ms.localizationpriority: medium
 ---
 
@@ -63,7 +63,7 @@ At this point, execution will stop on the line of code where you set the breakpo
 
 ## Use the VS Code debugger for Excel in Microsoft Edge
 
-You can use VS Code to debug UI-less custom functions in Excel on the Microsoft Edge browser. To use VS Code with Microsoft Edge, you must install the [Debugger for Microsoft Edge](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-edge) extension.
+You can use VS Code to debug UI-less custom functions in Excel on the Microsoft Edge browser. To use VS Code with Microsoft Edge, you must install the [Microsoft Edge DevTools extension for Visual Studio Code](/microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension).
 
 ### Run your add-in from VS Code
 

--- a/docs/testing/debug-desktop-using-edge-chromium.md
+++ b/docs/testing/debug-desktop-using-edge-chromium.md
@@ -1,12 +1,12 @@
 ---
 title: Debug add-ins on Windows using Visual Studio Code and Microsoft Edge WebView2 (Chromium-based)
 description: 'Learn how to debug Office Add-ins that use Microsoft Edge WebView2 (Chromium-based) by using the Debugger for Microsoft Edge extension in VS Code.'
-ms.date: 11/09/2021
+ms.date: 01/07/2022
 ms.localizationpriority: high
 ---
 # Debug add-ins on Windows using Visual Studio Code and Microsoft Edge WebView2 (Chromium-based)
 
-Office Add-ins running on Windows can use the Debugger for Microsoft Edge extension in Visual Studio Code to debug against the Edge Chromium WebView2 runtime. 
+Office Add-ins running on Windows can use the Debugger for Microsoft Edge extension in Visual Studio Code to debug against the Edge Chromium WebView2 runtime.
 
 > [!TIP]
 > If you cannot, or don't wish to, debug using tools built into Visual Studio Code; or you are encountering a problem that only occurs when the add-in is run outside Visual Studio Code, you can debug Edge Chromium WebView2 runtime by using the Edge (Chromium-based) developer tools as described in [Debug add-ins using developer tools for Microsoft Edge WebView2](debug-add-ins-using-devtools-edge-chromium.md).
@@ -29,11 +29,11 @@ Office Add-ins running on Windows can use the Debugger for Microsoft Edge extens
    > npx office-addin-debugging start <your manifest path>
    > ```
 
-1. Open your project in VS Code. Within VS Code, select **Ctrl+Shift+X** to open the Extensions bar. Search for the "Debugger for Microsoft Edge" extension and install it.
+1. Open your project in VS Code. Within VS Code, select **Ctrl+Shift+X** to open the Extensions bar. Search for the "[Microsoft Edge DevTools](/microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension)" extension and install it.
 
-1. Next, choose  **View > Run** or enter **Ctrl+Shift+D** to switch to debug view.
+1. Next, choose  **View > Run** or enter **Ctrl+Shift+D** to switch to debug view.
 
-1. From the **RUN AND DEBUG** options, choose the Edge Chromium option for your host application, such as **Excel Desktop (Edge Chromium)**. Select **F5** or choose **Run > Start Debugging** from the menu to begin debugging. This action automatically launches a local server in a Node window to host your add-in and then automatically opens the host application, such as Excel or Word. This may take several seconds.
+1. From the **RUN AND DEBUG** options, choose the Edge Chromium option for your host application, such as **Excel Desktop (Edge Chromium)**. Select **F5** or choose **Run > Start Debugging** from the menu to begin debugging. This action automatically launches a local server in a Node window to host your add-in and then automatically opens the host application, such as Excel or Word. This may take several seconds.
 
 1. In the host application, your add-in is now ready to use. Select **Show Taskpane** or run any other add-in command. A dialog box will appear, reading:
 


### PR DESCRIPTION
We have a broken link pointing to "https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-edge". This PR That extension no longer seems to exist, so the original link has been replaced with a link to what appears to be the new iteration of that extension. The PR also adjusts another indirect reference to that extension.