### PR TITLE
[Outlook] (manifest) update 2 overviews for JSON manifest awareness

### DIFF
--- a/docs/outlook/manifests.md
+++ b/docs/outlook/manifests.md
@@ -1,13 +1,17 @@
 ---
 title: Outlook add-in manifests
-description: The manifest describes how an Outlook add-in integrates across Outlook clients; includes an example.
-ms.date: 05/27/2020
+description: Get an overview of the two kinds of manifests available for Outlook Add-ins.
+ms.date: 10/18/2022
 ms.localizationpriority: high
 ---
 
 # Outlook add-in manifests
 
-An Outlook add-in consists of two components: the XML add-in manifest and a web page supported by the JavaScript library for Office Add-ins (office.js). The manifest describes how the add-in integrates across Outlook clients. The following is an example.
+An Outlook add-in consists of two components: the add-in manifest and a web app supported by the JavaScript library for Office Add-ins (office.js). The manifest describes how the add-in integrates across Outlook clients.
+
+There are two possible formats for the manifest: XML and JSON. You can learn about the JSON manifest at [Teams manifest for Office Add-ins (preview)](json-manifest-overview.md). This article is about the XML manifest.
+
+The following is an example of the XML manifest.
 
  > [!NOTE]
  > All URL values in the following sample begin with "https://appdemo.contoso.com". This value is a placeholder. In an actual valid manifest, these values would contain valid https web URLs.
@@ -413,7 +417,6 @@ Activation rules can be used to activate an add-in based on one or more of the f
 - The presence of an attachment
 
 For details and samples of activation rules, see [Activation rules for Outlook add-ins](activation-rules.md).
-
 
 ## Next steps: Add-in commands
 

--- a/docs/outlook/manifests.md
+++ b/docs/outlook/manifests.md
@@ -9,7 +9,7 @@ ms.localizationpriority: high
 
 An Outlook add-in consists of two components: the add-in manifest and a web app supported by the JavaScript library for Office Add-ins (office.js). The manifest describes how the add-in integrates across Outlook clients.
 
-There are two possible formats for the manifest: XML and JSON. You can learn about the JSON manifest at [Teams manifest for Office Add-ins (preview)](json-manifest-overview.md). This article is about the XML manifest.
+There are two possible formats for the manifest: XML and JSON. You can learn about the JSON manifest at [Teams manifest for Office Add-ins (preview)](../develop/json-manifest-overview.md). This article is about the XML manifest.
 
 The following is an example of the XML manifest.
 

--- a/docs/outlook/testing-and-tips.md
+++ b/docs/outlook/testing-and-tips.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy and install Outlook add-ins for testing
 description: Create a manifest file, deploy the add-in UI file to a web server, install the add-in in your mailbox, and then test the add-in.
-ms.date: 07/08/2021
+ms.date: 10/18/2022
 ms.localizationpriority: high
 ---
 
@@ -19,7 +19,7 @@ As part of the process of developing an Outlook add-in, you'll probably find you
 
 ## Create a manifest file for the add-in
 
-Each add-in is described by an XML manifest, a document that gives the server information about the add-in, provides descriptive information about the add-in for the user, and identifies the location of the add-in UI HTML file. You can store the manifest in a local folder or server, as long as the location is accessible by the Exchange server of the mailbox that you're testing with. We'll assume that you store your manifest in a local folder. For information about how to create a manifest file, see [Outlook add-in manifests](manifests.md).
+Each add-in is described by a manifest, a document that gives the server information about the add-in, provides descriptive information about the add-in for the user, and identifies the location of the add-in UI HTML file. You can store the manifest in a local folder or server, as long as the location is accessible by the Exchange server of the mailbox that you're testing with. We'll assume that you store your manifest in a local folder. For information about how to create a manifest file, see [Outlook add-in manifests](manifests.md).
 
 ## Deploy an add-in to a web server
 


### PR DESCRIPTION
This is a very minimalist update of two articles to make them compatible with the fact that there is now a JSON-formatted manifest (in preview). 

More extensive updates of one or both of these should be done too with the aim of not duplicating manifest documentation between the Outlook docs and the overall Office Add-in docs. 