### PR TITLE
[Outlook] (manifest) Define default SendMode option and add Block option

### DIFF
--- a/docs/reference/manifest/launchevent.md
+++ b/docs/reference/manifest/launchevent.md
@@ -44,7 +44,7 @@ For more information, see [Version overrides in the manifest](../../develop/add-
 
 ## Available SendMode options (preview)
 
-When you include the `OnMessageSend` or `OnAppointmentSend` event in the manifest, you should also set the **SendMode** property. If a **SendMode** option is not specified, `SoftBlock`is set by default. The following are the available options. Based on the conditions your add-in is looking for, the user is alerted if your add-in finds an issue in the item being sent.
+When you include the `OnMessageSend` or `OnAppointmentSend` event in the manifest, you should also set the **SendMode** property. If a **SendMode** option is not specified, `SoftBlock` is set by default. The following are the available options. Based on the conditions your add-in is looking for, the user is alerted if your add-in finds an issue in the item being sent.
 
 | SendMode option | Description |
 |---|---|

--- a/docs/reference/manifest/launchevent.md
+++ b/docs/reference/manifest/launchevent.md
@@ -1,7 +1,7 @@
 ---
 title: LaunchEvent in the manifest file
 description: The LaunchEvent element configures your add-in to activate based on supported events.
-ms.date: 03/10/2022
+ms.date: 03/16/2022
 ms.localizationpriority: medium
 ---
 
@@ -40,7 +40,7 @@ For more information, see [Version overrides in the manifest](../../develop/add-
 |:-----|:-----|:-----|
 |  **Type**  |  Yes  | Specifies a supported event type. For the set of supported types, see [Configure your Outlook add-in for event-based activation](../../outlook/autolaunch.md#supported-events). |
 |  **FunctionName**  |  Yes  | Specifies the name of the JavaScript function to handle the event specified in the `Type` attribute. |
-|  **SendMode** (preview) |  No  | Used by `OnMessageSend` and `OnAppointmentSend` events. Specifies the options available to the user if your add-in stops an item from being sent. If the **SendMode** property isn't included, the `SoftBlock` option is set by default. For available options, refer to [Available SendMode options](#available-sendmode-options-preview). |
+|  **SendMode** (preview) |  No  | Used by `OnMessageSend` and `OnAppointmentSend` events. Specifies the options available to the user if your add-in stops an item from being sent or if the add-in is unable to connect to the server. If the **SendMode** property isn't included, the `SoftBlock` option is set by default. For available options, refer to [Available SendMode options](#available-sendmode-options-preview). |
 
 ## Available SendMode options (preview)
 
@@ -49,8 +49,8 @@ When you include the `OnMessageSend` or `OnAppointmentSend` event in the manifes
 | SendMode option | Description |
 |---|---|
 |`PromptUser`|In the alert, the user can choose to **Send Anyway**, or address the issue then try to send the item again.|
-|`SoftBlock`|The user is alerted that the item they're sending doesn't meet the add-in conditions. The user should fix the issue before trying to send the item again.|
-|`Block`|If the item being sent doesn't meet the add-in conditions, or if the add-in is unable to connect to the server, the user must fix the issue before trying to send the item again.|
+|`SoftBlock`|The user is alerted that the item they're sending doesn't meet the add-in conditions and the add-in will decide what to do. For example, the add-in can be set to simply alert the user about the issue or require the user to address the issue before sending the item again. If the add-in is unable to connect to the server when the add-in is activated, the item will always be sent.|
+|`Block`|If the item being sent doesn't meet the add-in conditions, or if the add-in is unable to connect to the server, the item is blocked from being sent.|
 
 ## See also
 

--- a/docs/reference/manifest/launchevent.md
+++ b/docs/reference/manifest/launchevent.md
@@ -40,7 +40,7 @@ For more information, see [Version overrides in the manifest](../../develop/add-
 |:-----|:-----|:-----|
 |  **Type**  |  Yes  | Specifies a supported event type. For the set of supported types, see [Configure your Outlook add-in for event-based activation](../../outlook/autolaunch.md#supported-events). |
 |  **FunctionName**  |  Yes  | Specifies the name of the JavaScript function to handle the event specified in the `Type` attribute. |
-|  **SendMode** (preview) |  No  | Used by `OnMessageSend` and `OnAppointmentSend` events. Specifies the options available to the user if your add-in stops an item from being sent or if the add-in is unable to connect to the server. If the **SendMode** property isn't included, the `SoftBlock` option is set by default. For available options, refer to [Available SendMode options](#available-sendmode-options-preview). |
+|  **SendMode** (preview) |  No  | Used by `OnMessageSend` and `OnAppointmentSend` events. Specifies the options available to the user if your add-in stops an item from being sent or if the add-in is unavailable. If the **SendMode** property isn't included, the `SoftBlock` option is set by default. For available options, refer to [Available SendMode options](#available-sendmode-options-preview). |
 
 ## Available SendMode options (preview)
 
@@ -48,9 +48,9 @@ When you include the `OnMessageSend` or `OnAppointmentSend` event in the manifes
 
 | SendMode option | Description |
 |---|---|
-|`PromptUser`|In the alert, the user can choose to **Send Anyway**, or address the issue and then try to send the item again. If the add-in is taking a long time to process the item, the user will have the option to stop running the add-in and choose **Send Anyway**.|
-|`SoftBlock`|Default option if the **SendMode** property isn't included. The user is alerted that the item they're sending doesn't meet the add-in conditions, and must address the issue before trying to send the item again. However, if the add-in is unavailable when an item is being sent (for example, the add-in is unable to connect to the server), the user will be able to send the item.
-|`Block`|If the item being sent doesn't meet the add-in conditions, or if the add-in is unavailable (for example, the add-in is unable to connect to the server), the item is blocked from being sent.|
+|`PromptUser`|If the item doesn't meet the add-in's conditions, the user can choose *Send Anyway** in the alert, or address the issue then try to send the item again. If the add-in is taking a long time to process the item, the user will be prompted with the option to stop running the add-in and choose **Send Anyway**. In the event the add-in is unavailable (for example, there's an error loading the add-in), the item will be sent.|
+|`SoftBlock`|Default option if the **SendMode** property isn't included. The user is alerted that the item they're sending doesn't meet the add-in's conditions and they must address the issue before trying to send the item again. However, if the add-in is unavailable (for example, there's an error loading the add-in), the item will be sent.|
+|`Block`|The item isn't sent if any of the following situations occur.<br>- The item doesn't meet the add-in's conditions.<br>- The add-in is unable to connect to the server.<br>- There's an error loading the add-in.|
 
 ## See also
 

--- a/docs/reference/manifest/launchevent.md
+++ b/docs/reference/manifest/launchevent.md
@@ -1,7 +1,7 @@
 ---
 title: LaunchEvent in the manifest file
 description: The LaunchEvent element configures your add-in to activate based on supported events.
-ms.date: 02/02/2022
+ms.date: 03/10/2022
 ms.localizationpriority: medium
 ---
 
@@ -40,16 +40,17 @@ For more information, see [Version overrides in the manifest](../../develop/add-
 |:-----|:-----|:-----|
 |  **Type**  |  Yes  | Specifies a supported event type. For the set of supported types, see [Configure your Outlook add-in for event-based activation](../../outlook/autolaunch.md#supported-events). |
 |  **FunctionName**  |  Yes  | Specifies the name of the JavaScript function to handle the event specified in the `Type` attribute. |
-|  **SendMode** (preview) |  No  | Required for `OnMessageSend` and `OnAppointmentSend` events. Specifies the options available to the user if your add-in stops the item from being sent. For available options, refer to [Available SendMode options](#available-sendmode-options-preview). |
+|  **SendMode** (preview) |  No  | Used by `OnMessageSend` and `OnAppointmentSend` events. Specifies the options available to the user if your add-in stops an item from being sent. If a `SendMode` option is not specified, the `SoftBlock` option is set by default. For available options, refer to [Available SendMode options](#available-sendmode-options-preview). |
 
 ## Available SendMode options (preview)
 
-When you include the `OnMessageSend` or `OnAppointmentSend` event in the manifest, you must also set the **SendMode** property. The following are the available options. Based on the conditions your add-in is looking for, the user is alerted if your add-in finds an issue in the item being sent.
+When you include the `OnMessageSend` or `OnAppointmentSend` event in the manifest, you should also set the **SendMode** property. If a **SendMode** option is not specified, `SoftBlock`is set by default. The following are the available options. Based on the conditions your add-in is looking for, the user is alerted if your add-in finds an issue in the item being sent.
 
 | SendMode option | Description |
 |---|---|
 |`PromptUser`|In the alert, the user can choose to **Send Anyway**, or address the issue then try to send the item again.|
-|`SoftBlock`|The user must fix the issue before trying to send the item again.|
+|`SoftBlock`|The user is alerted that the item they're sending doesn't meet the add-in conditions. The user should fix the issue before trying to send the item again.|
+|`Block`|If the item being sent doesn't meet the add-in conditions, or if the add-in is unable to connect to the server, the user must fix the issue before trying to send the item again.|
 
 ## See also
 

--- a/docs/reference/manifest/launchevent.md
+++ b/docs/reference/manifest/launchevent.md
@@ -1,7 +1,7 @@
 ---
 title: LaunchEvent in the manifest file
 description: The LaunchEvent element configures your add-in to activate based on supported events.
-ms.date: 03/16/2022
+ms.date: 03/18/2022
 ms.localizationpriority: medium
 ---
 
@@ -48,9 +48,9 @@ When you include the `OnMessageSend` or `OnAppointmentSend` event in the manifes
 
 | SendMode option | Description |
 |---|---|
-|`PromptUser`|In the alert, the user can choose to **Send Anyway**, or address the issue then try to send the item again.|
-|`SoftBlock`|The user is alerted that the item they're sending doesn't meet the add-in conditions and the add-in will decide what to do. For example, the add-in can be set to simply alert the user about the issue or require the user to address the issue before sending the item again. If the add-in is unable to connect to the server when the add-in is activated, the item will always be sent.|
-|`Block`|If the item being sent doesn't meet the add-in conditions, or if the add-in is unable to connect to the server, the item is blocked from being sent.|
+|`PromptUser`|In the alert, the user can choose to **Send Anyway**, or address the issue and then try to send the item again. If the add-in is taking a long time to process the item, the user will have the option to stop running the add-in and choose **Send Anyway**.|
+|`SoftBlock`|Default option if the **SendMode** property isn't included. The user is alerted that the item they're sending doesn't meet the add-in conditions, and must address the issue before trying to send the item again. However, if the add-in is unavailable when an item is being sent (for example, the add-in is unable to connect to the server), the user will be able to send the item.
+|`Block`|If the item being sent doesn't meet the add-in conditions, or if the add-in is unavailable (for example, the add-in is unable to connect to the server), the item is blocked from being sent.|
 
 ## See also
 

--- a/docs/reference/manifest/launchevent.md
+++ b/docs/reference/manifest/launchevent.md
@@ -40,11 +40,11 @@ For more information, see [Version overrides in the manifest](../../develop/add-
 |:-----|:-----|:-----|
 |  **Type**  |  Yes  | Specifies a supported event type. For the set of supported types, see [Configure your Outlook add-in for event-based activation](../../outlook/autolaunch.md#supported-events). |
 |  **FunctionName**  |  Yes  | Specifies the name of the JavaScript function to handle the event specified in the `Type` attribute. |
-|  **SendMode** (preview) |  No  | Used by `OnMessageSend` and `OnAppointmentSend` events. Specifies the options available to the user if your add-in stops an item from being sent. If a `SendMode` option is not specified, the `SoftBlock` option is set by default. For available options, refer to [Available SendMode options](#available-sendmode-options-preview). |
+|  **SendMode** (preview) |  No  | Used by `OnMessageSend` and `OnAppointmentSend` events. Specifies the options available to the user if your add-in stops an item from being sent. If the **SendMode** property isn't included, the `SoftBlock` option is set by default. For available options, refer to [Available SendMode options](#available-sendmode-options-preview). |
 
 ## Available SendMode options (preview)
 
-When you include the `OnMessageSend` or `OnAppointmentSend` event in the manifest, you should also set the **SendMode** property. If a **SendMode** option is not specified, `SoftBlock` is set by default. The following are the available options. Based on the conditions your add-in is looking for, the user is alerted if your add-in finds an issue in the item being sent.
+When you include the `OnMessageSend` or `OnAppointmentSend` event in the manifest, you should also set the **SendMode** property. If the **SendMode** property isn't included, the `SoftBlock` option is set by default. The following are the available options. Based on the conditions your add-in is looking for, the user is alerted if your add-in finds an issue in the item being sent.
 
 | SendMode option | Description |
 |---|---|

--- a/docs/reference/manifest/launchevent.md
+++ b/docs/reference/manifest/launchevent.md
@@ -48,7 +48,7 @@ When you include the `OnMessageSend` or `OnAppointmentSend` event in the manifes
 
 | SendMode option | Description |
 |---|---|
-|`PromptUser`|If the item doesn't meet the add-in's conditions, the user can choose *Send Anyway** in the alert, or address the issue then try to send the item again. If the add-in is taking a long time to process the item, the user will be prompted with the option to stop running the add-in and choose **Send Anyway**. In the event the add-in is unavailable (for example, there's an error loading the add-in), the item will be sent.|
+|`PromptUser`|If the item doesn't meet the add-in's conditions, the user can choose **Send Anyway** in the alert, or address the issue then try to send the item again. If the add-in is taking a long time to process the item, the user will be prompted with the option to stop running the add-in and choose **Send Anyway**. In the event the add-in is unavailable (for example, there's an error loading the add-in), the item will be sent.|
 |`SoftBlock`|Default option if the **SendMode** property isn't included. The user is alerted that the item they're sending doesn't meet the add-in's conditions and they must address the issue before trying to send the item again. However, if the add-in is unavailable (for example, there's an error loading the add-in), the item will be sent.|
 |`Block`|The item isn't sent if any of the following situations occur.<br>- The item doesn't meet the add-in's conditions.<br>- The add-in is unable to connect to the server.<br>- There's an error loading the add-in.|
 


### PR DESCRIPTION
The SendMode property of the LaunchEvent element is not required. Clarified this in the manifest documentation and added a description for the Block option.