### PR TITLE
[Outlook] (categories) Correct categories API support in OWA

### DIFF
--- a/docs/outlook/categories.md
+++ b/docs/outlook/categories.md
@@ -1,7 +1,7 @@
 ---
 title: Get and set categories
 description: How to manage categories on mailbox and item.
-ms.date: 10/03/2022
+ms.date: 11/09/2022
 ms.localizationpriority: medium
 ---
 
@@ -84,7 +84,7 @@ You can use the API to add, get, and remove categories for a message or appointm
 > [!IMPORTANT]
 > Only categories in the master list on your mailbox are available for you to apply to a message or appointment. See the earlier section [Manage categories in the master list](#manage-categories-in-the-master-list) for more information.
 >
-> In Outlook on the web, you can't use the API to manage categories on a message in Read mode.
+> In Outlook on the web, you can't use the API to manage categories on a message in Compose mode.
 
 ### Add categories to an item
 


### PR DESCRIPTION
Per our [reference documentation](https://learn.microsoft.com/en-us/javascript/api/outlook/office.categories?view=outlook-js-preview#outlook-office-categories-addasync-member(1)), the categories API isn't supported in Compose mode in Outlook on the web.