### PR TITLE
[Outlook] (Mac) Remove preview tag from new Mac UI references

### DIFF
--- a/docs/outlook/autolaunch.md
+++ b/docs/outlook/autolaunch.md
@@ -24,8 +24,8 @@ The following table lists events that are currently available and the supported 
 
 |Event|Description|Minimum requirement set and supported clients|
 |---|---|---|
-|`OnNewMessageCompose`|On composing a new message (includes reply, reply all, and forward) but not on editing, for example, a draft.|[1.10](/javascript/api/requirement-sets/outlook/requirement-set-1.10/outlook-requirement-set-1.10)<br><br>- Windows<sup>1</sup><br>- Web browser<br>- New Mac UI preview|
-|`OnNewAppointmentOrganizer`|On creating a new appointment but not on editing an existing one.|[1.10](/javascript/api/requirement-sets/outlook/requirement-set-1.10/outlook-requirement-set-1.10)<br><br>- Windows<sup>1</sup><br>- Web browser<br>- New Mac UI preview|
+|`OnNewMessageCompose`|On composing a new message (includes reply, reply all, and forward) but not on editing, for example, a draft.|[1.10](/javascript/api/requirement-sets/outlook/requirement-set-1.10/outlook-requirement-set-1.10)<br><br>- Windows<sup>1</sup><br>- Web browser<br>- New Mac UI |
+|`OnNewAppointmentOrganizer`|On creating a new appointment but not on editing an existing one.|[1.10](/javascript/api/requirement-sets/outlook/requirement-set-1.10/outlook-requirement-set-1.10)<br><br>- Windows<sup>1</sup><br>- Web browser<br>- New Mac UI |
 |`OnMessageAttachmentsChanged`|On adding or removing attachments while composing a message.<br><br>Event-specific data object: [AttachmentsChangedEventArgs](/javascript/api/outlook/office.attachmentschangedeventargs?view=outlook-js-1.11&preserve-view=true)|[1.11](/javascript/api/requirement-sets/outlook/requirement-set-1.11/outlook-requirement-set-1.11)<br><br>- Windows<sup>1</sup><br>- Web browser|
 |`OnAppointmentAttachmentsChanged`|On adding or removing attachments while composing an appointment.<br><br>Event-specific data object: [AttachmentsChangedEventArgs](/javascript/api/outlook/office.attachmentschangedeventargs?view=outlook-js-1.11&preserve-view=true)|[1.11](/javascript/api/requirement-sets/outlook/requirement-set-1.11/outlook-requirement-set-1.11)<br><br>- Windows<sup>1</sup><br>- Web browser|
 |`OnMessageRecipientsChanged`|On adding or removing recipients while composing a message.<br><br>Event-specific data object: [RecipientsChangedEventArgs](/javascript/api/outlook/office.recipientschangedeventargs?view=outlook-js-1.11&preserve-view=true)|[1.11](/javascript/api/requirement-sets/outlook/requirement-set-1.11/outlook-requirement-set-1.11)<br><br>- Windows<sup>1</sup><br>- Web browser|
@@ -48,7 +48,7 @@ To preview these events where available:
 - For Outlook on the web:
   - [Configure targeted release on your Microsoft 365 tenant.](/microsoft-365/admin/manage/release-options-in-office-365?view=o365-worldwide&preserve-view=true#set-up-the-release-option-in-the-admin-center)
   - Reference the **beta** library on the CDN (https://appsforoffice.microsoft.com/lib/beta/hosted/office.js). The [type definition file](https://appsforoffice.microsoft.com/lib/beta/hosted/office.d.ts) for TypeScript compilation and IntelliSense is found at the CDN and [DefinitelyTyped](https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/master/types/office-js-preview/index.d.ts). You can install these types with `npm install --save-dev @types/office-js-preview`.
-- For Outlook on the new Mac UI preview:
+- For Outlook on the new Mac UI:
   - The minimum required build is 16.54 (21101001). Join the [Office Insider program](https://insider.office.com/join/Mac) and choose the **Beta Channel** for access to Office beta builds.
 - For Outlook on Windows:
   - The minimum required build is 16.0.14511.10000. Join the [Office Insider program](https://insider.office.com/join/windows) and choose the **Beta Channel** for access to Office beta builds.
@@ -80,7 +80,7 @@ To enable event-based activation of your add-in, you must configure the [Runtime
         <!-- Event-based activation happens in a lightweight runtime.-->
         <Runtimes>
           <!-- HTML file including reference to or inline JavaScript event handlers.
-               This is used by Outlook on the web and Outlook on the new Mac UI preview. -->
+               This is used by Outlook on the web and Outlook on the new Mac UI. -->
           <Runtime resid="WebViewRuntime.Url">
             <!-- JavaScript file containing event handlers. This is used by Outlook Desktop. -->
             <Override type="javascript" resid="JSRuntime.Url"/>
@@ -184,7 +184,7 @@ To enable event-based activation of your add-in, you must configure the [Runtime
 </VersionOverrides>
 ```
 
-Outlook on Windows uses a JavaScript file, while Outlook on the web and on the new Mac UI preview use an HTML file that can reference the same JavaScript file. You must provide references to both these files in the `Resources` node of the manifest as the Outlook platform ultimately determines whether to use HTML or JavaScript based on the Outlook client. As such, to configure event handling, provide the location of the HTML in the `Runtime` element, then in its `Override` child element provide the location of the JavaScript file inlined or referenced by the HTML.
+Outlook on Windows uses a JavaScript file, while Outlook on the web and on the new Mac UI use an HTML file that can reference the same JavaScript file. You must provide references to both these files in the `Resources` node of the manifest as the Outlook platform ultimately determines whether to use HTML or JavaScript based on the Outlook client. As such, to configure event handling, provide the location of the HTML in the `Runtime` element, then in its `Override` child element provide the location of the JavaScript file inlined or referenced by the HTML.
 
 > [!TIP]
 > To learn more about manifests for Outlook add-ins, see [Outlook add-in manifests](manifests.md).
@@ -287,15 +287,15 @@ In this scenario, you'll add handling for composing new items.
 
 1. In Outlook on the web, create a new message.
 
-    ![Screenshot of a message window in Outlook on the web with the subject set on compose.](../images/outlook-web-autolaunch-1.png)
+    ![A message window in Outlook on the web with the subject set on compose.](../images/outlook-web-autolaunch-1.png)
 
-1. In Outlook on the new Mac UI preview, create a new message.
+1. In Outlook on the new Mac UI, create a new message.
 
-    ![Screenshot of a message window in Outlook on the new Mac UI preview with the subject set on compose.](../images/outlook-mac-autolaunch.png)
+    ![A message window in Outlook on the new Mac UI with the subject set on compose.](../images/outlook-mac-autolaunch.png)
 
 1. In Outlook on Windows, create a new message.
 
-    ![Screenshot of a message window in Outlook on Windows with the subject set on compose.](../images/outlook-win-autolaunch.png)
+    ![A message window in Outlook on Windows with the subject set on compose.](../images/outlook-win-autolaunch.png)
 
 ## Debug
 

--- a/docs/outlook/compare-outlook-add-in-support-in-outlook-for-mac.md
+++ b/docs/outlook/compare-outlook-add-in-support-in-outlook-for-mac.md
@@ -1,7 +1,7 @@
 ---
 title: Compare Outlook add-in support in Outlook on Mac
 description: Learn how add-in support in Outlook on Mac compares with other Outlook clients.
-ms.date: 12/13/2021
+ms.date: 06/09/2022
 ms.localizationpriority: medium
 ---
 
@@ -11,7 +11,7 @@ You can create and run an Outlook add-in the same way in Outlook on Mac as in th
 
 For more information, see [Deploy and install Outlook add-ins for testing](testing-and-tips.md).
 
-For information about new UI support, see [Add-in support in Outlook on new Mac UI](#add-in-support-in-outlook-on-new-mac-ui-preview).
+For information about new UI support, see [Add-in support in Outlook on new Mac UI](#add-in-support-in-outlook-on-new-mac-ui).
 
 | Area | Outlook on the web, Windows, and mobile devices | Outlook on Mac |
 |:-----|:-----|:-----|
@@ -24,13 +24,13 @@ For information about new UI support, see [Add-in support in Outlook on new Mac 
 | String representing the time zone in the `dateTimeCreated` and `dateTimeModified` properties |As an example: `Thu Mar 13 2014 14:09:11 GMT+0800 (China Standard Time)` | As an example: `Thu Mar 13 2014 14:09:11 GMT+0800 (CST)` |
 | Time accuracy of `dateTimeCreated` and `dateTimeModified` | If an add-in uses the following code, the accuracy is up to a millisecond.<br/>`JSON.stringify(Office.context.mailbox.item, null, 4);`| The accuracy is up to only a second. |
 
-## Add-in support in Outlook on new Mac UI (preview)
+## Add-in support in Outlook on new Mac UI
 
-Outlook add-ins are now supported on the new Mac UI (preview), up to requirement set 1.10. However, the following requirement sets and features are **NOT** supported yet.
+Outlook add-ins are now supported on the new Mac UI, up to requirement set 1.10. However, the following requirement sets and features are **NOT** supported yet.
 
 - API requirement set 1.11
 
-We encourage you to preview Outlook on the new Mac UI, available from version 16.38.506. To learn more about how to try it out, see [Outlook for Mac - Release notes for Insider Fast builds](https://support.microsoft.com/office/d6347358-5613-433e-a49e-a9a0e8e0462a).
+To learn more about the new Mac UI, see [The new Outlook for Mac](https://support.microsoft.com/en-us/office/the-new-outlook-for-mac-6283be54-e74d-434e-babb-b70cefc77439).
 
 You can determine which UI version you're on, as follows:
 
@@ -38,6 +38,6 @@ You can determine which UI version you're on, as follows:
 
 ![Current UI on Mac.](../images/outlook-on-mac-classic.png)
 
-**New UI (preview)**
+**New UI**
 
-![New UI in preview on Mac.](../images/outlook-on-mac-new.png)
+![New UI on Mac.](../images/outlook-on-mac-new.png)

--- a/docs/outlook/compare-outlook-add-in-support-in-outlook-for-mac.md
+++ b/docs/outlook/compare-outlook-add-in-support-in-outlook-for-mac.md
@@ -30,13 +30,13 @@ Outlook add-ins are now supported on the new Mac UI (available from Outlook vers
 
 - API requirement set 1.11
 
-To learn more about the new Mac UI, see [The new Outlook for Mac](https://support.microsoft.com/en-us/office/the-new-outlook-for-mac-6283be54-e74d-434e-babb-b70cefc77439).
+To learn more about the new Mac UI, see [The new Outlook for Mac](https://support.microsoft.com/office/6283be54-e74d-434e-babb-b70cefc77439).
 
 You can determine which UI version you're on, as follows:
 
-**Current UI**
+**Classic UI**
 
-![Current UI on Mac.](../images/outlook-on-mac-classic.png)
+![Classic UI on Mac.](../images/outlook-on-mac-classic.png)
 
 **New UI**
 

--- a/docs/outlook/compare-outlook-add-in-support-in-outlook-for-mac.md
+++ b/docs/outlook/compare-outlook-add-in-support-in-outlook-for-mac.md
@@ -26,7 +26,7 @@ For information about new UI support, see [Add-in support in Outlook on new Mac 
 
 ## Add-in support in Outlook on new Mac UI
 
-Outlook add-ins are now supported on the new Mac UI, up to requirement set 1.10. However, the following requirement sets and features are **NOT** supported yet.
+Outlook add-ins are now supported on the new Mac UI (available from Outlook version 16.38.506), up to requirement set 1.10. However, the following requirement sets and features are **NOT** supported yet.
 
 - API requirement set 1.11
 

--- a/docs/outlook/smart-alerts-onmessagesend-walkthrough.md
+++ b/docs/outlook/smart-alerts-onmessagesend-walkthrough.md
@@ -2,7 +2,7 @@
 title: Use Smart Alerts and the OnMessageSend and OnAppointmentSend events in your Outlook add-in (preview)
 description: Learn how to handle the on-send events in your Outlook add-in using event-based activation.
 ms.topic: article
-ms.date: 06/02/2022
+ms.date: 06/09/2022
 ms.localizationpriority: medium
 ---
 
@@ -44,7 +44,7 @@ Complete the [Outlook quick start](../quickstarts/outlook-quickstart.md?tabs=yeo
         <!-- Event-based activation happens in a lightweight runtime.-->
         <Runtimes>
           <!-- HTML file including reference to or inline JavaScript event handlers.
-               This is used by Outlook on the web and Outlook on the new Mac UI preview. -->
+               This is used by Outlook on the web and Outlook on the new Mac UI. -->
           <Runtime resid="WebViewRuntime.Url">
             <!-- JavaScript file containing event handlers. This is used by Outlook Desktop. -->
             <Override type="javascript" resid="JSRuntime.Url"/>

--- a/docs/outlook/smart-alerts-onmessagesend-walkthrough.md
+++ b/docs/outlook/smart-alerts-onmessagesend-walkthrough.md
@@ -44,7 +44,7 @@ Complete the [Outlook quick start](../quickstarts/outlook-quickstart.md?tabs=yeo
         <!-- Event-based activation happens in a lightweight runtime.-->
         <Runtimes>
           <!-- HTML file including reference to or inline JavaScript event handlers.
-               This is used by Outlook on the web and Outlook on the new Mac UI. -->
+               This is used by Outlook on the web and on the new Mac UI. -->
           <Runtime resid="WebViewRuntime.Url">
             <!-- JavaScript file containing event handlers. This is used by Outlook Desktop. -->
             <Override type="javascript" resid="JSRuntime.Url"/>


### PR DESCRIPTION
Per [Get ready for the new Outlook for Mac](https://techcommunity.microsoft.com/t5/outlook-blog/get-ready-for-the-new-outlook-for-mac/ba-p/2897724) and [The new Outlook for Mac](https://support.microsoft.com/en-us/office/the-new-outlook-for-mac-6283be54-e74d-434e-babb-b70cefc77439), the new Mac UI is now deployed.