### PR TITLE
[all hosts] Remove unused redirects to reference

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -37,50 +37,6 @@
         "source_path": "docs/reference/onenote-api-reference.md",	
         "redirect_url": "/javascript/api/onenote?view=onenote-js-1.1"	
       },	
-      {	
-        "source_path": "docs/reference/outlook-api-reference-preview.md",	
-        "redirect_url": "/javascript/api/outlook?view=outlook-js-preview"	
-      },	
-      {	
-        "source_path": "docs/reference/outlook-api-reference-1-1.md",	
-        "redirect_url": "/javascript/api/outlook?view=outlook-js-1.1"	
-      },	
-      {	
-        "source_path": "docs/reference/outlook-api-reference-1-2.md",	
-        "redirect_url": "/javascript/api/outlook?view=outlook-js-1.2"	
-      },	
-      {	
-        "source_path": "docs/reference/outlook-api-reference-1-3.md",	
-        "redirect_url": "/javascript/api/outlook?view=outlook-js-1.3"	
-      },	
-      {	
-        "source_path": "docs/reference/outlook-api-reference-1-4.md",	
-        "redirect_url": "/javascript/api/outlook?view=outlook-js-1.4"	
-      },	
-      {	
-        "source_path": "docs/reference/outlook-api-reference-1-5.md",	
-        "redirect_url": "/javascript/api/outlook?view=outlook-js-1.5"	
-      },	
-      {	
-        "source_path": "docs/reference/outlook-api-reference-1-6.md",	
-        "redirect_url": "/javascript/api/outlook?view=outlook-js-1.6"	
-      },	
-      {	
-        "source_path": "docs/reference/outlook-api-reference-1-7.md",	
-        "redirect_url": "/javascript/api/outlook?view=outlook-js-1.7"	
-      },	
-      {	
-        "source_path": "docs/reference/outlook-api-reference-1-8.md",	
-        "redirect_url": "/javascript/api/outlook?view=outlook-js-1.8"	
-      },	
-      {
-        "source_path": "docs/reference/outlook-api-reference-1-9.md",	
-        "redirect_url": "/javascript/api/outlook?view=outlook-js-1.9"	
-      },
-      {
-        "source_path": "docs/reference/outlook-api-reference-1-10.md",	
-        "redirect_url": "/javascript/api/outlook?view=outlook-js-1.10"	
-      },
       {
         "source_path": "docs/reference/outlook-api-reference-1-11.md",	
         "redirect_url": "/javascript/api/outlook?view=outlook-js-1.11"	
@@ -96,10 +52,6 @@
       {	
         "source_path": "docs/reference/word-api-reference.md",	
         "redirect_url": "/javascript/api/word?view=word-js-preview"	
-      },
-      {
-        "source_path": "docs/reference/common-api-reference.md",
-        "redirect_url": "/javascript/api/office?view=common-js"
       },
       {
         "source_path": "docs/reference/manifest-reference.md",


### PR DESCRIPTION
We were using these in the TOC so that the context would change to reference instead of staying in conceptual. With the move of reference content to the reference repo, we no longer use these in the TOC.