### PR TITLE
[all hosts] (Application-specific APIs) Adding undo behavior note

### DIFF
--- a/docs/develop/application-specific-api-model.md
+++ b/docs/develop/application-specific-api-model.md
@@ -1,7 +1,7 @@
 ---
 title: Using the application-specific API model
 description: Learn about the promise-based API model for Excel, OneNote, and Word add-ins.
-ms.date: 09/23/2022
+ms.date: 11/18/2022
 ms.localizationpriority: medium
 ---
 
@@ -246,6 +246,10 @@ await Excel.run(async (context) => {
     dataSheet.position = 1;
 });
 ```
+
+## Application undo stack
+
+When an application-specific API is processed, the undo stack of the application is cleared. This means that you can't undo changes made prior to any action done by an add-in (unless that add-in only uses Common APIs or doesn't interact with the file). The same is true for changes made by the add-in.
 
 ## See also
 

--- a/docs/testing/runtimes.md
+++ b/docs/testing/runtimes.md
@@ -1,13 +1,13 @@
 ---
 title: Runtimes in Office Add-ins
 description: Learn about the runtimes that are used by Office Add-ins.
-ms.date: 09/28/2022
+ms.date: 11/18/2022
 ms.localizationpriority: medium
 ---
 
 # Runtimes in Office Add-ins
 
-Office Add-ins execute in runtimes embedded in Office. As an interpreted language, JavaScript must run in a JavaScript runtime. [Node.js](https://nodejs.org) and modern browsers are examples of such runtimes. 
+Office Add-ins execute in runtimes embedded in Office. As an interpreted language, JavaScript must run in a JavaScript runtime. [Node.js](https://nodejs.org) and modern browsers are examples of such runtimes.
 
 ## Types of runtimes
 
@@ -18,7 +18,7 @@ There are two types of runtimes used by Office Add-ins:
 
 Details about these types are later in this article at [JavaScript-only runtime](#javascript-only-runtime) and [Browser runtime](#browser-runtime).
 
-The following table shows which possible features of an add-in use each type of runtime. 
+The following table shows which possible features of an add-in use each type of runtime.
 
 | Type of runtime | Add-in feature |
 |:-----|:-----|
@@ -35,13 +35,12 @@ The following table shows the same information organized by which type of runtim
 |dialog | browser | browser | browser |
 |function command | browser | browser | browser |
 
-
-In Office on the web, everything always runs in a browser type runtime. In fact, with one exception, everything in an add-in on the web runs in the *same* browser process: the browser process in which the user has opened Office on the web. The exception is when a dialog is opened with a call of [Office.ui.displayDialogAsync](/javascript/api/office/office.ui#office-office-ui-displaydialogasync-member(1)) and the [DialogOptions.displayInIFrame](/javascript/api/office/office.dialogoptions#office-office-dialogoptions-displayiniframe-member) option is *not* passed and set to `true`. When the option is not passed (so it has the default `false` value), the dialog opens in its own process. The same principle applies to the [OfficeRuntime.displayWebDialog](/javascript/api/office-runtime#office-runtime-officeruntime-displaywebdialog-function(1)) method and the [OfficeRuntime.DisplayWebDialogOptions.displayInIFrame](/javascript/api/office-runtime/officeruntime.displaywebdialogoptions#office-runtime-officeruntime-displaywebdialogoptions-displayiniframe-member) option.
+In Office on the web, everything always runs in a browser type runtime. With one exception, everything in an add-in on the web runs in the *same* browser process: the browser process in which the user has opened Office on the web. The exception is when a dialog is opened with a call of [Office.ui.displayDialogAsync](/javascript/api/office/office.ui#office-office-ui-displaydialogasync-member(1)) and the [DialogOptions.displayInIFrame](/javascript/api/office/office.dialogoptions#office-office-dialogoptions-displayiniframe-member) option is *not* passed and set to `true`. When the option is not passed (so it has the default `false` value), the dialog opens in its own process. The same principle applies to the [OfficeRuntime.displayWebDialog](/javascript/api/office-runtime#office-runtime-officeruntime-displaywebdialog-function(1)) method and the [OfficeRuntime.DisplayWebDialogOptions.displayInIFrame](/javascript/api/office-runtime/officeruntime.displaywebdialogoptions#office-runtime-officeruntime-displaywebdialogoptions-displayiniframe-member) option.
 
 When an add-in is running on a platform other than the web, the following principles apply.
 
-- A dialog runs in its own runtime process. 
-- An Outlook event-based task runs in its own runtime process. 
+- A dialog runs in its own runtime process.
+- An Outlook event-based task runs in its own runtime process.
 - By default, task panes, function commands, and Excel custom functions each run in their own runtime process. However, for some Office host applications, the add-in manifest can be configured so that any two, or all three, can run in the same runtime. See [Shared runtime](#shared-runtime).
 
 Depending on the host Office application and the features used in the add-in, there may be many runtimes in an add-in. Each usually will run in its own process but not necessarily simultaneously. The following are examples.
@@ -50,7 +49,7 @@ Depending on the host Office application and the features used in the add-in, th
 
   - A task pane
   - A function command
-  - A dialog (A dialog can be launched from either the task pane or the function command.) 
+  - A dialog (A dialog can be launched from either the task pane or the function command.)
   
       > [!NOTE]
       > It's not a good practice to have multiple dialogs open simultaneously, but if the add-in enables the user to open one from the task pane and another from the function command at the same time, this add-in would have four runtimes. A task pane, and a given invocation of a function command can have only one open dialog at a time; but if the function command is invoked multiple times, a new dialog is opened on top of its predecessor with each invocation, so there could be many runtimes. The remainder of this list ignores the possibility of multiple open dialogs.
@@ -64,7 +63,7 @@ Depending on the host Office application and the features used in the add-in, th
 
 - An Excel add-in with the same features and is configured to share the same runtime across the task pane, function command, and custom function, has *two* runtimes. A shared runtime can open only one dialog at a time.
 - An Excel add-in with the same features, except that it has no dialog, and is configured to share the same runtime across the task pane, function command, and custom function, has *one* runtime.
-- An Outlook add-in that has the following features has as many as *four* runtimes. (Runtimes cannot be shared in Outlook.)
+- An Outlook add-in that has the following features has as many as *four* runtimes. Runtimes cannot be shared in Outlook.
 
   - A task pane
   - A function command
@@ -74,29 +73,30 @@ Depending on the host Office application and the features used in the add-in, th
 ## Share data across runtimes
 
 > [!NOTE]
+>
 > - If you know that your add-in will only be used in Office on the web and that it will not open any dialogs with the `displayInIFrame` option set to `true`, then you can ignore this section. Since everything in your add-in runs in the same runtime process, you can just use global variables to share data between features.
-> - As noted above in [Types of runtimes](#types-of-runtimes), the type of runtime used by a feature varies partly by platform. It's a good practice to avoid having add-in code that branches based on platform, so the guidance in this section recommends techniques that will work cross-platform. There is only one case, noted below, in which branching code is required. 
+> - As noted above in [Types of runtimes](#types-of-runtimes), the type of runtime used by a feature varies partly by platform. It's a good practice to avoid having add-in code that branches based on platform, so the guidance in this section recommends techniques that will work cross-platform. There is only one case, noted below, in which branching code is required.
 
 For Excel, PowerPoint, and Word add-ins, use a [Shared runtime](#shared-runtime) when any two or more features, except dialogs, need to share data. In Outlook, or scenarios where sharing a runtime isn't feasible, you need alternative methods. The parts of the add-in that are in separate runtime processes don't share global data automatically and are treated by the add-in's web application server as separate sessions, so [Window.sessionStorage](https://developer.mozilla.org/docs/Web/API/Window/sessionStorage) cannot be used to share data between them. *The following guidance assumes that you're not using a shared runtime.*
 
-- Pass data between a dialog and its parent task pane, function command, or custom function by using the [Office.ui.messageParent](/javascript/api/office/office.ui#office-office-ui-messageparent-member(1)) and [Dialog.messageChild](/javascript/api/office/office.dialog#office-office-dialog-messagechild-member(1)) methods. 
+- Pass data between a dialog and its parent task pane, function command, or custom function by using the [Office.ui.messageParent](/javascript/api/office/office.ui#office-office-ui-messageparent-member(1)) and [Dialog.messageChild](/javascript/api/office/office.dialog#office-office-dialog-messagechild-member(1)) methods.
 
     > [!NOTE]
-    > The `OfficeRuntime.storage` methods cannot be called in a dialog, so this is not an option for sharing data between a dialog and another runtime. 
+    > The `OfficeRuntime.storage` methods cannot be called in a dialog, so this is not an option for sharing data between a dialog and another runtime.
 
-- To share data between a task pane and a function command, store data in [Window.localStorage](https://developer.mozilla.org/docs/Web/API/Window/localStorage), which is shared across all runtimes that access the same specific [origin](https://developer.mozilla.org/docs/Glossary/Origin). 
+- To share data between a task pane and a function command, store data in [Window.localStorage](https://developer.mozilla.org/docs/Web/API/Window/localStorage), which is shared across all runtimes that access the same specific [origin](https://developer.mozilla.org/docs/Glossary/Origin).
     > [!NOTE]
     > LocalStorage isn't accessible in a JavaScript-only runtime and, thus, it isn't available in Excel custom functions. It also can't be used to share data with an Outlook event-based tasks (since those tasks use a JavaScript-only runtime on some platforms).
 
     > [!TIP]
-    > Data in `Window.localStorage` persists between sessions of the add-in and is shared by add-ins with the same origin. Both of these characteristics are often undesirable for an add-in. 
+    > Data in `Window.localStorage` persists between sessions of the add-in and is shared by add-ins with the same origin. Both of these characteristics are often undesirable for an add-in.
     >
-    > - To ensure that each session of a given add-in starts fresh call the [Window.localStorage.clear](https://developer.mozilla.org/docs/Web/API/Storage/clear) method when the add-in starts. 
-    > - To allow some stored values to persist, but reinitialize other values, use [Window.localStorage.setItem](https://developer.mozilla.org/docs/Web/API/Storage/setItem) when the add-in starts for each item that should be reset to an initial value. 
+    > - To ensure that each session of a given add-in starts fresh call the [Window.localStorage.clear](https://developer.mozilla.org/docs/Web/API/Storage/clear) method when the add-in starts.
+    > - To allow some stored values to persist, but reinitialize other values, use [Window.localStorage.setItem](https://developer.mozilla.org/docs/Web/API/Storage/setItem) when the add-in starts for each item that should be reset to an initial value.
     > - To delete an item entirely, call [Window.localStorage.removeItem](https://developer.mozilla.org/docs/Web/API/Storage/removeItem).
 
 - To share data between an Excel custom function and any other runtime, use [OfficeRuntime.storage](/javascript/api/office-runtime/officeruntime.storage).
-- To share data between an Outlook event-based task and a task pane or function command, you must branch your code by the value of the [Office.context.platform](/javascript/api/office/office.context#office-office-context-platform-member) property. 
+- To share data between an Outlook event-based task and a task pane or function command, you must branch your code by the value of the [Office.context.platform](/javascript/api/office/office.context#office-office-context-platform-member) property.
 
     - When the value is `PC` (Windows), store and retrieve data using the [Office.sessionData](/javascript/api/outlook/office.sessiondata) APIs.
     - When the value is `Mac`, use `Window.localStorage` as described earlier in this list.
@@ -110,9 +110,9 @@ For more information, see [Persist add-in state and settings](../develop/persist
 
 ## JavaScript-only runtime
 
-The JavaScript-only runtime that is used in Office Add-ins is a modification of an open source runtime originally created for [React Native](https://reactnative.dev/). It contains a JavaScript engine supplemented with support for [WebSockets](https://developer.mozilla.org/docs/Web/API/WebSockets_API), [Full CORS (Cross-Origin Resource Sharing)](https://developer.mozilla.org/docs/Web/HTTP/CORS), and [OfficeRuntime.storage](/javascript/api/office-runtime/officeruntime.storage). It doesn't have a rendering engine, and it doesn't support cookies or [local storage](https://developer.mozilla.org/docs/Web/API/Window/localStorage). 
+The JavaScript-only runtime that is used in Office Add-ins is a modification of an open source runtime originally created for [React Native](https://reactnative.dev/). It contains a JavaScript engine supplemented with support for [WebSockets](https://developer.mozilla.org/docs/Web/API/WebSockets_API), [Full CORS (Cross-Origin Resource Sharing)](https://developer.mozilla.org/docs/Web/HTTP/CORS), and [OfficeRuntime.storage](/javascript/api/office-runtime/officeruntime.storage). It doesn't have a rendering engine, and it doesn't support cookies or [local storage](https://developer.mozilla.org/docs/Web/API/Window/localStorage).
 
-This type of runtime is used in Outlook event-based tasks in Office on Windows only and in Excel custom functions *except* when the custom functions are [sharing a runtime](#shared-runtime). 
+This type of runtime is used in Outlook event-based tasks in Office on Windows only and in Excel custom functions *except* when the custom functions are [sharing a runtime](#shared-runtime).
 
 - When used for an Excel custom function, the runtime starts up when either the worksheet recalculates or the custom function calculates. It doesn't shut down until the workbook is closed.  
 - When used in an Outlook event-based task, the runtime starts up when the event occurs. It ends when the first of the following occurs.
@@ -134,7 +134,7 @@ A browser runtime lifespan varies depending on the feature that it implements an
 - When an add-in with a task pane is launched, a browser runtime starts, unless it's a shared runtime that is already running. If it's a shared runtime, it shuts down when the document is closed. If it's not a shared runtime, it shuts down when the task pane is closed.
 - When a dialog is opened, a browser runtime starts. It shuts down when the dialog is closed.
 - When a function command is executed (which happens when a user selects its button or menu item), a browser runtime starts, unless it's a shared runtime that is already running. If it's a shared runtime, it shuts down when the document is closed. If it's not a shared runtime, it shuts down when the first of the following occurs.
- 
+
   - The function command calls the `completed` method of its event parameter.
   - 5 minutes have elapsed since the triggering event. (If a dialog was opened in the function command and it's still open when the parent runtime times out, the dialog runtime stays running until the dialog is closed.)
 
@@ -150,6 +150,7 @@ A browser runtime has more features than a JavaScript-only runtime, but starts u
 A "shared runtime" isn't a type of runtime. It refers to a [browser-type runtime](#browser-runtime) that's being shared by features of the add-in that would otherwise each have their own runtime. Specifically, you have the option of configuring the add-in's task pane and function commands to share a runtime. In an Excel add-in, you can also configure custom functions to share the runtime of a task pane or function command or both. When you do this, the custom functions are running in a browser-type runtime, instead of a [JavaScript-only runtime](#javascript-only-runtime) as it otherwise would. See [Configure your add-in to use a shared runtime](../develop/configure-your-add-in-to-use-a-shared-runtime.md) for information about the benefits and limitations of sharing runtimes and instructions for configuring the add-in to use a shared runtime. In brief, the JavaScript-only runtime uses less memory and starts up faster, but has fewer features.
 
 > [!NOTE]
-> - You can share runtimes only in Excel, PowerPoint, and Word. 
+>
+> - You can share runtimes only in Excel, PowerPoint, and Word.
 > - You cannot configure a dialog to share a runtime. Each dialog always has its own, except when the dialog is launched in Office on the web with the `displayInIFrame` option set to `true`.
 > - A shared runtime never uses the original Microsoft Edge WebView (EdgeHTML) runtime. If the conditions for using Microsoft Edge with WebView2 (Chromium-based) are met (as specified in [Browsers used by Office Add-ins](../concepts/browsers-used-by-office-web-add-ins.md)), then that runtime is used. Otherwise, the Internet Explorer 11 runtime is used.


### PR DESCRIPTION
This PR adds a note to let people know that the undo stack is cleared when an application-specific API is called.

It also does some minor cleanup to the runtimes article, because I considered that article as a place to add this note.

One note for reviewers: I thought about adding information to the custom functions runtime article, but voted against it. Saying non-shared runtimes support undo with CFs sounds too much like an endorsement. However, I'm open to other thoughts.