### PR TITLE
[all hosts] (TOC) Move preview tag from name to displayName

### DIFF
--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -109,7 +109,7 @@ items:
       items:
       - name: Overview
         href: develop/add-in-manifests.md
-      - name: Teams manifest for Office Add-ins (preview)
+      - name: Teams manifest for Office Add-ins
         href: develop/json-manifest-overview.md
       - name: Manifest reference
         href: reference/manifest-reference.md
@@ -412,15 +412,15 @@ items:
     - name: Comments
       href: excel/excel-add-ins-comments.md
       displayName: Excel
-    - name: Data types (preview)
+    - name: Data types
       items:
-        - name: Overview (preview)
+        - name: Overview
           href: excel/excel-data-types-overview.md
           displayName: Excel
-        - name: Concepts (preview)
+        - name: Concepts
           href: excel/excel-data-types-concepts.md
           displayName: Excel
-        - name: Entity value cards (preview)
+        - name: Entity value cards
           href: excel/excel-data-types-entity-card.md
           displayName: Excel
     - name: Data validation
@@ -540,7 +540,7 @@ items:
     - name: Autogenerate JSON metadata
       href: excel/custom-functions-json-autogeneration.md
       displayName: Excel, Custom Functions
-    - name: Data types (preview)
+    - name: Data types
       href: excel/custom-functions-data-types-concepts.md
       displayName: Excel, Custom Functions
     - name: Call Excel JavaScript APIs
@@ -613,7 +613,7 @@ items:
   - name: Build your first Outlook add-in
     href: quickstarts/outlook-quickstart.md
     displayName: Outlook
-  - name: Build an Outlook add-in with a Teams manifest (preview)
+  - name: Build an Outlook add-in with a Teams manifest
     href: quickstarts/outlook-quickstart-json-manifest.md
     displayName: Outlook   
   - name: Outlook add-in tutorial

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -111,6 +111,7 @@ items:
         href: develop/add-in-manifests.md
       - name: Teams manifest for Office Add-ins
         href: develop/json-manifest-overview.md
+        displayName: preview
       - name: Manifest reference
         href: reference/manifest-reference.md
       - name: Extended overrides
@@ -413,16 +414,17 @@ items:
       href: excel/excel-add-ins-comments.md
       displayName: Excel
     - name: Data types
+      displayName: preview
       items:
         - name: Overview
           href: excel/excel-data-types-overview.md
-          displayName: Excel
+          displayName: Excel, preview
         - name: Concepts
           href: excel/excel-data-types-concepts.md
-          displayName: Excel
+          displayName: Excel, preview
         - name: Entity value cards
           href: excel/excel-data-types-entity-card.md
-          displayName: Excel
+          displayName: Excel, preview
     - name: Data validation
       href: excel/excel-add-ins-data-validation.md
       displayName: Excel
@@ -542,7 +544,7 @@ items:
       displayName: Excel, Custom Functions
     - name: Data types
       href: excel/custom-functions-data-types-concepts.md
-      displayName: Excel, Custom Functions
+      displayName: Excel, Custom Functions, preview
     - name: Call Excel JavaScript APIs
       href: excel/call-excel-apis-from-custom-function.md
       displayName: Excel, Custom Functions
@@ -615,7 +617,7 @@ items:
     displayName: Outlook
   - name: Build an Outlook add-in with a Teams manifest
     href: quickstarts/outlook-quickstart-json-manifest.md
-    displayName: Outlook   
+    displayName: Outlook, preview
   - name: Outlook add-in tutorial
     href: tutorials/outlook-tutorial.md
     displayName: Outlook


### PR DESCRIPTION
Per [docs contributor guide](https://review.docs.microsoft.com/en-us/help/contribute/preview-content?branch=main#headings-titles-and-tocs), TOC labels shouldn't include preview tags. Moving to [displayName property](https://review.docs.microsoft.com/en-us/help/contribute/toc-management?branch=main#yaml-toc-format) allows users to search for "preview" and locate the related content.