### PR TITLE
[Word] (Samples) Updating JS patterns in Word articles

### DIFF
--- a/docs/quickstarts/word-quickstart.md
+++ b/docs/quickstarts/word-quickstart.md
@@ -163,11 +163,11 @@ Congratulations, you've successfully created a Word task pane add-in! Next, lear
             await Word.run(async (context) => {
 
                 // Create a proxy object for the document.
-                let thisDocument = context.document;
+                const thisDocument = context.document;
 
                 // Queue a command to get the current selection.
                 // Create a proxy range object for the selection.
-                let range = thisDocument.getSelection();
+                const range = thisDocument.getSelection();
 
                 // Queue a command to replace the selected text.
                 range.insertText('"Hitch your wagon to a star."\n', Word.InsertLocation.replace);
@@ -189,7 +189,7 @@ Congratulations, you've successfully created a Word task pane add-in! Next, lear
             await Word.run(async (context) => {
 
                 // Create a proxy object for the document body.
-                let body = context.document.body;
+                const body = context.document.body;
 
                 // Queue a command to insert text at the start of the document body.
                 body.insertText('"Knowledge is of no value unless you put it into practice."\n', Word.InsertLocation.start);
@@ -211,7 +211,7 @@ Congratulations, you've successfully created a Word task pane add-in! Next, lear
             await Word.run(async (context) => {
 
                 // Create a proxy object for the document body.
-                let body = context.document.body;
+                const body = context.document.body;
 
                 // Queue a command to insert text at the end of the document body.
                 body.insertText('"To know the road ahead, ask those coming back."\n', Word.InsertLocation.end);

--- a/docs/quickstarts/word-quickstart.md
+++ b/docs/quickstarts/word-quickstart.md
@@ -176,7 +176,7 @@ Congratulations, you've successfully created a Word task pane add-in! Next, lear
                 // and return a promise to indicate task completion.
                 await context.sync();
                 console.log('Added a quote from Ralph Waldo Emerson.');
-            });
+            })
             .catch(function (error) {
                 console.log('Error: ' + JSON.stringify(error));
                 if (error instanceof OfficeExtension.Error) {
@@ -198,7 +198,7 @@ Congratulations, you've successfully created a Word task pane add-in! Next, lear
                 // and return a promise to indicate task completion.
                 await context.sync();
                 console.log('Added a quote from Anton Chekhov.');
-            });
+            })
             .catch(function (error) {
                 console.log('Error: ' + JSON.stringify(error));
                 if (error instanceof OfficeExtension.Error) {
@@ -220,7 +220,7 @@ Congratulations, you've successfully created a Word task pane add-in! Next, lear
                 // and return a promise to indicate task completion.
                 await context.sync();
                 console.log('Added a quote from a Chinese proverb.');
-            });
+            })
             .catch(function (error) {
                 console.log('Error: ' + JSON.stringify(error));
                 if (error instanceof OfficeExtension.Error) {
@@ -284,7 +284,7 @@ Congratulations, you've successfully created a Word task pane add-in! Next, lear
 
 ### Try it out
 
-1. Using Visual Studio, test the newly created Word add-in by pressing **F5** or choosing the **Start** button to launch Word with the **Show Taskpane** add-in button displayed in the ribbon. The add-in will be hosted locally on IIS.
+1. Using Visual Studio, test the newly created Word add-in by pressing **F5** or choosing **Debug** > **Start Debugging** to launch Word with the **Show Taskpane** add-in button displayed in the ribbon. The add-in will be hosted locally on IIS.
 
 2. In Word, choose the **Home** tab, and then choose the **Show Taskpane** button in the ribbon to open the add-in task pane. (If you are using the one-time purchase version of Office, instead of the Microsoft 365 version, then custom buttons are not supported. Instead, the task pane will open immediately.)
 

--- a/docs/quickstarts/word-quickstart.md
+++ b/docs/quickstarts/word-quickstart.md
@@ -1,7 +1,7 @@
 ---
 title: Build your first Word task pane add-in
 description: Learn how to build a simple Word task pane add-in by using the Office JS API.
-ms.date: 01/13/2022
+ms.date: 02/23/2022
 ms.prod: word
 ms.localizationpriority: high
 ---
@@ -147,9 +147,9 @@ Congratulations, you've successfully created a Word task pane add-in! Next, lear
                 // Use this to check whether the API is supported in the Word client.
                 if (Office.context.requirements.isSetSupported('WordApi', '1.1')) {
                     // Do something that is only available via the new APIs
-                    $('#emerson').click(insertEmersonQuoteAtSelection);
-                    $('#checkhov').click(insertChekhovQuoteAtTheBeginning);
-                    $('#proverb').click(insertChineseProverbAtTheEnd);
+                    $('#emerson').click(() => tryCatch(insertEmersonQuoteAtSelection));
+                    $('#checkhov').click(() => tryCatch(insertChekhovQuoteAtTheBeginning));
+                    $('#proverb').click(() => tryCatch(insertChineseProverbAtTheEnd));
                     $('#supportedVersion').html('This code is using Word 2016 or later.');
                 }
                 else {
@@ -159,77 +159,68 @@ Congratulations, you've successfully created a Word task pane add-in! Next, lear
             });
         });
 
-        function insertEmersonQuoteAtSelection() {
-            Word.run(function (context) {
+        async function insertEmersonQuoteAtSelection() {
+            await Word.run(async (context) => {
 
                 // Create a proxy object for the document.
-                var thisDocument = context.document;
+                let thisDocument = context.document;
 
                 // Queue a command to get the current selection.
                 // Create a proxy range object for the selection.
-                var range = thisDocument.getSelection();
+                let range = thisDocument.getSelection();
 
                 // Queue a command to replace the selected text.
                 range.insertText('"Hitch your wagon to a star."\n', Word.InsertLocation.replace);
 
                 // Synchronize the document state by executing the queued commands,
                 // and return a promise to indicate task completion.
-                return context.sync().then(function () {
-                    console.log('Added a quote from Ralph Waldo Emerson.');
-                });
-            })
-            .catch(function (error) {
-                console.log('Error: ' + JSON.stringify(error));
-                if (error instanceof OfficeExtension.Error) {
-                    console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-                }
+                await context.sync();
+                console.log('Added a quote from Ralph Waldo Emerson.');
             });
         }
 
-        function insertChekhovQuoteAtTheBeginning() {
-            Word.run(function (context) {
+        async function insertChekhovQuoteAtTheBeginning() {
+            await Word.run(async (context) => {
 
                 // Create a proxy object for the document body.
-                var body = context.document.body;
+                let body = context.document.body;
 
                 // Queue a command to insert text at the start of the document body.
                 body.insertText('"Knowledge is of no value unless you put it into practice."\n', Word.InsertLocation.start);
 
                 // Synchronize the document state by executing the queued commands,
                 // and return a promise to indicate task completion.
-                return context.sync().then(function () {
-                    console.log('Added a quote from Anton Chekhov.');
-                });
-            })
-            .catch(function (error) {
-                console.log('Error: ' + JSON.stringify(error));
-                if (error instanceof OfficeExtension.Error) {
-                    console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-                }
+                await context.sync();
+                console.log('Added a quote from Anton Chekhov.');
             });
         }
 
-        function insertChineseProverbAtTheEnd() {
-            Word.run(function (context) {
+        async function insertChineseProverbAtTheEnd() {
+            await Word.run(async (context) => {
 
                 // Create a proxy object for the document body.
-                var body = context.document.body;
+                let body = context.document.body;
 
                 // Queue a command to insert text at the end of the document body.
                 body.insertText('"To know the road ahead, ask those coming back."\n', Word.InsertLocation.end);
 
                 // Synchronize the document state by executing the queued commands,
                 // and return a promise to indicate task completion.
-                return context.sync().then(function () {
-                    console.log('Added a quote from a Chinese proverb.');
-                });
-            })
-            .catch(function (error) {
+                await context.sync();
+                console.log('Added a quote from a Chinese proverb.');
+            });
+        }
+
+        /** Default helper for invoking an action and handling errors. */
+        async function tryCatch(callback) {
+            try {
+                await callback();
+            } catch (error) {
                 console.log('Error: ' + JSON.stringify(error));
                 if (error instanceof OfficeExtension.Error) {
                     console.log('Debug info: ' + JSON.stringify(error.debugInfo));
                 }
-            });
+            }
         }
     })();
     ```

--- a/docs/quickstarts/word-quickstart.md
+++ b/docs/quickstarts/word-quickstart.md
@@ -147,9 +147,9 @@ Congratulations, you've successfully created a Word task pane add-in! Next, lear
                 // Use this to check whether the API is supported in the Word client.
                 if (Office.context.requirements.isSetSupported('WordApi', '1.1')) {
                     // Do something that is only available via the new APIs
-                    $('#emerson').click(() => tryCatch(insertEmersonQuoteAtSelection));
-                    $('#checkhov').click(() => tryCatch(insertChekhovQuoteAtTheBeginning));
-                    $('#proverb').click(() => tryCatch(insertChineseProverbAtTheEnd));
+                    $('#emerson').click(insertEmersonQuoteAtSelection);
+                    $('#checkhov').click(insertChekhovQuoteAtTheBeginning);
+                    $('#proverb').click(insertChineseProverbAtTheEnd);
                     $('#supportedVersion').html('This code is using Word 2016 or later.');
                 }
                 else {
@@ -177,6 +177,12 @@ Congratulations, you've successfully created a Word task pane add-in! Next, lear
                 await context.sync();
                 console.log('Added a quote from Ralph Waldo Emerson.');
             });
+            .catch(function (error) {
+                console.log('Error: ' + JSON.stringify(error));
+                if (error instanceof OfficeExtension.Error) {
+                    console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+                }
+            });
         }
 
         async function insertChekhovQuoteAtTheBeginning() {
@@ -192,6 +198,12 @@ Congratulations, you've successfully created a Word task pane add-in! Next, lear
                 // and return a promise to indicate task completion.
                 await context.sync();
                 console.log('Added a quote from Anton Chekhov.');
+            });
+            .catch(function (error) {
+                console.log('Error: ' + JSON.stringify(error));
+                if (error instanceof OfficeExtension.Error) {
+                    console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+                }
             });
         }
 
@@ -209,18 +221,12 @@ Congratulations, you've successfully created a Word task pane add-in! Next, lear
                 await context.sync();
                 console.log('Added a quote from a Chinese proverb.');
             });
-        }
-
-        /** Default helper for invoking an action and handling errors. */
-        async function tryCatch(callback) {
-            try {
-                await callback();
-            } catch (error) {
+            .catch(function (error) {
                 console.log('Error: ' + JSON.stringify(error));
                 if (error instanceof OfficeExtension.Error) {
                     console.log('Debug info: ' + JSON.stringify(error.debugInfo));
                 }
-            }
+            });
         }
     })();
     ```

--- a/docs/tutorials/word-tutorial.md
+++ b/docs/tutorials/word-tutorial.md
@@ -401,7 +401,7 @@ In all previous functions in this series of tutorials, you queued commands to *w
 
 These steps must be completed whenever your code needs to *read* information from the Office document.
 
-1. Within the `insertTextIntoRange()` function, replace `TODO3` with the following code.
+1. Within the `insertTextIntoRange()` function, replace `TODO2` with the following code.
   
     ```js
     originalRange.load("text");

--- a/docs/tutorials/word-tutorial.md
+++ b/docs/tutorials/word-tutorial.md
@@ -91,12 +91,12 @@ In this step of the tutorial, you'll programmatically test that your add-in supp
    - The `Word.run` is followed by a `catch` block. This is a best practice that you should always follow.
 
     ```js
-    function insertParagraph() {
-        Word.run(function (context) {
+    async function insertParagraph() {
+        await Word.run(async (context) => {
 
             // TODO1: Queue commands to insert a paragraph into the document.
 
-            return context.sync();
+            await context.sync();
         })
         .catch(function (error) {
             console.log("Error: " + error);
@@ -114,7 +114,7 @@ In this step of the tutorial, you'll programmatically test that your add-in supp
    - The second parameter is the location within the body where the paragraph will be inserted. Other options for insert paragraph, when the parent object is the body, are "End" and "Replace".
 
     ```js
-    var docBody = context.document.body;
+    const docBody = context.document.body;
     docBody.insertParagraph("Office has several versions, including Office 2016, Microsoft 365 subscription, and Office on the web.",
                             "Start");
     ```
@@ -181,12 +181,12 @@ In this step of the tutorial, you'll apply a built-in style to text, apply a cus
 1. Add the following function to the end of the file.
 
     ```js
-    function applyStyle() {
-        Word.run(function (context) {
+    async function applyStyle() {
+        await Word.run(async (context) => {
 
             // TODO1: Queue commands to style text.
 
-            return context.sync();
+            await context.sync();
         })
         .catch(function (error) {
             console.log("Error: " + error);
@@ -200,7 +200,7 @@ In this step of the tutorial, you'll apply a built-in style to text, apply a cus
 1. Within the `applyStyle()` function, replace `TODO1` with the following code. Note that the code applies a style to a paragraph, but styles can also be applied to ranges of text.
 
     ```js
-    var firstParagraph = context.document.body.paragraphs.getFirst();
+    const firstParagraph = context.document.body.paragraphs.getFirst();
     firstParagraph.styleBuiltIn = Word.Style.intenseReference;
     ```
 
@@ -225,12 +225,12 @@ In this step of the tutorial, you'll apply a built-in style to text, apply a cus
 1. Add the following function to the end of the file.
 
     ```js
-    function applyCustomStyle() {
-        Word.run(function (context) {
+    async function applyCustomStyle() {
+        await Word.run(async (context) => {
 
             // TODO1: Queue commands to apply the custom style.
 
-            return context.sync();
+            await context.sync();
         })
         .catch(function (error) {
             console.log("Error: " + error);
@@ -244,7 +244,7 @@ In this step of the tutorial, you'll apply a built-in style to text, apply a cus
 1. Within the `applyCustomStyle()` function, replace `TODO1` with the following code. Note that the code applies a custom style that does not exist yet. You'll create a style with the name **MyCustomStyle** in the [Test the add-in](#test-the-add-in-1) step.
 
     ```js
-    var lastParagraph = context.document.body.paragraphs.getLast();
+    const lastParagraph = context.document.body.paragraphs.getLast();
     lastParagraph.style = "MyCustomStyle";
     ```
 
@@ -271,12 +271,12 @@ In this step of the tutorial, you'll apply a built-in style to text, apply a cus
 1. Add the following function to the end of the file.
 
     ```js
-    function changeFont() {
-        Word.run(function (context) {
+    async function changeFont() {
+        await Word.run(async (context) => {
 
             // TODO1: Queue commands to apply a different font.
 
-            return context.sync();
+            await context.sync();
         })
         .catch(function (error) {
             console.log("Error: " + error);
@@ -290,7 +290,7 @@ In this step of the tutorial, you'll apply a built-in style to text, apply a cus
 1. Within the `changeFont()` function, replace `TODO1` with the following code. Note that the code gets a reference to the second paragraph by using the `ParagraphCollection.getFirst` method chained to the `Paragraph.getNext` method.
 
     ```js
-    var secondParagraph = context.document.body.paragraphs.getFirst().getNext();
+    const secondParagraph = context.document.body.paragraphs.getFirst().getNext();
     secondParagraph.font.set({
             name: "Courier New",
             bold: true,
@@ -343,8 +343,8 @@ In this step of the tutorial, you'll add text inside and outside of selected ran
 1. Add the following function to the end of the file.
 
     ```js
-    function insertTextIntoRange() {
-        Word.run(function (context) {
+    async function insertTextIntoRange() {
+        await Word.run(async (context) => {
 
             // TODO1: Queue commands to insert text into a selected range.
 
@@ -354,7 +354,7 @@ In this step of the tutorial, you'll add text inside and outside of selected ran
             // TODO3: Queue commands to repeat the text of the original
             //        range at the end of the document.
 
-            return context.sync();
+            await context.sync();
         })
         .catch(function (error) {
             console.log("Error: " + error);
@@ -378,8 +378,8 @@ In this step of the tutorial, you'll add text inside and outside of selected ran
    - You saw in an earlier stage of the tutorial that the insert* methods of the body object do not have the "Before" and "After" options. This is because you can't put content outside of the document's body.
 
     ```js
-    var doc = context.document;
-    var originalRange = doc.getSelection();
+    const doc = context.document;
+    const originalRange = doc.getSelection();
     originalRange.insertText(" (C2R)", "End");
     ```
 
@@ -401,49 +401,37 @@ In all previous functions in this series of tutorials, you queued commands to *w
 
 These steps must be completed whenever your code needs to *read* information from the Office document.
 
-1. Within the `insertTextIntoRange()` function, replace `TODO2` with the following code.
+1. Within the `insertTextIntoRange()` function, replace `TODO3` with the following code.
   
     ```js
     originalRange.load("text");
-    return context.sync()
-        .then(function() {
-            // TODO4: Move the doc.body.insertParagraph line here.
-        })
-        // TODO5: Move the final call of context.sync here and ensure
-        //        that it does not run until the insertParagraph has
-        //        been queued.
-    ```
+    await context.sync();
 
-1. You can't have two `return` statements in the same unbranching code path, so delete the final line `return context.sync();` at the end of the `Word.run`. You'll add a new final `context.sync` later in this tutorial.
+    // TODO4: Move the doc.body.insertParagraph line here.
+
+    // TODO5: Move the final call of context.sync here and ensure
+    //        that it does not run until the insertParagraph has
+    //        been queued.
+    ```
 
 1. Cut the `doc.body.insertParagraph` line and paste in place of `TODO4`.
-
-1. Replace `TODO5` with the following code. Note:
-
-   - Passing the `sync` method to a `then` function ensures that it does not run until the `insertParagraph` logic has been queued.
-
-   - The `then` method invokes whatever function is passed to it, and you don't want `sync` to be invoked twice, so omit the "()" from the end of context.sync.
-
-    ```js
-    .then(context.sync);
-    ```
 
 When you're done, the entire function should look like the following:
 
 ```js
-function insertTextIntoRange() {
-    Word.run(function (context) {
+async function insertTextIntoRange() {
+    await Word.run(async (context) => {
 
-        var doc = context.document;
-        var originalRange = doc.getSelection();
+        const doc = context.document;
+        const originalRange = doc.getSelection();
         originalRange.insertText(" (C2R)", "End");
 
         originalRange.load("text");
-        return context.sync()
-            .then(function() {
-                doc.body.insertParagraph("Current text of original range: " + originalRange.text, "End");
-            })
-            .then(context.sync);
+        await context.sync();
+
+        doc.body.insertParagraph("Original range: " + originalRange.text, "End");
+
+        await context.sync();
     })
     .catch(function (error) {
         console.log("Error: " + error);
@@ -475,8 +463,8 @@ function insertTextIntoRange() {
 1. Add the following function to the end of the file.
 
     ```js
-    function insertTextBeforeRange() {
-        Word.run(function (context) {
+    async function insertTextBeforeRange() {
+        await Word.run(async (context) => {
 
             // TODO1: Queue commands to insert a new range before the
             //        selected range.
@@ -503,8 +491,8 @@ function insertTextIntoRange() {
    - The second parameter specifies where in the range the additional text should be inserted. For more details about the location options, see the previous discussion of the `insertTextIntoRange` function.
 
     ```js
-    var doc = context.document;
-    var originalRange = doc.getSelection();
+    const doc = context.document;
+    const originalRange = doc.getSelection();
     originalRange.insertText("Office 2019, ", "Before");
     ```
 
@@ -512,14 +500,13 @@ function insertTextIntoRange() {
 
      ```js
     originalRange.load("text");
-    return context.sync()
-        .then(function() {
-            // TODO3: Queue commands to insert the original range as a
-            //        paragraph at the end of the document.
-        })
-        // TODO4: Make a final call of context.sync here and ensure
-        //        that it does not run until the insertParagraph has
-        //        been queued.
+    await context.sync();
+
+    // TODO3: Queue commands to insert the original range as a
+    //        paragraph at the end of the document.
+
+    // TODO4: Make a final call of context.sync here and ensure
+    //        that it runs after the insertParagraph has been queued.
     ```
 
 1. Replace `TODO3` with the following code. This new paragraph will demonstrate the fact that the new text is ***not*** part of the original selected range. The original range still has only the text it had when it was selected.
@@ -531,7 +518,7 @@ function insertTextIntoRange() {
 1. Replace `TODO4` with the following code.
 
     ```js
-    .then(context.sync);
+    await context.sync();
     ```
 
 ### Replace the text of a range
@@ -555,12 +542,12 @@ function insertTextIntoRange() {
 1. Add the following function to the end of the file.
 
     ```js
-    function replaceText() {
-        Word.run(function (context) {
+    async function replaceText() {
+        await Word.run(async (context) => {
 
             // TODO1: Queue commands to replace the text.
 
-            return context.sync();
+            await context.sync();
         })
         .catch(function (error) {
             console.log("Error: " + error);
@@ -574,8 +561,8 @@ function insertTextIntoRange() {
 1. Within the `replaceText()` function, replace `TODO1` with the following code. Note that the method is intended to replace the string "several" with the string "many". It makes a simplifying assumption that the string is present and the user has selected it.
 
     ```js
-    var doc = context.document;
-    var originalRange = doc.getSelection();
+    const doc = context.document;
+    const originalRange = doc.getSelection();
     originalRange.insertText("many", "Replace");
     ```
 
@@ -647,12 +634,12 @@ Complete the following steps to define the image that you'll insert into the doc
 1. Add the following function to the end of the file.
 
     ```js
-    function insertImage() {
-        Word.run(function (context) {
+    async function insertImage() {
+        await Word.run(async (context) => {
 
             // TODO1: Queue commands to insert an image.
 
-            return context.sync();
+            await context.sync();
         })
         .catch(function (error) {
             console.log("Error: " + error);
@@ -690,12 +677,12 @@ Complete the following steps to define the image that you'll insert into the doc
 1. Add the following function to the end of the file.
 
     ```js
-    function insertHTML() {
-        Word.run(function (context) {
+    async function insertHTML() {
+        await Word.run(async (context) => {
 
             // TODO1: Queue commands to insert a string of HTML.
 
-            return context.sync();
+            await context.sync();
         })
         .catch(function (error) {
             console.log("Error: " + error);
@@ -713,7 +700,7 @@ Complete the following steps to define the image that you'll insert into the doc
    - The second line inserts a string of HTML at the end of the paragraph; specifically two paragraphs, one formatted with Verdana font, the other with the default styling of the Word document. (As you saw in the `insertImage` method earlier, the `context.document.body` object also has the `insert*` methods.)
 
     ```js
-    var blankParagraph = context.document.body.paragraphs.getLast().insertParagraph("", "After");
+    const blankParagraph = context.document.body.paragraphs.getLast().insertParagraph("", "After");
     blankParagraph.insertHtml('<p style="font-family: verdana;">Inserted HTML.</p><p>Another paragraph</p>', "End");
     ```
 
@@ -738,15 +725,15 @@ Complete the following steps to define the image that you'll insert into the doc
 1. Add the following function to the end of the file.
 
     ```js
-    function insertTable() {
-        Word.run(function (context) {
+    async function insertTable() {
+        await Word.run(async (context) => {
 
             // TODO1: Queue commands to get a reference to the paragraph
             //        that will proceed the table.
 
             // TODO2: Queue commands to create a table and populate it with data.
 
-            return context.sync();
+            await context.sync();
         })
         .catch(function (error) {
             console.log("Error: " + error);
@@ -760,7 +747,7 @@ Complete the following steps to define the image that you'll insert into the doc
 1. Within the `insertTable()` function, replace `TODO1` with the following code. Note that this line uses the `ParagraphCollection.getFirst` method to get a reference ot the first paragraph and then uses the `Paragraph.getNext` method to get a reference to the second paragraph.
 
     ```js
-    var secondParagraph = context.document.body.paragraphs.getFirst().getNext();
+    const secondParagraph = context.document.body.paragraphs.getFirst().getNext();
     ```
 
 1. Within the `insertTable()` function, replace `TODO2` with the following code. Note:
@@ -774,7 +761,7 @@ Complete the following steps to define the image that you'll insert into the doc
    - The table will have plain default styling, but the `insertTable` method returns a `Table` object with many members, some of which are used to style the table.
 
     ```js
-    var tableData = [
+    const tableData = [
             ["Name", "ID", "Birth City"],
             ["Bob", "434", "Chicago"],
             ["Sue", "719", "Havana"],
@@ -830,12 +817,12 @@ In this step of the tutorial, you'll learn how to create Rich Text content contr
 1. Add the following function to the end of the file.
 
     ```js
-    function createContentControl() {
-        Word.run(function (context) {
+    async function createContentControl() {
+        await Word.run(async (context) => {
 
             // TODO1: Queue commands to create a content control.
 
-            return context.sync();
+            await context.sync();
         })
         .catch(function (error) {
             console.log("Error: " + error);
@@ -859,8 +846,8 @@ In this step of the tutorial, you'll learn how to create Rich Text content contr
    - The `ContentControl.color` property specifies the color of the tags or the border of the bounding box.
 
     ```js
-    var serviceNameRange = context.document.getSelection();
-    var serviceNameContentControl = serviceNameRange.insertContentControl();
+    const serviceNameRange = context.document.getSelection();
+    const serviceNameContentControl = serviceNameRange.insertContentControl();
     serviceNameContentControl.title = "Service Name";
     serviceNameContentControl.tag = "serviceName";
     serviceNameContentControl.appearance = "Tags";
@@ -888,13 +875,13 @@ In this step of the tutorial, you'll learn how to create Rich Text content contr
 1. Add the following function to the end of the file.
 
     ```js
-    function replaceContentInControl() {
-        Word.run(function (context) {
+    async function replaceContentInControl() {
+        await Word.run(async (context) => {
 
             // TODO1: Queue commands to replace the text in the Service Name
             //        content control.
 
-            return context.sync();
+            await context.sync();
         })
         .catch(function (error) {
             console.log("Error: " + error);
@@ -910,7 +897,7 @@ In this step of the tutorial, you'll learn how to create Rich Text content contr
     - The `ContentControlCollection.getByTag` method returns a `ContentControlCollection` of all content controls of the specified tag. We use `getFirst` to get a reference to the desired control.
 
     ```js
-    var serviceNameContentControl = context.document.contentControls.getByTag("serviceName").getFirst();
+    const serviceNameContentControl = context.document.contentControls.getByTag("serviceName").getFirst();
     serviceNameContentControl.insertText("Fabrikam Online Productivity Suite", "Replace");
     ```
 

--- a/docs/word/search-option-guidance.md
+++ b/docs/word/search-option-guidance.md
@@ -1,6 +1,6 @@
 ---
 title: Use search options to find text in your Word add-in 
-description: 'Learn to use search options in your Word add-in'
+description: Learn to use search options in your Word add-in.
 ms.date: 02/24/2022
 ms.localizationpriority: medium
 ---

--- a/docs/word/search-option-guidance.md
+++ b/docs/word/search-option-guidance.md
@@ -1,7 +1,7 @@
 ---
 title: Use search options to find text in your Word add-in 
 description: 'Learn to use search options in your Word add-in'
-ms.date: 09/27/2019
+ms.date: 02/24/2022
 ms.localizationpriority: medium
 ---
 
@@ -44,7 +44,7 @@ The following table provides guidance around the Word JavaScript API's search wi
 
 ### Escaping the special characters
 
-Wildcard search is essentially the same as searching on a regular expression. There are special characters in regular expressions, including '[', ']', '(', ')', '{', '}', '\*', '?', '<', '>', '!', and '@'. If one of these characters is part of the literal string the code is searching for, then it needs to be escaped, so that Word knows it should be treated literally and not as part of the logic of the regular expression. To escape a character in the Word UI search, you would precede it with a '\' character, but to escape it programmatically, put it between '[]' characters. For example, '[\*]\*' searches for any string that begins with a '\*' followed by any number of other characters. 
+Wildcard search is essentially the same as searching on a regular expression. There are special characters in regular expressions, including '[', ']', '(', ')', '{', '}', '\*', '?', '<', '>', '!', and '@'. If one of these characters is part of the literal string the code is searching for, then it needs to be escaped, so that Word knows it should be treated literally and not as part of the logic of the regular expression. To escape a character in the Word UI search, you would precede it with a '\' character, but to escape it programmatically, put it between '[]' characters. For example, '[\*]\*' searches for any string that begins with a '\*' followed by any number of other characters.
 
 ## Examples
 
@@ -54,36 +54,27 @@ The following examples demonstrate common scenarios.
 
 ```js
 // Run a batch operation against the Word object model.
-Word.run(function (context) {
+await Word.run(async (context) => {
 
     // Queue a command to search the document and ignore punctuation.
-    var searchResults = context.document.body.search('video you', {ignorePunct: true});
+    const searchResults = context.document.body.search('video you', {ignorePunct: true});
 
     // Queue a command to load the search results and get the font property values.
     context.load(searchResults, 'font');
 
-    // Synchronize the document state by executing the queued commands,
-    // and return a promise to indicate task completion.
-    return context.sync().then(function () {
-        console.log('Found count: ' + searchResults.items.length);
+    // Synchronize the document state.
+    await context.sync();
+    console.log('Found count: ' + searchResults.items.length);
 
-        // Queue a set of commands to change the font for each found item.
-        for (var i = 0; i < searchResults.items.length; i++) {
-            searchResults.items[i].font.color = 'purple';
-            searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
-            searchResults.items[i].font.bold = true;
-        }
-
-        // Synchronize the document state by executing the queued commands,
-        // and return a promise to indicate task completion.
-        return context.sync();
-    });  
-})
-.catch(function (error) {
-    console.log('Error: ' + JSON.stringify(error));
-    if (error instanceof OfficeExtension.Error) {
-        console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+    // Queue a set of commands to change the font for each found item.
+    for (let i = 0; i < searchResults.items.length; i++) {
+        searchResults.items[i].font.color = 'purple';
+        searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
+        searchResults.items[i].font.bold = true;
     }
+
+    // Synchronize the document state.
+    await context.sync();
 });
 ```
 
@@ -91,36 +82,27 @@ Word.run(function (context) {
 
 ```js
 // Run a batch operation against the Word object model.
-Word.run(function (context) {
+await Word.run(async (context) => {
 
     // Queue a command to search the document based on a prefix.
-    var searchResults = context.document.body.search('vid', {matchPrefix: true});
+    const searchResults = context.document.body.search('vid', {matchPrefix: true});
 
     // Queue a command to load the search results and get the font property values.
     context.load(searchResults, 'font');
 
-    // Synchronize the document state by executing the queued commands,
-    // and return a promise to indicate task completion.
-    return context.sync().then(function () {
-        console.log('Found count: ' + searchResults.items.length);
+    // Synchronize the document state.
+    await context.sync();
+    console.log('Found count: ' + searchResults.items.length);
 
-        // Queue a set of commands to change the font for each found item.
-        for (var i = 0; i < searchResults.items.length; i++) {
-            searchResults.items[i].font.color = 'purple';
-            searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
-            searchResults.items[i].font.bold = true;
-        }
-
-        // Synchronize the document state by executing the queued commands,
-        // and return a promise to indicate task completion.
-        return context.sync();
-    });  
-})
-.catch(function (error) {
-    console.log('Error: ' + JSON.stringify(error));
-    if (error instanceof OfficeExtension.Error) {
-        console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+    // Queue a set of commands to change the font for each found item.
+    for (let i = 0; i < searchResults.items.length; i++) {
+        searchResults.items[i].font.color = 'purple';
+        searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
+        searchResults.items[i].font.bold = true;
     }
+
+    // Synchronize the document state.
+    await context.sync();
 });
 ```
 
@@ -128,36 +110,27 @@ Word.run(function (context) {
 
 ```js
 // Run a batch operation against the Word object model.
-Word.run(function (context) {
+await Word.run(async (context) => {
 
     // Queue a command to search the document for any string of characters after 'ly'.
-    var searchResults = context.document.body.search('ly', {matchSuffix: true});
+    const searchResults = context.document.body.search('ly', {matchSuffix: true});
 
     // Queue a command to load the search results and get the font property values.
     context.load(searchResults, 'font');
 
-    // Synchronize the document state by executing the queued commands,
-    // and return a promise to indicate task completion.
-    return context.sync().then(function () {
-        console.log('Found count: ' + searchResults.items.length);
+    // Synchronize the document state.
+    await context.sync();
+    console.log('Found count: ' + searchResults.items.length);
 
-        // Queue a set of commands to change the font for each found item.
-        for (var i = 0; i < searchResults.items.length; i++) {
-            searchResults.items[i].font.color = 'orange';
-            searchResults.items[i].font.highlightColor = 'black';
-            searchResults.items[i].font.bold = true;
-        }
-
-        // Synchronize the document state by executing the queued commands,
-        // and return a promise to indicate task completion.
-        return context.sync();
-    });  
-})
-.catch(function (error) {
-    console.log('Error: ' + JSON.stringify(error));
-    if (error instanceof OfficeExtension.Error) {
-        console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+    // Queue a set of commands to change the font for each found item.
+    for (let i = 0; i < searchResults.items.length; i++) {
+        searchResults.items[i].font.color = 'orange';
+        searchResults.items[i].font.highlightColor = 'black';
+        searchResults.items[i].font.bold = true;
     }
+
+    // Synchronize the document state .
+    await context.sync();
 });
 ```
 
@@ -165,37 +138,28 @@ Word.run(function (context) {
 
 ```js
 // Run a batch operation against the Word object model.
-Word.run(function (context) {
+await Word.run(async (context) => {
 
     // Queue a command to search the document with a wildcard
     // for any string of characters that starts with 'to' and ends with 'n'.
-    var searchResults = context.document.body.search('to*n', {matchWildcards: true});
+    const searchResults = context.document.body.search('to*n', {matchWildcards: true});
 
     // Queue a command to load the search results and get the font property values.
     context.load(searchResults, 'font');
 
-    // Synchronize the document state by executing the queued commands,
-    // and return a promise to indicate task completion.
-    return context.sync().then(function () {
-        console.log('Found count: ' + searchResults.items.length);
+    // Synchronize the document state.
+    await context.sync();
+    console.log('Found count: ' + searchResults.items.length);
 
-        // Queue a set of commands to change the font for each found item.
-        for (var i = 0; i < searchResults.items.length; i++) {
-            searchResults.items[i].font.color = 'purple';
-            searchResults.items[i].font.highlightColor = 'pink';
-            searchResults.items[i].font.bold = true;
-        }
-
-        // Synchronize the document state by executing the queued commands,
-        // and return a promise to indicate task completion.
-        return context.sync();
-    });  
-})
-.catch(function (error) {
-    console.log('Error: ' + JSON.stringify(error));
-    if (error instanceof OfficeExtension.Error) {
-        console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+    // Queue a set of commands to change the font for each found item.
+    for (let i = 0; i < searchResults.items.length; i++) {
+        searchResults.items[i].font.color = 'purple';
+        searchResults.items[i].font.highlightColor = 'pink';
+        searchResults.items[i].font.bold = true;
     }
+
+    // Synchronize the document state.
+    await context.sync();
 });
 ```
 

--- a/docs/word/word-add-ins-programming-overview.md
+++ b/docs/word/word-add-ins-programming-overview.md
@@ -1,7 +1,7 @@
 ---
 title: Word add-ins overview
 description: 'Learn the basics of Word Add-ins.'
-ms.date: 10/14/2020
+ms.date: 02/24/2022
 ms.topic: overview
 ms.custom: scenarios:getting-started
 ms.localizationpriority: high
@@ -24,13 +24,13 @@ The following figure shows an example of a Word add-in that runs in a task pane.
 The Word add-in (1) can send requests to the Word document (2) and can use JavaScript to access the paragraph object and update, delete, or move the paragraph. For example, the following code shows how to append a new sentence to that paragraph.
 
 ```js
-Word.run(function (context) {
-    var paragraphs = context.document.getSelection().paragraphs;
+await Word.run(async (context) => {
+    const paragraphs = context.document.getSelection().paragraphs;
     paragraphs.load();
-    return context.sync().then(function () {
-        paragraphs.items[0].insertText(' New sentence in the paragraph.',
+    await context.sync();
+    paragraphs.items[0].insertText(' New sentence in the paragraph.',
                                        Word.InsertLocation.end);
-    }).then(context.sync);
+    await context.sync();
 });
 
 ```

--- a/docs/word/word-add-ins-programming-overview.md
+++ b/docs/word/word-add-ins-programming-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Word add-ins overview
-description: 'Learn the basics of Word Add-ins.'
+description: Learn the basics of Word Add-ins.
 ms.date: 02/24/2022
 ms.topic: overview
 ms.custom: scenarios:getting-started
@@ -21,7 +21,7 @@ The following figure shows an example of a Word add-in that runs in a task pane.
 
 ![Add-in running in a task pane in Word.](../images/word-add-in-show-host-client.png)
 
-The Word add-in (1) can send requests to the Word document (2) and can use JavaScript to access the paragraph object and update, delete, or move the paragraph. For example, the following code shows how to append a new sentence to that paragraph.
+The Word add-in can (1) send requests to the Word document and (2) use JavaScript to access the paragraph object and update, delete, or move the paragraph. For example, the following code shows how to append a new sentence to that paragraph.
 
 ```js
 await Word.run(async (context) => {


### PR DESCRIPTION
This PR updates the JavaScript samples in the Word-specific articles to match the modern JS patterns that use `async`/`await`.

Reviewers, please note that I was unable to successfully run the Word tutorial with Visual Studio under any circumstance. Please let me know if that problem is happening for you too.