### PR TITLE
[Outlook] (manifest) Clarify use of Highlight attribute

### DIFF
--- a/docs/outlook/use-regular-expressions-to-show-an-outlook-add-in.md
+++ b/docs/outlook/use-regular-expressions-to-show-an-outlook-add-in.md
@@ -1,17 +1,17 @@
 ---
 title: Use regular expression activation rules to show an add-in
 description: Learn how to use regular expression activation rules for Outlook contextual add-ins.
-ms.date: 07/08/2022
+ms.date: 08/19/2022
 ms.localizationpriority: medium
 ---
 
 # Use regular expression activation rules to show an Outlook add-in
 
-You can specify regular expression rules to have a [contextual add-in](contextual-outlook-add-ins.md) activated when a match is found in specific fields of the message. Contextual add-ins activate only in read mode, Outlook does not activate contextual add-ins when the user is composing an item. There are also other scenarios where Outlook does not activate add-ins, for example, digitally signed items. For more information, see [Activation rules for Outlook add-ins](activation-rules.md).
+You can specify regular expression rules to have a [contextual add-in](contextual-outlook-add-ins.md) activated when a match is found in specific fields of the message. Contextual add-ins activate only in read mode. Outlook doesn't activate contextual add-ins when the user is composing an item. There are also other scenarios where Outlook doesn't activate add-ins, for example, digitally signed items. For more information, see [Activation rules for Outlook add-ins](activation-rules.md).
 
 You can specify a regular expression as part of an [ItemHasRegularExpressionMatch](/javascript/api/manifest/rule#itemhasregularexpressionmatch-rule) rule or [ItemHasKnownEntity](/javascript/api/manifest/rule#itemhasknownentity-rule) rule in the add-in XML manifest. The rules are specified in a [DetectedEntity](/javascript/api/manifest/extensionpoint#detectedentity) extension point.
 
-Outlook evaluates regular expressions based on the rules for the JavaScript interpreter used by the browser on the client computer. Outlook supports the same list of special characters that all XML processors also support. The following table lists these special characters. You can use these characters in a regular expression by specifying the escaped sequence for the corresponding character, as described in the following table.
+Outlook evaluates regular expressions based on the rules for the JavaScript interpreter used by the browser on the client computer. Outlook supports the same list of special characters that all XML processors also support. The following table lists these special characters. You can use these characters in a regular expression by specifying the escape sequence of the corresponding character, as described in the following table.
 
 |Character|Description|Escape sequence to use|
 |:-----|:-----|:-----|
@@ -29,15 +29,15 @@ An  `ItemHasRegularExpressionMatch` rule is useful in controlling activation of 
 |:-----|:-----|
 |`RegExName`|Specifies the name of the regular expression so that you can refer to the expression in the code for your add-in.|
 |`RegExValue`|Specifies the regular expression that will be evaluated to determine whether the add-in should be shown.|
-|`PropertyName`|Specifies the name of the property that the regular expression will be evaluated against. The allowed values are `BodyAsHTML`, `BodyAsPlaintext`, `SenderSMTPAddress`, and `Subject`.<br/><br/>If you specify `BodyAsHTML`, Outlook only applies the regular expression if the item body is HTML. Otherwise, Outlook returns no matches for that regular expression.<br/><br/>If you specify `BodyAsPlaintext`, Outlook always applies the regular expression on the item body.<br/><br/>**Note:** You must set the `PropertyName` attribute to `BodyAsPlaintext` if you specify the `Highlight` attribute for the `Rule` element.|
+|`PropertyName`|Specifies the name of the property that the regular expression will be evaluated against. The allowed values are `BodyAsHTML`, `BodyAsPlaintext`, `SenderSMTPAddress`, and `Subject`.<br/><br/>If you specify `BodyAsHTML`, Outlook only applies the regular expression if the item body is HTML. Otherwise, Outlook returns no matches for that regular expression.<br/><br/>If you specify `BodyAsPlaintext`, Outlook always applies the regular expression on the item body.<br/><br/>**Important:** If you need to specify the **Highlight** attribute for the **\<Rule\>** element, you must set the **PropertyName** attribute to `BodyAsPlaintext`. |
 |`IgnoreCase`|Specifies whether to ignore case when matching the regular expression specified by `RegExName`.|
-| `Highlight` | Specifies how the client should highlight matching text. This element can only be applied to `Rule` elements within `ExtensionPoint` elements. Can be one of the following: `all` or `none`. If not specified, the default value is `all`.<br/><br/>**Note:** You must set the `PropertyName` attribute to `BodyAsPlaintext` if you specify the `Highlight` attribute for the `Rule` element. |
+| `Highlight` | Specifies how the client should highlight matching text. This element can only be applied to `Rule` elements within `ExtensionPoint` elements. Can be one of the following: `all` or `none`. If not specified, the default value is `all`.<br/><br/>**Important:** To specify the **Highlight** attribute in the **\<Rule\>** element, you must set the **PropertyName** attribute to `BodyAsPlaintext`. |
 
 ### Best practices for using regular expressions in rules
 
 Pay special attention to the following when you use regular expressions.
 
-- If you specify an `ItemHasRegularExpressionMatch` rule on the body of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as `.*` to attempt to obtain the entire body of an item does not always return the expected results.
+- If you specify an `ItemHasRegularExpressionMatch` rule on the body of an item, the regular expression should further filter the body and shouldn't attempt to return the entire body of the item. Using a regular expression such as `.*` to attempt to obtain the entire body of an item doesn't always return the expected results.
 - The plain text body returned on one browser can be different in subtle ways on another. If you use an `ItemHasRegularExpressionMatch` rule with `BodyAsPlaintext` as the `PropertyName` attribute, test your regular expression on all the browsers that your add-in supports.
 
     Because different browsers use different ways to obtain the text body of a selected item, you should make sure that your regular expression supports the subtle differences that can be returned as part of the body text. For example, some browsers such as Internet Explorer 9 uses the `innerText` property of the DOM, and others such as Firefox uses the `.textContent()` method to obtain the text body of an item. Also, different browsers may return line breaks differently: a line break is `\r\n` on Internet Explorer, and `\n` on Firefox and Chrome. For more information, se [W3C DOM Compatibility - HTML](https://quirksmode.org/dom/html/).
@@ -84,7 +84,7 @@ The following `ItemHasRegularExpressionMatch` rule activates the add-in whenever
 An `ItemHasKnownEntity` rule activates an add-in based on the existence of an entity in the subject or body of the selected item. The [EntityType](/javascript/api/outlook/office.mailboxenums.entitytype) type defines the supported entities. Applying a regular expression on an `ItemHasKnownEntity` rule provides the convenience where activation is based on a subset of values for an entity (for example, a specific set of URLs, or telephone numbers with a certain area code).
 
 > [!NOTE]
-> Outlook can only extract entity strings in English regardless of the default locale specified in the manifest. Only messages support the `MeetingSuggestion` entity type; appointments do not. You cannot extract entities from items in the **Sent Items** folder, nor can you use an `ItemHasKnownEntity` rule to activate an add-in for items in the **Sent Items** folder.
+> Outlook can only extract entity strings in English regardless of the default locale specified in the manifest. Only messages support the `MeetingSuggestion` entity type; appointments don't support this. You can't extract entities from items in the **Sent Items** folder, nor can you use an `ItemHasKnownEntity` rule to activate an add-in for items in the **Sent Items** folder.
 
 The `ItemHasKnownEntity` rule supports the attributes in the following table. Note that while specifying a regular expression is optional in an `ItemHasKnownEntity` rule, if you choose to use a regular expression as an entity filter, you must specify both the `RegExFilter` and `FilterName` attributes.
 
@@ -120,7 +120,7 @@ You can obtain matches to a regular expression by using the following methods on
 When the regular expressions are evaluated, the matches are returned to your add-in in an array object. For `getRegExMatches`, that object has the identifier of the name of the regular expression.
 
 > [!NOTE]
-> Outlook does not return matches in any particular order in the array. Also, you should not assume that matches are returned in the same order in this array even when you run the same add-in on each of these clients on the same item in the same mailbox.
+> Outlook doesn't return matches in any particular order in the array. Also, you shouldn't assume that matches are returned in the same order in this array even when you run the same add-in on each of these clients on the same item in the same mailbox.
 
 ### Examples
 
@@ -183,4 +183,4 @@ const suggestions = Office.context.mailbox.item.getFilteredEntitiesByName("CampS
 - [Activation rules for Outlook add-ins](activation-rules.md)
 - [Limits for activation and JavaScript API for Outlook add-ins](limits-for-activation-and-javascript-api-for-outlook-add-ins.md)
 - [Match strings in an Outlook item as well-known entities](match-strings-in-an-item-as-well-known-entities.md)
-- [Best Practices for Regular Expressions in the .NET Framework](/dotnet/standard/base-types/best-practices)
+- [Best practices for regular expressions in the .NET framework](/dotnet/standard/base-types/best-practices)


### PR DESCRIPTION
In response to a [forum post](https://stackoverflow.com/questions/73088079/outlook-add-in-regular-expression-works-on-body-but-not-on-subject) and internal bug 165177.