### PR TITLE
[Testing] (Sideload) Divide iPad and Mac desktop sideloading instructions

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -1179,7 +1179,7 @@
         {
             "source_path": "docs/reference/objectmodel/preview-requirement-set/outlook-requirement-set-preview.md",
             "redirect_url": "/javascript/api/requirement-sets/outlook/preview-requirement-set/outlook-requirement-set-preview"
-        }
+        },
         {
             "source_path": "docs/testing/sideload-an-office-add-in-on-ipad-and-mac.md",
             "redirect_url": "/office/dev/add-ins/testing/sideload-an-office-add-in-on-mac"

--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -1180,5 +1180,9 @@
             "source_path": "docs/reference/objectmodel/preview-requirement-set/outlook-requirement-set-preview.md",
             "redirect_url": "/javascript/api/requirement-sets/outlook/preview-requirement-set/outlook-requirement-set-preview"
         }
+        {
+            "source_path": "docs/testing/sideload-an-office-add-in-on-ipad-and-mac.md",
+            "redirect_url": "/office/dev/add-ins/testing/sideload-an-office-add-in-on-mac"
+        }
     ]
 }

--- a/docs/concepts/add-in-development-best-practices.md
+++ b/docs/concepts/add-in-development-best-practices.md
@@ -82,7 +82,7 @@ For patterns that you can apply as you develop your first-run experience, see [U
 
 - Ensure that your add-in works in both portrait and landscape modes. Be aware that on touch devices, part of your add-in might be hidden by the soft keyboard.
 
-- Test your add-in on a real device by using [sideloading](../testing/sideload-an-office-add-in-on-ipad-and-mac.md).
+- Test your add-in on a real device by using [sideloading](../testing/sideload-an-office-add-in-on-ipad.md).
 
 > [!NOTE]
 > If you're using [Fluent UI React](../design/using-office-ui-fabric-react.md) for your design elements, many of these elements are built into the design system.

--- a/docs/develop/develop-office-add-ins-for-the-ipad.md
+++ b/docs/develop/develop-office-add-ins-for-the-ipad.md
@@ -40,7 +40,7 @@ Apply the following best practices for developing add-ins that run on iPad.
 
 -  **Develop and debug the add-in on Windows or Mac and sideload it to an iPad.**
 
-    You can't develop the add-in directly on an iPad, but you can develop and debug it on a Windows or Mac computer and sideload it to an iPad for testing. Because an add-in that runs in Office on iOS or Mac supports the same APIs as an add-in running in Office on Windows, your add-in's code should run the same way on these platforms. For details, see [Test and debug Office Add-ins](../testing/test-debug-office-add-ins.md) and [Sideload Office Add-ins on iPad and Mac for testing](../testing/sideload-an-office-add-in-on-ipad-and-mac.md).
+    You can't develop the add-in directly on an iPad, but you can develop and debug it on a Windows or Mac computer and sideload it to an iPad for testing. Because an add-in that runs in Office on iOS or Mac supports the same APIs as an add-in running in Office on Windows, your add-in's code should run the same way on these platforms. For details, see [Test and debug Office Add-ins](../testing/test-debug-office-add-ins.md) and [Sideload Office Add-ins on iPad for testing](../testing/sideload-an-office-add-in-on-ipad.md).
 
 -  **Specify API requirements in your add-in's manifest or with runtime checks.**
 

--- a/docs/quickstarts/excel-quickstart-vue.md
+++ b/docs/quickstarts/excel-quickstart-vue.md
@@ -209,7 +209,8 @@ The add-in project that you've created with the Yeoman generator contains sample
 
    - Windows: [Sideload Office Add-ins on Windows](../testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins.md)
    - Web browser: [Sideload Office Add-ins in Office on the web](../testing/sideload-office-add-ins-for-testing.md#sideload-an-office-add-in-in-office-on-the-web)
-   - iPad and Mac: [Sideload Office Add-ins on iPad and Mac](../testing/sideload-an-office-add-in-on-ipad-and-mac.md)
+   - iPad: [Sideload Office Add-ins on iPad](../testing/sideload-an-office-add-in-on-ipad.md)
+   - Mac: [Sideload Office Add-ins on Mac](../testing/sideload-an-office-add-in-on-mac.md)
 
 1. Open the add-in task pane in Excel. On the **Home** tab, choose the **Show Taskpane** button.
 

--- a/docs/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins.md
+++ b/docs/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins.md
@@ -21,7 +21,8 @@ You can test an Office Add-in in an Office client that is on Windows by publishi
 This article applies only to testing Word, Excel, PowerPoint, and Project add-ins and only on Windows. If you want to test on another platform or want to test an Outlook add-in, see one of the following topics to sideload your add-in.
 
 - [Sideload Office Add-ins in Office on the web for testing](sideload-office-add-ins-for-testing.md)
-- [Sideload Office Add-ins on iPad and Mac for testing](sideload-an-office-add-in-on-ipad-and-mac.md)
+- [Sideload Office Add-ins on Mac for testing](sideload-an-office-add-in-on-mac.md)
+- [Sideload Office Add-ins on iPad for testing](sideload-an-office-add-in-on-ipad.md)
 - [Sideload Outlook add-ins for testing](../outlook/sideload-outlook-add-ins-for-testing.md)
 
 The following video walks you through the process of sideloading your add-in in Office on the web or desktop using a shared folder catalog.  

--- a/docs/testing/debug-office-add-ins-on-ipad-and-mac.md
+++ b/docs/testing/debug-office-add-ins-on-ipad-and-mac.md
@@ -28,7 +28,7 @@ To start, open a terminal and set the `OfficeWebAddinDeveloperExtras` property f
     > [!IMPORTANT]
     > Mac App Store builds of Office do not support the `OfficeWebAddinDeveloperExtras` flag.
 
-Then, open the Office application and [sideload your add-in](sideload-an-office-add-in-on-ipad-and-mac.md). Right-click the add-in and you should see an **Inspect Element** option in the context menu. Select that option and it will pop the Inspector, where you can set breakpoints and debug your add-in.
+Then, open the Office application and [sideload your add-in](sideload-an-office-add-in-on-mac.md). Right-click the add-in and you should see an **Inspect Element** option in the context menu. Select that option and it will pop the Inspector, where you can set breakpoints and debug your add-in.
 
 > [!NOTE]
 > If you're trying to use the inspector and the dialog flickers, update Office to the latest version. If that doesn't resolve the flickering, try the following workaround.

--- a/docs/testing/sideload-an-office-add-in-on-ipad.md
+++ b/docs/testing/sideload-an-office-add-in-on-ipad.md
@@ -1,13 +1,13 @@
 ---
-title: Sideload Office Add-ins on iPad and Mac for testing
-description: Test your Office Add-in on iPad and Mac by sideloading.
-ms.date: 09/24/2021
+title: Sideload Office Add-ins on iPad for testing
+description: Test your Office Add-in on iPad by sideloading.
+ms.date: 06/29/2022
 ms.localizationpriority: medium
 ---
 
-# Sideload Office Add-ins on iPad and Mac for testing
+# Sideload Office Add-ins on iPad for testing
 
-To see how your add-in will run in Office on iOS, you can sideload your add-in's manifest onto an iPad using iTunes, or sideload your add-in's manifest directly in Office on Mac. This action won't enable you to set breakpoints and debug your add-in's code while it's running, but you can see how it behaves and verify that the UI is usable and rendering appropriately.
+To see how your add-in will run in Office on iOS, you can sideload your add-in's manifest onto an iPad using iTunes. This action won't enable you to set breakpoints and debug your add-in's code while it's running, but you can see how it behaves and verify that the UI is usable and rendering appropriately.
 
 > [!NOTE]
 > To sideload an Outlook add-in, see [Sideload Outlook add-ins for testing](../outlook/sideload-outlook-add-ins-for-testing.md).
@@ -19,18 +19,6 @@ To see how your add-in will run in Office on iOS, you can sideload your add-in's
   > If you're running macOS Catalina, [iTunes is no longer available](https://support.apple.com/HT210200) so you should follow the instructions in the section [Sideload an add-in on Excel or Word on iPad using macOS Catalina](#sideload-an-add-in-on-excel-or-word-on-ipad-using-macos-catalina) later in this article.
 
 - An iPad running iOS 8.2 or later with [Excel](https://apps.apple.com/app/microsoft-excel/id586683407) or [Word](https://apps.apple.com/app/microsoft-word/id586447913) installed, and a sync cable.
-
-- The manifest .xml file for the add-in you want to test.
-
-## Prerequisites for Office on Mac
-
-- A Mac running OS X v10.10 "Yosemite" or later with [Office on Mac](https://products.office.com/buy/compare-microsoft-office-products?tab=omac) installed.
-
-- Word on Mac version 15.18 (160109).
-
-- Excel on Mac version 15.19 (160206).
-
-- PowerPoint on Mac version 15.24 (160614)
 
 - The manifest .xml file for the add-in you want to test.
 
@@ -75,36 +63,12 @@ To see how your add-in will run in Office on iOS, you can sideload your add-in's
 
     ![Insert Add-ins in the Excel app.](../images/excel-insert-add-in.png)
 
-## Sideload an add-in in Office on Mac
-
-1. Open **Terminal** and go to one of the following folders where you'll save your add-in's manifest file. If the `wef` folder doesn't exist on your computer, create it.
-
-    - For Word:  `/Users/<username>/Library/Containers/com.microsoft.Word/Data/Documents/wef`
-    - For Excel:  `/Users/<username>/Library/Containers/com.microsoft.Excel/Data/Documents/wef`
-    - For PowerPoint: `/Users/<username>/Library/Containers/com.microsoft.Powerpoint/Data/Documents/wef`
-
-2. Open the folder in **Finder** using the command `open .` (including the period or dot). Copy your add-in's manifest file to this folder.
-
-    ![Wef folder in Office on Mac.](../images/all-my-files.png)
-
-3. Open Word, and then open a document. Restart Word if it's already running.
-
-4. In Word, choose **Insert** > **Add-ins** > **My Add-ins** (drop-down menu), and then choose your add-in.
-
-    ![My Add-ins in Office on Mac.](../images/my-add-ins-wikipedia.png)
-
-    > [!IMPORTANT]
-    > Sideloaded add-ins will not show up in the My Add-ins dialog box. They are only visible within the drop-down menu (small down-arrow to the right of My Add-ins on the **Insert** tab). Sideloaded add-ins are listed under the **Developer Add-ins** heading in this menu.
-
-5. Verify that your add-in is displayed in Word.
-
-    ![Office Add-in displayed in Office on Mac.](../images/lorem-ipsum-wikipedia.png)
-
 ## Remove a sideloaded add-in
 
 You can remove a previously sideloaded add-in by clearing the Office cache on your computer. Details on how to clear the cache for each platform and application can be found in the article [Clear the Office cache](clear-cache.md).
 
 ## See also
 
+- [Sideload Office Add-ins on Mac for testing](sideload-an-office-add-in-on-mac.md)
 - [Debug Office Add-ins on a Mac](debug-office-add-ins-on-ipad-and-mac.md)
 - [Sideload Outlook add-ins for testing](../outlook/sideload-outlook-add-ins-for-testing.md)

--- a/docs/testing/sideload-an-office-add-in-on-mac.md
+++ b/docs/testing/sideload-an-office-add-in-on-mac.md
@@ -20,7 +20,7 @@ To see how your add-in will run on Office on Mac, you can sideload your add-in's
 
 - Excel on Mac version 15.19 (160206).
 
-- PowerPoint on Mac version 15.24 (160614)
+- PowerPoint on Mac version 15.24 (160614).
 
 - The manifest .xml file for the add-in you want to test.
 

--- a/docs/testing/sideload-an-office-add-in-on-mac.md
+++ b/docs/testing/sideload-an-office-add-in-on-mac.md
@@ -1,7 +1,7 @@
 ---
 title: Sideload Office Add-ins on Mac for testing
 description: Test your Office Add-in on Mac by sideloading.
-ms.date: 06/29/2022
+ms.date: 07/07/2022
 ms.localizationpriority: medium
 ---
 
@@ -26,26 +26,28 @@ To see how your add-in will run on Office on Mac, you can sideload your add-in's
 
 ## Sideload an add-in in Office on Mac
 
-1. Open **Terminal** and go to one of the following folders where you'll save your add-in's manifest file. If the `wef` folder doesn't exist on your computer, create it.
+1. Use **Finder** to sideload the manifest file. Open **Finder** and enter Command+Shift+G to open the **Go to folder** dialog.
+
+1. Enter one of the following folders, based on the application you want to use for sideloading. If the `wef` folder doesn't exist on your computer, create it. The remaining steps describe how to sideload a Word add-in.
 
     - For Word:  `/Users/<username>/Library/Containers/com.microsoft.Word/Data/Documents/wef`
     - For Excel:  `/Users/<username>/Library/Containers/com.microsoft.Excel/Data/Documents/wef`
     - For PowerPoint: `/Users/<username>/Library/Containers/com.microsoft.Powerpoint/Data/Documents/wef`
 
-2. Open the folder in **Finder** using the command `open .` (including the period or dot). Copy your add-in's manifest file to this folder.
+1. Copy your add-in's manifest file to this `wef` folder.
 
     ![Wef folder in Office on Mac.](../images/all-my-files.png)
 
-3. Open Word, and then open a document. Restart Word if it's already running.
+1. Open Word, and then open a document. Restart Word if it's already running.
 
-4. In Word, choose **Insert** > **Add-ins** > **My Add-ins** (drop-down menu), and then choose your add-in.
+1. In Word, choose **Insert** > **Add-ins** > **My Add-ins** (drop-down menu), and then choose your add-in.
 
     ![My Add-ins in Office on Mac.](../images/my-add-ins-wikipedia.png)
 
     > [!IMPORTANT]
     > Sideloaded add-ins will not show up in the My Add-ins dialog box. They are only visible within the drop-down menu (small down-arrow to the right of My Add-ins on the **Insert** tab). Sideloaded add-ins are listed under the **Developer Add-ins** heading in this menu.
 
-5. Verify that your add-in is displayed in Word.
+1. Verify that your add-in is displayed in Word.
 
     ![Office Add-in displayed in Office on Mac.](../images/lorem-ipsum-wikipedia.png)
 

--- a/docs/testing/sideload-an-office-add-in-on-mac.md
+++ b/docs/testing/sideload-an-office-add-in-on-mac.md
@@ -26,7 +26,7 @@ To see how your add-in will run on Office on Mac, you can sideload your add-in's
 
 ## Sideload an add-in in Office on Mac
 
-1. Use **Finder** to sideload the manifest file. Open **Finder** and enter Command+Shift+G to open the **Go to folder** dialog.
+1. Use **Finder** to sideload the manifest file. Open **Finder** and then enter Command+Shift+G to open the **Go to folder** dialog.
 
 1. Enter one of the following filepaths, based on the application you want to use for sideloading. If the `wef` folder doesn't exist on your computer, create it.
 
@@ -34,8 +34,8 @@ To see how your add-in will run on Office on Mac, you can sideload your add-in's
     - For Excel:  `/Users/<username>/Library/Containers/com.microsoft.Excel/Data/Documents/wef`
     - For PowerPoint: `/Users/<username>/Library/Containers/com.microsoft.Powerpoint/Data/Documents/wef`
 
-    > [!NOTE]
-    > The remaining steps describe how to sideload a Word add-in.
+        > [!NOTE]
+        > The remaining steps describe how to sideload a Word add-in.
 
 1. Copy your add-in's manifest file to this `wef` folder.
 

--- a/docs/testing/sideload-an-office-add-in-on-mac.md
+++ b/docs/testing/sideload-an-office-add-in-on-mac.md
@@ -28,11 +28,14 @@ To see how your add-in will run on Office on Mac, you can sideload your add-in's
 
 1. Use **Finder** to sideload the manifest file. Open **Finder** and enter Command+Shift+G to open the **Go to folder** dialog.
 
-1. Enter one of the following folders, based on the application you want to use for sideloading. If the `wef` folder doesn't exist on your computer, create it. The remaining steps describe how to sideload a Word add-in.
+1. Enter one of the following filepaths, based on the application you want to use for sideloading. If the `wef` folder doesn't exist on your computer, create it.
 
     - For Word:  `/Users/<username>/Library/Containers/com.microsoft.Word/Data/Documents/wef`
     - For Excel:  `/Users/<username>/Library/Containers/com.microsoft.Excel/Data/Documents/wef`
     - For PowerPoint: `/Users/<username>/Library/Containers/com.microsoft.Powerpoint/Data/Documents/wef`
+
+    > [!NOTE]
+    > The remaining steps describe how to sideload a Word add-in.
 
 1. Copy your add-in's manifest file to this `wef` folder.
 

--- a/docs/testing/sideload-an-office-add-in-on-mac.md
+++ b/docs/testing/sideload-an-office-add-in-on-mac.md
@@ -1,0 +1,60 @@
+---
+title: Sideload Office Add-ins on Mac for testing
+description: Test your Office Add-in on Mac by sideloading.
+ms.date: 06/29/2022
+ms.localizationpriority: medium
+---
+
+# Sideload Office Add-ins on Mac for testing
+
+To see how your add-in will run on Office on Mac, you can sideload your add-in's manifest. This action won't enable you to set breakpoints and debug your add-in's code while it's running, but you can see how it behaves and verify that the UI is usable and rendering appropriately.
+
+> [!NOTE]
+> To sideload an Outlook add-in, see [Sideload Outlook add-ins for testing](../outlook/sideload-outlook-add-ins-for-testing.md).
+
+## Prerequisites for Office on Mac
+
+- A Mac running OS X v10.10 "Yosemite" or later with [Office on Mac](https://products.office.com/buy/compare-microsoft-office-products?tab=omac) installed.
+
+- Word on Mac version 15.18 (160109).
+
+- Excel on Mac version 15.19 (160206).
+
+- PowerPoint on Mac version 15.24 (160614)
+
+- The manifest .xml file for the add-in you want to test.
+
+## Sideload an add-in in Office on Mac
+
+1. Open **Terminal** and go to one of the following folders where you'll save your add-in's manifest file. If the `wef` folder doesn't exist on your computer, create it.
+
+    - For Word:  `/Users/<username>/Library/Containers/com.microsoft.Word/Data/Documents/wef`
+    - For Excel:  `/Users/<username>/Library/Containers/com.microsoft.Excel/Data/Documents/wef`
+    - For PowerPoint: `/Users/<username>/Library/Containers/com.microsoft.Powerpoint/Data/Documents/wef`
+
+2. Open the folder in **Finder** using the command `open .` (including the period or dot). Copy your add-in's manifest file to this folder.
+
+    ![Wef folder in Office on Mac.](../images/all-my-files.png)
+
+3. Open Word, and then open a document. Restart Word if it's already running.
+
+4. In Word, choose **Insert** > **Add-ins** > **My Add-ins** (drop-down menu), and then choose your add-in.
+
+    ![My Add-ins in Office on Mac.](../images/my-add-ins-wikipedia.png)
+
+    > [!IMPORTANT]
+    > Sideloaded add-ins will not show up in the My Add-ins dialog box. They are only visible within the drop-down menu (small down-arrow to the right of My Add-ins on the **Insert** tab). Sideloaded add-ins are listed under the **Developer Add-ins** heading in this menu.
+
+5. Verify that your add-in is displayed in Word.
+
+    ![Office Add-in displayed in Office on Mac.](../images/lorem-ipsum-wikipedia.png)
+
+## Remove a sideloaded add-in
+
+You can remove a previously sideloaded add-in by clearing the Office cache on your computer. Details on how to clear the cache for each platform and application can be found in the article [Clear the Office cache](clear-cache.md).
+
+## See also
+
+- [Sideload Office Add-ins on iPad for testing](sideload-an-office-add-in-on-ipad.md)
+- [Debug Office Add-ins on a Mac](debug-office-add-ins-on-ipad-and-mac.md)
+- [Sideload Outlook add-ins for testing](../outlook/sideload-outlook-add-ins-for-testing.md)

--- a/docs/testing/sideload-office-add-ins-for-testing.md
+++ b/docs/testing/sideload-office-add-ins-for-testing.md
@@ -102,6 +102,7 @@ You can remove a previously sideloaded add-in by clearing your browser's cache. 
 
 ## See also
 
-- [Sideload Office Add-ins on iPad and Mac](sideload-an-office-add-in-on-ipad-and-mac.md)
+- [Sideload Office Add-ins on Mac](sideload-an-office-add-in-on-mac.md)
+- [Sideload Office Add-ins on iPad](sideload-an-office-add-in-on-ipad.md)
 - [Sideload Outlook add-ins for testing](../outlook/sideload-outlook-add-ins-for-testing.md)
 - [Clear the Office cache](clear-cache.md)

--- a/docs/testing/test-debug-office-add-ins.md
+++ b/docs/testing/test-debug-office-add-ins.md
@@ -29,7 +29,9 @@ You can use sideloading to install an Office Add-in for testing without having t
 
 - [Sideload Office Add-ins in Office on the web](sideload-office-add-ins-for-testing.md)
 
-- [Sideload Office Add-ins on iPad and Mac](sideload-an-office-add-in-on-ipad-and-mac.md)
+- [Sideload Office Add-ins on Mac](sideload-an-office-add-in-on-mac.md)
+
+- [Sideload Office Add-ins on iPad](sideload-an-office-add-in-on-ipad.md)
 
 - [Sideload Outlook add-ins for testing](../outlook/sideload-outlook-add-ins-for-testing.md)
 

--- a/docs/testing/troubleshoot-development-errors.md
+++ b/docs/testing/troubleshoot-development-errors.md
@@ -108,7 +108,8 @@ When you're loading the Office JavaScript Library from a local copy instead of f
 ## See also
 
 - [Debug add-ins in Office on the web](debug-add-ins-in-office-online.md)
-- [Sideload an Office Add-in on iPad and Mac](sideload-an-office-add-in-on-ipad-and-mac.md)  
+- [Sideload an Office Add-in on Mac](sideload-an-office-add-in-on-mac.md)  
+- [Sideload an Office Add-in on iPad](sideload-an-office-add-in-on-ipad.md)  
 - [Debug Office Add-ins on a Mac](debug-office-add-ins-on-ipad-and-mac.md)  
 - [Microsoft Office Add-in Debugger Extension for Visual Studio Code](debug-with-vs-extension.md)
 - [Validate an Office Add-in's manifest](troubleshoot-manifest.md)

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -312,8 +312,10 @@ items:
         href: testing/debug-add-ins-in-office-online.md
     - name: iPad and Mac
       items:
-      - name: Sideload Office Add-ins on iPad and Mac
-        href: testing/sideload-an-office-add-in-on-ipad-and-mac.md
+      - name: Sideload Office Add-ins on Mac
+        href: testing/sideload-an-office-add-in-on-mac.md
+      - name: Sideload Office Add-ins on iPad
+        href: testing/sideload-an-office-add-in-on-ipad.md
       - name: Debug on Mac
         href: testing/debug-office-add-ins-on-ipad-and-mac.md
     - name: Clear the Office cache


### PR DESCRIPTION
Addressing customer suggestion #3502. I agree with the customer's take that using only Finder is more logical for this process. Tested and confirmed steps on Mac OS. 