### PR TITLE
[Excel, Word, PPT] (Errors) Abstracting the Excel errors page to app-specific

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -208,6 +208,11 @@
             "redirect_document_id": false
         },
         {
+            "source_path": "docs/excel/excel-add-ins-error-handling.md",
+            "redirect_url": "/office/dev/add-ins/testing/application-specific-api-error-handling.md",
+            "redirect_document_id": true
+        },
+        {
             "source_path": "docs/excel/excel-add-ins-extend-excel.md",
             "redirect_url": "/office/dev/add-ins/excel/excel-add-ins-overview",
             "redirect_document_id": true

--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -209,7 +209,7 @@
         },
         {
             "source_path": "docs/excel/excel-add-ins-error-handling.md",
-            "redirect_url": "/office/dev/add-ins/testing/application-specific-api-error-handling.md",
+            "redirect_url": "/office/dev/add-ins/testing/application-specific-api-error-handling",
             "redirect_document_id": true
         },
         {

--- a/docs/excel/performance.md
+++ b/docs/excel/performance.md
@@ -241,6 +241,6 @@ async function run() {
 ## See also
 
 * [Excel JavaScript object model in Office Add-ins](excel-add-ins-core-concepts.md)
-* [Error handling with the Excel JavaScript API](excel-add-ins-error-handling.md)
+* [Error handling with the application-specific JavaScript APIs](../testing/application-specific-api-error-handling.md)
 * [Resource limits and performance optimization for Office Add-ins](../concepts/resource-limits-and-performance-optimization.md)
 * [Worksheet Functions Object (JavaScript API for Excel)](/javascript/api/excel/excel.functions)

--- a/docs/reference/javascript-api-for-office-error-codes.md
+++ b/docs/reference/javascript-api-for-office-error-codes.md
@@ -137,6 +137,6 @@ The following table summarizes binding behavior in Word.
 
 - [Office Add-ins development lifecycle](../overview/office-add-ins.md)
 - [Understanding the Office JavaScript API](../develop/understanding-the-javascript-api-for-office.md)
-- [Error handling with the Excel JavaScript API](../excel/excel-add-ins-error-handling.md)
+- [Error handling with the application-specific JavaScript APIs](../testing/application-specific-api-error-handling.md)
 - [Troubleshoot error messages for single sign-on (SSO)](../develop/troubleshoot-sso-in-office-add-ins.md)
 - [Troubleshoot development errors with Office Add-ins](../testing/troubleshoot-development-errors.md)

--- a/docs/testing/application-specific-api-error-handling.md
+++ b/docs/testing/application-specific-api-error-handling.md
@@ -1,21 +1,18 @@
 ---
-title: Error handling with the Excel JavaScript API
-description: Learn about Excel JavaScript API error handling logic to account for runtime errors.
-ms.date: 06/10/2022
+title: Error handling with the application-specific JavaScript APIs
+description: Learn about Excel, Word, PowerPoint, and other application-specific JavaScript API error handling logic to account for runtime errors.
+ms.date: 07/05/2022
 ms.localizationpriority: medium
 ---
 
 
-# Error handling with the Excel JavaScript API
+# Error handling with the application-specific JavaScript APIs
 
-When you build an add-in using the Excel JavaScript API, be sure to include error handling logic to account for runtime errors. Doing so is critical, due to the asynchronous nature of the API.
-
-> [!NOTE]
-> For more information about the `sync()` method and the asynchronous nature of Excel JavaScript API, see [Excel JavaScript object model in Office Add-ins](excel-add-ins-core-concepts.md).
+When you build an add-in using the [application-specific Office JavaScript APIs](../develop/application-specific-api-model.md), be sure to include error handling logic to account for runtime errors. Doing so is critical, due to the asynchronous nature of the APIs.
 
 ## Best practices
 
-In our [code samples](https://github.com/OfficeDev/Office-Add-in-samples) and [Script Lab](../overview/explore-with-script-lab.md) snippets, you'll notice that every call to `Excel.run` is accompanied by a `catch` statement to catch any errors that occur within the `Excel.run`. We recommend that you use the same pattern when you build an add-in using the Excel JavaScript APIs.
+In our [code samples](https://github.com/OfficeDev/Office-Add-in-samples) and [Script Lab](../overview/explore-with-script-lab.md) snippets, you'll notice that every call to `Excel.run`, `PowerPoint.run`, or `Word.run` is accompanied by a `catch` statement to catch any errors. We recommend that you use the same pattern when you build an add-in using the application-specific APIs.
 
 ```js
 $("#run").click(() => tryCatch(run));
@@ -44,7 +41,7 @@ async function tryCatch(callback) {
 
 ## API errors
 
-When an Excel JavaScript API request fails to run successfully, the API returns an error object that contains the following properties.
+When an Office JavaScript API request fails to run successfully, the API returns an error object that contains the following properties.
 
 - **code**:  The `code` property of an error message contains a string that is part of the `OfficeExtension.ErrorCodes` or `Excel.ErrorCodes` list. For example, the error code "InvalidReference" indicates that the reference is not valid for the specified operation. Error codes are not localized.
 
@@ -64,7 +61,7 @@ The following table is a list of errors that the API may return.
 |`AccessDenied` |You cannot perform the requested operation.| |
 |`ActivityLimitReached`|Activity limit has been reached.| |
 |`ApiNotAvailable`|The requested API is not available.| |
-|`ApiNotFound`|The API you are trying to use could not be found. It may be available in a newer version of Excel. See the [Excel JavaScript API requirement sets](/javascript/api/requirement-sets/excel/excel-api-requirement-sets) article for more information.| |
+|`ApiNotFound`|The API you are trying to use could not be found. It may be available in a newer version of Excel. See the [Excel JavaScript API requirement sets](/javascript/api/requirement-sets) article for more information.| |
 |`BadPassword`|The password you supplied is incorrect.| |
 |`Conflict`|Request could not be processed because of a conflict.| |
 |`ContentLengthRequired`|A `Content-length` HTTP header is missing.| |
@@ -86,7 +83,7 @@ The following table is a list of errors that the API may return.
 |`MemoryLimitReached`|The memory limit has been reached. Your action could not be completed.| |
 |`MergedRangeConflict`|Cannot complete the operation. A table can't overlap with another table, a PivotTable report, query results, merged cells, or an XML Map.|
 |`NonBlankCellOffSheet`|Microsoft Excel can't insert new cells because it would push non-empty cells off the end of the worksheet. These non-empty cells might appear empty but have blank values, some formatting, or a formula. Delete enough rows or columns to make room for what you want to insert and then try again.| |
-|`NotImplemented`|The requested feature isn't implemented.| |
+|`NotImplemented`|The requested feature isn't implemented.| This could mean the API is in preview or only supported on a particular platform (such as online-only). See [Office client application and platform availability for Office Add-ins](/javascript/api/requirement-sets) for more information.|
 |`OperationCellsExceedLimit`|The attempted operation affects more than the limit of 33554000 cells.| If the `TableColumnCollection.add API` triggers this error, confirm that there is no unintentional data within the worksheet but outside of the table. In particular, check for data in the right-most columns of the worksheet. Remove the unintended data to resolve this error. One way to verify how many cells that an operation processes is to run the following calculation: `(number of table rows) x (16383 - (number of table columns))`. The number 16383 is the maximum number of columns that Excel supports. <br><br>This error only occurs in Excel on the web. |
 |`PivotTableRangeConflict`|The attempted operation causes a conflict with a PivotTable range.| |
 |`RangeExceedsLimit`|The cell count in the range has exceeded the maximum supported number. See the [Resource limits and performance optimization for Office Add-ins](../concepts/resource-limits-and-performance-optimization.md#excel-add-ins) article for more information.| |
@@ -101,7 +98,7 @@ The following table is a list of errors that the API may return.
 |`UnsupportedSheet`|This sheet type does not support this operation, since it is a Macro or Chart sheet.| |
 
 > [!NOTE]
-> The preceding table lists error messages you may encounter while using the Excel JavaScript API. If you are working with the Common API instead of the application-specific Excel JavaScript API, see [Office Common API error codes](../reference/javascript-api-for-office-error-codes.md) to learn about relevant error messages.
+> The preceding table lists error messages you may encounter while using the application-specific APIs. If you are working with the Common API, see [Office Common API error codes](../reference/javascript-api-for-office-error-codes.md) to learn about relevant error messages.
 
 ## Error notifications
 
@@ -111,6 +108,5 @@ If you're not using React for the UI, consider using the older Fabric UI compone
 
 ## See also
 
-- [Excel JavaScript object model in Office Add-ins](excel-add-ins-core-concepts.md)
 - [OfficeExtension.Error object (JavaScript API for Excel)](/javascript/api/office/officeextension.error?view=excel-js-preview&preserve-view=true)
 - [Office Common API error codes](../reference/javascript-api-for-office-error-codes.md)

--- a/docs/testing/application-specific-api-error-handling.md
+++ b/docs/testing/application-specific-api-error-handling.md
@@ -61,7 +61,7 @@ The following table is a list of errors that the API may return.
 |`AccessDenied` |You cannot perform the requested operation.| |
 |`ActivityLimitReached`|Activity limit has been reached.| |
 |`ApiNotAvailable`|The requested API is not available.| |
-|`ApiNotFound`|The API you are trying to use could not be found. It may be available in a newer version of Excel. See the [Excel JavaScript API requirement sets](/javascript/api/requirement-sets) article for more information.| |
+|`ApiNotFound`|The API you are trying to use could not be found. It may be available in a newer version of Excel. See the [Excel JavaScript API requirement sets](/javascript/api/requirement-sets/excel/excel-api-requirement-sets) article for more information.| |
 |`BadPassword`|The password you supplied is incorrect.| |
 |`Conflict`|Request could not be processed because of a conflict.| |
 |`ContentLengthRequired`|A `Content-length` HTTP header is missing.| |

--- a/docs/testing/application-specific-api-error-handling.md
+++ b/docs/testing/application-specific-api-error-handling.md
@@ -52,9 +52,12 @@ When an Office JavaScript API request fails to run successfully, the API returns
 > [!NOTE]
 > If you use `console.log()` to print error messages to the console, those messages are only visible on the server. End users do not see those error messages in the add-in task pane or anywhere in the Office application. To report errors to the user, see [Error notifications](#error-notifications).
 
-## Error Messages
+## Error Codes and messages
 
-The following table is a list of errors that the API may return.
+The following tables list the errors that application-specific APIs may return.
+
+> [!NOTE]
+> The preceding table lists error messages you may encounter while using the application-specific APIs. If you are working with the Common API, see [Office Common API error codes](../reference/javascript-api-for-office-error-codes.md) to learn about relevant error messages.
 
 |Error code | Error message | Notes |
 |:----------|:--------------|:------|
@@ -65,11 +68,7 @@ The following table is a list of errors that the API may return.
 |`BadPassword`|The password you supplied is incorrect.| |
 |`Conflict`|Request could not be processed because of a conflict.| |
 |`ContentLengthRequired`|A `Content-length` HTTP header is missing.| |
-|`EmptyChartSeries`|The attempted operation failed because the chart series is empty.| |
-|`FilteredRangeConflict`|The attempted operation causes a conflict with a filtered range.| |
-|`FormulaLengthExceedsLimit`|The bytecode of the applied formula exceeds the maximum length limit. For Office on 32-bit machines, the bytecode length limit is 16384 characters. On 64-bit machines, the bytecode length limit is 32768 characters.| This error occurs in both Excel on the web and on desktop.|
 |`GeneralException`|There was an internal error while processing the request.| |
-|`InactiveWorkbook`|The operation failed because multiple workbooks are open and the workbook being called by this API has lost focus.| |
 |`InsertDeleteConflict`|The insert or delete operation attempted resulted in a conflict.| |
 |`InvalidArgument` |The argument is invalid or missing or has an incorrect format.| |
 |`InvalidBinding` |This object binding is no longer valid due to previous updates.| |
@@ -81,24 +80,30 @@ The following table is a list of errors that the API may return.
 |`ItemAlreadyExists`|The resource being created already exists.| |
 |`ItemNotFound` |The requested resource doesn't exist.| |
 |`MemoryLimitReached`|The memory limit has been reached. Your action could not be completed.| |
-|`MergedRangeConflict`|Cannot complete the operation. A table can't overlap with another table, a PivotTable report, query results, merged cells, or an XML Map.|
-|`NonBlankCellOffSheet`|Microsoft Excel can't insert new cells because it would push non-empty cells off the end of the worksheet. These non-empty cells might appear empty but have blank values, some formatting, or a formula. Delete enough rows or columns to make room for what you want to insert and then try again.| |
 |`NotImplemented`|The requested feature isn't implemented.| This could mean the API is in preview or only supported on a particular platform (such as online-only). See [Office client application and platform availability for Office Add-ins](/javascript/api/requirement-sets) for more information.|
-|`OperationCellsExceedLimit`|The attempted operation affects more than the limit of 33554000 cells.| If the `TableColumnCollection.add API` triggers this error, confirm that there is no unintentional data within the worksheet but outside of the table. In particular, check for data in the right-most columns of the worksheet. Remove the unintended data to resolve this error. One way to verify how many cells that an operation processes is to run the following calculation: `(number of table rows) x (16383 - (number of table columns))`. The number 16383 is the maximum number of columns that Excel supports. <br><br>This error only occurs in Excel on the web. |
-|`PivotTableRangeConflict`|The attempted operation causes a conflict with a PivotTable range.| |
-|`RangeExceedsLimit`|The cell count in the range has exceeded the maximum supported number. See the [Resource limits and performance optimization for Office Add-ins](../concepts/resource-limits-and-performance-optimization.md#excel-add-ins) article for more information.| |
-|`RefreshWorkbookLinksBlocked`|The operation failed because the user hasn't granted permission to refresh external workbook links.| |
 |`RequestAborted`|The request was aborted during run time.| |
-|`RequestPayloadSizeLimitExceeded`|The request payload size has exceeded the limit. See the [Resource limits and performance optimization for Office Add-ins](../concepts/resource-limits-and-performance-optimization.md#excel-add-ins) article for more information.| This error only occurs in Excel on the web.|
-|`ResponsePayloadSizeLimitExceeded`|The response payload size has exceeded the limit. See the [Resource limits and performance optimization for Office Add-ins](../concepts/resource-limits-and-performance-optimization.md#excel-add-ins) article for more information.|  This error only occurs in Excel on the web.|
+|`RequestPayloadSizeLimitExceeded`|The request payload size has exceeded the limit. See the [Resource limits and performance optimization for Office Add-ins](../concepts/resource-limits-and-performance-optimization.md#excel-add-ins) article for more information.| This error only occurs in Office on the web.|
+|`ResponsePayloadSizeLimitExceeded`|The response payload size has exceeded the limit. See the [Resource limits and performance optimization for Office Add-ins](../concepts/resource-limits-and-performance-optimization.md#excel-add-ins) article for more information.|  This error only occurs in Office on the web.|
 |`ServiceNotAvailable`|The service is unavailable.| |
 |`Unauthenticated` |Required authentication information is either missing or invalid.| |
 |`UnsupportedFeature`|The operation failed because the source worksheet contains one or more unsupported features.| |
 |`UnsupportedOperation`|The operation being attempted is not supported.| |
-|`UnsupportedSheet`|This sheet type does not support this operation, since it is a Macro or Chart sheet.| |
 
-> [!NOTE]
-> The preceding table lists error messages you may encounter while using the application-specific APIs. If you are working with the Common API, see [Office Common API error codes](../reference/javascript-api-for-office-error-codes.md) to learn about relevant error messages.
+### Excel-specific error codes and messages
+
+|Error code | Error message | Notes |
+|:----------|:--------------|:------|
+|`EmptyChartSeries`|The attempted operation failed because the chart series is empty.| |
+|`FilteredRangeConflict`|The attempted operation causes a conflict with a filtered range.| |
+|`FormulaLengthExceedsLimit`|The bytecode of the applied formula exceeds the maximum length limit. For Office on 32-bit machines, the bytecode length limit is 16384 characters. On 64-bit machines, the bytecode length limit is 32768 characters.| This error occurs in both Excel on the web and on desktop.|
+|`InactiveWorkbook`|The operation failed because multiple workbooks are open and the workbook being called by this API has lost focus.| |
+|`MergedRangeConflict`|Cannot complete the operation. A table can't overlap with another table, a PivotTable report, query results, merged cells, or an XML Map.|
+|`NonBlankCellOffSheet`|Microsoft Excel can't insert new cells because it would push non-empty cells off the end of the worksheet. These non-empty cells might appear empty but have blank values, some formatting, or a formula. Delete enough rows or columns to make room for what you want to insert and then try again.| |
+|`OperationCellsExceedLimit`|The attempted operation affects more than the limit of 33554000 cells.| If the `TableColumnCollection.add API` triggers this error, confirm that there is no unintentional data within the worksheet but outside of the table. In particular, check for data in the right-most columns of the worksheet. Remove the unintended data to resolve this error. One way to verify how many cells that an operation processes is to run the following calculation: `(number of table rows) x (16383 - (number of table columns))`. The number 16383 is the maximum number of columns that Excel supports. <br><br>This error only occurs in Excel on the web. |
+|`PivotTableRangeConflict`|The attempted operation causes a conflict with a PivotTable range.| |
+|`RangeExceedsLimit`|The cell count in the range has exceeded the maximum supported number. See the [Resource limits and performance optimization for Office Add-ins](../concepts/resource-limits-and-performance-optimization.md#excel-add-ins) article for more information.| |
+|`RefreshWorkbookLinksBlocked`|The operation failed because the user hasn't granted permission to refresh external workbook links.| |
+|`UnsupportedSheet`|This sheet type does not support this operation, since it is a Macro or Chart sheet.| |
 
 ## Error notifications
 

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -85,8 +85,6 @@ items:
         href: develop/persisting-add-in-state-and-settings.md
       - name: Bind to regions in a document or spreadsheet
         href: develop/bind-to-regions-in-a-document-or-spreadsheet.md
-      - name: Common API error codes
-        href: reference/javascript-api-for-office-error-codes.md
     - name: Setup and run your add-in
       items:
       - name: Reference Office.js
@@ -321,16 +319,22 @@ items:
       displayName: uninstall, sideload
     - name: Debug with runtime logging
       href: testing/runtime-logging.md
+    - name: Errors
+      items:
+      - name: Application-specific API error handling
+        href: testing/application-specific-api-error-handling.md
+      - name: Common API error codes
+        href: reference/javascript-api-for-office-error-codes.md
+      - name: Troubleshoot user errors
+        href: testing/testing-and-troubleshooting.md
+      - name: Troubleshoot development errors
+        href: testing/troubleshoot-development-errors.md
     - name: Performance
       items:
       - name: Avoid using the context.sync method in loops
         href: concepts/correlated-objects-pattern.md
       - name: Resource limits and performance optimization for Office Add-ins
         href: concepts/resource-limits-and-performance-optimization.md
-    - name: Troubleshoot user errors
-      href: testing/testing-and-troubleshooting.md
-    - name: Troubleshoot development errors
-      href: testing/troubleshoot-development-errors.md
     - name: Unit testing
       href: testing/unit-testing.md
     - name: Usability testing
@@ -427,9 +431,6 @@ items:
           displayName: Excel, preview
     - name: Data validation
       href: excel/excel-add-ins-data-validation.md
-      displayName: Excel
-    - name: Error handling
-      href: excel/excel-add-ins-error-handling.md
       displayName: Excel
     - name: Events
       href: excel/excel-add-ins-events.md


### PR DESCRIPTION
This PR moves the error code and handling articles to the testing section of the TOC. It also generalizes the Excel error handling article to cover the whole application-specific space. Finally, it adds a note about when you'd get the `NotImplemented` error (which was the genesis of this PR...)

I'm open to thoughts about where these articles should live in the TOC. This is just my proposal.