### PR TITLE
[Outlook] (shared mailbox) Remove OWA support for shared mailbox feature

### DIFF
--- a/docs/outlook/delegate-access.md
+++ b/docs/outlook/delegate-access.md
@@ -50,7 +50,7 @@ The mailbox owner must first [provide access to a delegate](https://www.microsof
 
 #### Shared mailboxes
 
-Shared mailbox scenarios in Outlook add-ins are not currently supported on modern Outlook on the web.
+Shared mailbox scenarios in Outlook add-ins aren't currently supported in modern Outlook on the web.
 
 ### [Mac](#tab/unix)
 

--- a/docs/outlook/delegate-access.md
+++ b/docs/outlook/delegate-access.md
@@ -1,7 +1,7 @@
 ---
 title: Enable shared folders and shared mailbox scenarios in an Outlook add-in
 description: Discusses how to configure add-in support for shared folders (a.k.a. delegate access) and shared mailboxes.
-ms.date: 10/05/2021
+ms.date: 04/28/2022
 ms.localizationpriority: medium
 ---
 
@@ -48,14 +48,9 @@ An Exchange Server feature known as "automapping" is on by default which means t
 
 The mailbox owner must first [provide access to a delegate](https://www.microsoft.com/microsoft-365/blog/2013/09/04/configuring-delegate-access-in-outlook-web-app/) by updating the mailbox folder permissions. The delegate must then follow the instructions outlined in the "Add another person’s mailbox to your folder list in Outlook Web App" section of the article [Access another person's mailbox](https://support.microsoft.com/office/a909ad30-e413-40b5-a487-0ea70b763081).
 
-#### Shared mailboxes (preview)
+#### Shared mailboxes
 
-Exchange server admins can create and manage shared mailboxes for sets of users to access. At present, [Exchange Online](/exchange/collaboration-exo/shared-mailboxes) is the only supported server version for this feature.
-
-After receiving access, a shared mailbox user must follow the steps outlined in the "Add the shared mailbox so it displays under your primary mailbox" section of the article [Open and use a shared mailbox in Outlook on the web](https://support.microsoft.com/office/98b5a90d-4e38-415d-a030-f09a4cd28207).
-
-> [!WARNING]
-> Do **NOT** use other options like "Open another mailbox". The feature APIs may not work properly then.
+Shared mailbox scenarios in Outlook add-ins are not currently supported on modern Outlook on the web.
 
 ### [Mac](#tab/unix)
 
@@ -231,7 +226,7 @@ a. **Delegate access/Shared folders**
 1. They save the message then move it from their own **Drafts** folder to a folder shared with the delegate.
 1. The delegate opens the draft from the shared folder then continues composing.
 
-b. **Shared mailbox**
+b. **Shared mailbox (applies to Outlook on Windows only)**
 
 1. A shared mailbox user starts a message. This can be a new message, a reply, or a forward.
 1. They save the message then move it from their own **Drafts** folder to a folder in the shared mailbox.

--- a/docs/outlook/outlook-add-ins-overview.md
+++ b/docs/outlook/outlook-add-ins-overview.md
@@ -1,7 +1,7 @@
 ---
 title: Outlook add-ins overview
 description: Outlook add-ins are integrations built by third parties into Outlook by using our web-based platform. 
-ms.date: 07/16/2021
+ms.date: 04/28/2022
 ms.topic: overview
 ms.custom: scenarios:getting-started
 ms.localizationpriority: high
@@ -58,7 +58,7 @@ Outlook add-ins activate when the user is composing or reading a message or appo
 - In a [group mailbox](/microsoft-365/admin/create-groups/compare-groups?view=o365-worldwide&preserve-view=true#shared-mailboxes), in a shared mailbox\*, in another user's mailbox\*, in an [archive mailbox](/office365/servicedescriptions/exchange-online-archiving-service-description/archive-features#archive-mailbox), or in a public folder.
 
   > [!IMPORTANT]
-  > \* Support for delegate access scenarios (for example, folders shared from another user's mailbox) was introduced in [requirement set 1.8](/javascript/api/requirement-sets/outlook/requirement-set-1.8/outlook-requirement-set-1.8). Shared mailbox support is now in preview. To learn more, refer to [Enable shared folders and shared mailbox scenarios](delegate-access.md).
+  > \* Support for delegate access scenarios (for example, folders shared from another user's mailbox) was introduced in [requirement set 1.8](/javascript/api/requirement-sets/outlook/requirement-set-1.8/outlook-requirement-set-1.8). Shared mailbox support is now in preview in Outlook on Windows and on Mac. To learn more, refer to [Enable shared folders and shared mailbox scenarios](delegate-access.md).
 
 - Using a custom form.
 


### PR DESCRIPTION
The shared mailbox add-in feature is in preview on Outlook on Windows and on Mac at this time.