### PR TITLE
[OneNote] (quickstart) Update OneNote quick start with sideloading guidance

### DIFF
--- a/docs/quickstarts/onenote-quickstart.md
+++ b/docs/quickstarts/onenote-quickstart.md
@@ -45,7 +45,7 @@ In your code editor, open the file **./src/taskpane/taskpane.js** and add the fo
 
 ```js
 try {
-    await OneNote.run(async context => {
+    await OneNote.run(async (context) => {
 
         // Get the current page.
         var page = context.application.getActivePage();

--- a/docs/quickstarts/onenote-quickstart.md
+++ b/docs/quickstarts/onenote-quickstart.md
@@ -1,7 +1,7 @@
 ---
 title: Build your first OneNote task pane add-in
 description: Learn how to build a simple OneNote task pane add-in by using the Office JS API.
-ms.date: 01/13/2022
+ms.date: 02/11/2022
 ms.prod: onenote
 ms.localizationpriority: high
 ---
@@ -57,8 +57,8 @@ try {
         var html = "<p><ol><li>Item #1</li><li>Item #2</li></ol></p>";
         page.addOutline(40, 90, html);
 
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync();
+        // Run the queued commands.
+        await context.sync();
     });
 } catch (error) {
     console.log("Error: " + error);
@@ -73,20 +73,13 @@ try {
     cd "My Office Add-in"
     ```
 
-1. Start the local web server and sideload your add-in.
+1. Start the local web server. Run the following command in the root directory of your project.
+
+    ```command&nbsp;line
+    npm run dev-server
+    ```
 
     [!INCLUDE [alert use https](../includes/alert-use-https.md)]
-
-    > [!TIP]
-    > If you're testing your add-in on Mac, run the following command before proceeding. When you run this command, the local web server starts.
-    >
-    > ```command&nbsp;line
-    > npm run dev-server
-    > ```
-
-    Run the following command in the root directory of your project. When you run this command, the local web server starts. Replace "{url}" with the URL of a OneNote document on your OneDrive or a SharePoint library to which you have permissions.
-
-    [!INCLUDE [npm start:web command syntax](../includes/start-web-sideload-instructions.md)]`
 
 1. In [OneNote on the web](https://www.onenote.com/notebooks), open a notebook and create a new page.
 

--- a/docs/testing/sideload-office-add-ins-for-testing.md
+++ b/docs/testing/sideload-office-add-ins-for-testing.md
@@ -1,7 +1,7 @@
 ---
 title: Sideload Office Add-ins in Office on the web for testing
 description: 'Test your Office Add-in in Office on the web by sideloading.'
-ms.date: 01/13/2022
+ms.date: 02/11/2022
 ms.localizationpriority: medium
 ---
 
@@ -55,7 +55,7 @@ This process is supported for **Excel**, **OneNote**, **PowerPoint**, and **Word
 
 This method doesn't use the command line and can be accomplished using commands only within the host application (such as Excel).
 
-1. Open [Office on the web](https://office.live.com/). Open a document in **Excel**, **Word**, or **PowerPoint**. On the **Insert** tab on the ribbon in the **Add-ins** section, choose **Office Add-ins**.
+1. Open [Office on the web](https://office.com/). Open a document in **Excel**, **OneNote**, **PowerPoint**, or  **Word**. On the **Insert** tab on the ribbon in the **Add-ins** section, choose **Office Add-ins**.
 
 1. On the **Office Add-ins** dialog, select the **MY ADD-INS** tab, choose **Manage My Add-ins**, and then **Upload My Add-in**.
 
@@ -76,7 +76,7 @@ This method doesn't use the command line and can be accomplished using commands 
 
 1. Sign in to your Microsoft 365 account.
 
-1. Open the App Launcher on the left end of the toolbar and select **Excel**, **Word**, or **PowerPoint**, and then create a new document.
+1. Open the App Launcher on the left end of the toolbar and select **Excel**, **PowerPoint**, or **Word**, and then create a new document.
 
 1. Steps 3 - 6 are the same as in the preceding section **Sideload an Office Add-in in Office on the web**.
 


### PR DESCRIPTION
Running `npm run start:web -- --document {url}` for a OneNote add-in generated by yo office causes the following error:

```
Debugging is being started...
App type: web
Starting the dev server... (webpack serve --mode development)
The dev server is running on port 3000. Process id: 27556
Sideloading the Office Add-in...
Error: Unable to start debugging.
Error: Unable to sideload the Office Add-in.
Error: Sideload to the OneNote web app is not supported.
```

This PR removes that instruction in favor of manually sideloading the add-in. It also updates the sideloading guidance to mention OneNote. It also updates the sample code to use the "modern JS" pattern of `async`/`await`.