### PR TITLE
[PowerPoint] (Shapes) Modernizing sample code for PPT, OneNote, and missed Excel samples

### DIFF
--- a/docs/excel/excel-add-ins-data-validation.md
+++ b/docs/excel/excel-add-ins-data-validation.md
@@ -55,7 +55,7 @@ await Excel.run(async (context) => {
             }
         };
 
-    return context.sync();
+    await context.sync();
 });
 ```
 

--- a/docs/excel/excel-add-ins-pivottables.md
+++ b/docs/excel/excel-add-ins-pivottables.md
@@ -400,7 +400,7 @@ await Excel.run(async (context) => {
     pivotTable.hierarchies.items.forEach(function (hierarchy) {
         hierarchy.fields.getItem(hierarchy.name).clearAllFilters();
     });
-    return context.sync();
+    await context.sync();
 });
 ```
 

--- a/docs/excel/excel-add-ins-worksheets.md
+++ b/docs/excel/excel-add-ins-worksheets.md
@@ -181,7 +181,7 @@ await Excel.run(async (context) => {
         console.log(`Deleting worksheet named "${lastSheet.name}"`);
         lastSheet.delete();
 
-        return context.sync();
+        await context.sync();
     }
 });
 ```

--- a/docs/onenote/onenote-add-ins-programming-overview.md
+++ b/docs/onenote/onenote-add-ins-programming-overview.md
@@ -50,8 +50,8 @@ Use the `Application` object to access OneNote objects such as **Notebook**, **S
 For example:
 
 ```js
-function getPagesInSection() {
-    OneNote.run(function (context) {
+async function getPagesInSection() {
+    await OneNote.run(async (context) => {
 
         // Get the pages in the current section.
         var pages = context.application.getActiveSection().pages;
@@ -60,23 +60,14 @@ function getPagesInSection() {
         pages.load('id,title');
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-
-                // Read the id and title of each page.
-                $.each(pages.items, function(index, page) {
-                    var pageId = page.id;
-                    var pageTitle = page.title;
-                    console.log(pageTitle + ': ' + pageId);
-                });
-            })
-            .catch(function (error) {
-                app.showNotification("Error: " + error);
-                console.log("Error: " + error);
-                if (error instanceof OfficeExtension.Error) {
-                    console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                }
-            });
+        await context.sync();
+            
+        // Read the id and title of each page.
+        $.each(pages.items, function(index, page) {
+            var pageId = page.id;
+            var pageTitle = page.title;
+            console.log(pageTitle + ': ' + pageId);
+        });
     });
 }
 ```

--- a/docs/onenote/onenote-add-ins-programming-overview.md
+++ b/docs/onenote/onenote-add-ins-programming-overview.md
@@ -54,7 +54,7 @@ async function getPagesInSection() {
     await OneNote.run(async (context) => {
 
         // Get the pages in the current section.
-        var pages = context.application.getActiveSection().pages;
+        const pages = context.application.getActiveSection().pages;
 
         // Queue a command to load the id and title for each page.
         pages.load('id,title');
@@ -64,8 +64,8 @@ async function getPagesInSection() {
             
         // Read the id and title of each page.
         $.each(pages.items, function(index, page) {
-            var pageId = page.id;
-            var pageTitle = page.title;
+            let pageId = page.id;
+            let pageTitle = page.title;
             console.log(pageTitle + ': ' + pageId);
         });
     });

--- a/docs/powerpoint/shapes.md
+++ b/docs/powerpoint/shapes.md
@@ -25,8 +25,8 @@ The following code sample creates a rectangle named **"Square"** that is positio
 // This sample creates a rectangle positioned 100 points from the top and left sides
 // of the slide and is 150x150 points. The shape is put on the first slide.
 await PowerPoint.run(async (context) => {
-    let shapes = context.presentation.slides.getItemAt(0).shapes;
-    let rectangle = shapes.addGeometricShape(PowerPoint.GeometricShapeType.rectangle);
+    const shapes = context.presentation.slides.getItemAt(0).shapes;
+    const rectangle = shapes.addGeometricShape(PowerPoint.GeometricShapeType.rectangle);
     rectangle.left = 100;
     rectangle.top = 100;
     rectangle.height = 150;
@@ -48,8 +48,8 @@ The following code sample creates a straight line on the slide.
 ```js
 // This sample creates a straight line on the first slide.
 await PowerPoint.run(async (context) => {
-    let shapes = context.presentation.slides.getItemAt(0).shapes;
-    let line = shapes.addLine(Excel.ConnectorType.straight, {left: 200, top: 50, height: 300, width: 150});
+    const shapes = context.presentation.slides.getItemAt(0).shapes;
+    const line = shapes.addLine(Excel.ConnectorType.straight, {left: 200, top: 50, height: 300, width: 150});
     line.name = "StraightLine";
     await context.sync();
 });
@@ -64,8 +64,8 @@ The following code sample shows how to create a text box on the first slide.
 ```js
 // This sample creates a text box with the text "Hello!" and sizes it appropriately.
 await PowerPoint.run(async (context) => {
-    let shapes = context.presentation.slides.getItemAt(0).shapes;
-    let textbox = shapes.addTextBox("Hello!");
+    const shapes = context.presentation.slides.getItemAt(0).shapes;
+    const textbox = shapes.addTextBox("Hello!");
     textbox.left = 100;
     textbox.top = 100;
     textbox.height = 300;
@@ -86,10 +86,11 @@ Geometric shapes can contain text. Shapes have a `textFrame` property of type [T
 The following code sample creates a geometric shape named **"Braces"** with the text **"Shape text"**. It also adjusts the shape and text colors, as well as sets the text's vertical alignment to the center.
 
 ```js
-// This sample creates a light blue rectangle with braces ("{}") on the left and right ends and adds the purple text "Shape text" to the center.
+// This sample creates a light blue rectangle with braces ("{}") on the left and right ends
+// and adds the purple text "Shape text" to the center.
 await PowerPoint.run(async (context) => {
-    let shapes = context.presentation.slides.getItemAt(0).shapes;
-    let braces = shapes.addGeometricShape(PowerPoint.GeometricShapeType.bracePair);
+    const shapes = context.presentation.slides.getItemAt(0).shapes;
+    const braces = shapes.addGeometricShape(PowerPoint.GeometricShapeType.bracePair);
     braces.left = 100;
     braces.top = 400;
     braces.height = 50;
@@ -112,8 +113,8 @@ The following code sample shows how to delete shapes.
 ```js
 await PowerPoint.run(async (context) => {
     // Delete all shapes from the first slide.
-    let sheet = context.presentation.slides.getItemAt(0);
-    let shapes = sheet.shapes;
+    const sheet = context.presentation.slides.getItemAt(0);
+    const shapes = sheet.shapes;
 
     // Load all the shapes in the collection without loading their properties.
     shapes.load("items/$none");

--- a/docs/powerpoint/shapes.md
+++ b/docs/powerpoint/shapes.md
@@ -1,7 +1,7 @@
 ---
 title: Work with shapes using the PowerPoint JavaScript API
 description: 'Learn how to add, remove, and format shapes on PowerPoint slides.'
-ms.date: 10/06/2021
+ms.date: 02/22/2022
 ms.localizationpriority: medium
 ---
 
@@ -24,15 +24,15 @@ The following code sample creates a rectangle named **"Square"** that is positio
 ```js
 // This sample creates a rectangle positioned 100 points from the top and left sides
 // of the slide and is 150x150 points. The shape is put on the first slide.
-PowerPoint.run(function (context) {
-    var shapes = context.presentation.slides.getItemAt(0).shapes;
-    var rectangle = shapes.addGeometricShape(PowerPoint.GeometricShapeType.rectangle);
+await PowerPoint.run(async (context) => {
+    let shapes = context.presentation.slides.getItemAt(0).shapes;
+    let rectangle = shapes.addGeometricShape(PowerPoint.GeometricShapeType.rectangle);
     rectangle.left = 100;
     rectangle.top = 100;
     rectangle.height = 150;
     rectangle.width = 150;
     rectangle.name = "Square";
-    return context.sync();
+    await context.sync();
 });
 ```
 
@@ -47,11 +47,11 @@ The following code sample creates a straight line on the slide.
 
 ```js
 // This sample creates a straight line on the first slide.
-PowerPoint.run(function (context) {
-    var shapes = context.presentation.slides.getItemAt(0).shapes;
-    var line = shapes.addLine(Excel.ConnectorType.straight, {left: 200, top: 50, height: 300, width: 150});
+await PowerPoint.run(async (context) => {
+    let shapes = context.presentation.slides.getItemAt(0).shapes;
+    let line = shapes.addLine(Excel.ConnectorType.straight, {left: 200, top: 50, height: 300, width: 150});
     line.name = "StraightLine";
-    return context.sync();
+    await context.sync();
 });
 ```
 
@@ -63,15 +63,15 @@ The following code sample shows how to create a text box on the first slide.
 
 ```js
 // This sample creates a text box with the text "Hello!" and sizes it appropriately.
-PowerPoint.run(function (context) {
-    var shapes = context.presentation.slides.getItemAt(0).shapes;
-    var textbox = shapes.addTextBox("Hello!");
+await PowerPoint.run(async (context) => {
+    let shapes = context.presentation.slides.getItemAt(0).shapes;
+    let textbox = shapes.addTextBox("Hello!");
     textbox.left = 100;
     textbox.top = 100;
     textbox.height = 300;
     textbox.width = 450;
     textbox.name = "Textbox";
-    return context.sync();
+    await context.sync();
 });
 ```
 
@@ -87,9 +87,9 @@ The following code sample creates a geometric shape named **"Braces"** with the 
 
 ```js
 // This sample creates a light blue rectangle with braces ("{}") on the left and right ends and adds the purple text "Shape text" to the center.
-PowerPoint.run(function (context) {
-    var shapes = context.presentation.slides.getItemAt(0).shapes;
-    var braces = shapes.addGeometricShape(PowerPoint.GeometricShapeType.bracePair);
+await PowerPoint.run(async (context) => {
+    let shapes = context.presentation.slides.getItemAt(0).shapes;
+    let braces = shapes.addGeometricShape(PowerPoint.GeometricShapeType.bracePair);
     braces.left = 100;
     braces.top = 400;
     braces.height = 50;
@@ -99,7 +99,7 @@ PowerPoint.run(function (context) {
     braces.textFrame.textRange.text = "Shape text";
     braces.textFrame.textRange.font.color = "purple";
     braces.textFrame.verticalAlignment = PowerPoint.TextVerticalAlignment.middleCentered;
-    return context.sync();
+    await context.sync();
 });
 ```
 
@@ -110,20 +110,18 @@ Shapes are removed from the slide with the `Shape` object's `delete` method.
 The following code sample shows how to delete shapes.
 
 ```js
-PowerPoint.run(function (context) {
+await PowerPoint.run(async (context) => {
     // Delete all shapes from the first slide.
-    var sheet = context.presentation.slides.getItemAt(0);
-    var shapes = sheet.shapes;
+    let sheet = context.presentation.slides.getItemAt(0);
+    let shapes = sheet.shapes;
 
     // Load all the shapes in the collection without loading their properties.
     shapes.load("items/$none");
-    return context.sync()
-        .then(function () {
-            shapes.items.forEach(function (shape) {
-                shape.delete()
-            });
-            return context.sync();
-        })
-       .catch(errorHandlerFunction);
+    await context.sync();
+        
+    shapes.items.forEach(function (shape) {
+        shape.delete();
+    });
+    await context.sync();
 });
 ```


### PR DESCRIPTION
Part of [this internal work item](https://office.visualstudio.com/OC/_workitems/edit/2747466/) and related to #3254. 

This PR changes more of the samples to use the `async`/`await` pattern to reflect modern JS practices. 