### PR TITLE
[All hosts](deployment) Add information on when admin consent required again

### DIFF
--- a/docs/develop/sso-in-office-add-ins.md
+++ b/docs/develop/sso-in-office-add-ins.md
@@ -94,6 +94,9 @@ The following is an example of the markup.
 </WebApplicationInfo>
 ```
 
+> [!IMPORTANT]
+> If your add-in is deployed by one or more admins to their organizations, adding new scopes to the manifest will require the admin to consent to the updates. Users will be blocked from the add-in until consent is granted.
+
 > [!NOTE]
 > If you don't follow the format requirements in the manifest for SSO, your add-in will be rejected from AppSource until it meets the required format.
 

--- a/docs/includes/deploy-updates-that-require-admin-consent.md
+++ b/docs/includes/deploy-updates-that-require-admin-consent.md
@@ -1,0 +1,7 @@
+## Deploy updates
+
+When you add features or fix bugs in your add-in you'll need to deploy the updates. If your add-in is deployed by one or more admins to their organizations, some manifest changes will require the admin to consent to the updates. Users will be blocked from the add-in until consent is granted. We recommend you test deployment behavior on a staging site before deploying updates live. The following manifest changes will require the admin to consent again.
+
+- Changes to requested [permissions](/javascript/api/manifest/permissions).
+- Adding new [scopes](/javascript/api/manifest/scopes).
+- Adding new [Outlook events](../outlook/autolaunch.md).

--- a/docs/includes/deploy-updates-that-require-admin-consent.md
+++ b/docs/includes/deploy-updates-that-require-admin-consent.md
@@ -1,5 +1,5 @@
-When you add features or fix bugs in your add-in you'll need to deploy the updates. If your add-in is deployed by one or more admins to their organizations, some manifest changes will require the admin to consent to the updates. Users will be blocked from the add-in until consent is granted. The following manifest changes will require the admin to consent again.
+When you add features or fix bugs in your add-in, you'll need to deploy the updates. If your add-in is deployed by one or more admins to their organizations, some manifest changes will require the admin to consent to the updates. Users will be blocked from the add-in until consent is granted. The following manifest changes will require the admin to consent again.
 
 - Changes to requested [permissions](/javascript/api/manifest/permissions).
-- Adding new [scopes](/javascript/api/manifest/scopes).
-- Adding new [Outlook events](../outlook/autolaunch.md).
+- Additional [scopes](/javascript/api/manifest/scopes).
+- Additional [Outlook events](../outlook/autolaunch.md).

--- a/docs/includes/deploy-updates-that-require-admin-consent.md
+++ b/docs/includes/deploy-updates-that-require-admin-consent.md
@@ -1,6 +1,4 @@
-## Deploy updates
-
-When you add features or fix bugs in your add-in you'll need to deploy the updates. If your add-in is deployed by one or more admins to their organizations, some manifest changes will require the admin to consent to the updates. Users will be blocked from the add-in until consent is granted. We recommend you test deployment behavior on a staging site before deploying updates live. The following manifest changes will require the admin to consent again.
+When you add features or fix bugs in your add-in you'll need to deploy the updates. If your add-in is deployed by one or more admins to their organizations, some manifest changes will require the admin to consent to the updates. Users will be blocked from the add-in until consent is granted. The following manifest changes will require the admin to consent again.
 
 - Changes to requested [permissions](/javascript/api/manifest/permissions).
 - Adding new [scopes](/javascript/api/manifest/scopes).

--- a/docs/outlook/manifests.md
+++ b/docs/outlook/manifests.md
@@ -1,7 +1,7 @@
 ---
 title: Outlook add-in manifests
 description: Get an overview of the two kinds of manifests available for Outlook Add-ins.
-ms.date: 10/18/2022
+ms.date: 01/23/2023
 ms.localizationpriority: high
 ---
 
@@ -269,7 +269,7 @@ The root element for the Outlook add-in manifest is **\<OfficeApp\>**. This elem
 
 This is the version of the specific add-in. If a developer updates something in the manifest, the version must be incremented as well. This way, when the new manifest is installed, it will overwrite the existing one and the user will get the new functionality. If this add-in was submitted to the store, the new manifest will have to be re-submitted and re-validated. Then, users of this add-in will get the new updated manifest automatically in a few hours, after it is approved.
 
-If the add-in's requested permissions change, users will be prompted to upgrade and re-consent to the add-in. If the admin installed this add-in for the entire organization, the admin will have to re-consent first. Users will continue to see old functionality in the meantime.
+If the add-in's requested permissions change, users will be prompted to upgrade and re-consent to the add-in. If the admin installed this add-in for the entire organization, the admin will have to re-consent first. Users will be unable to use the add-in until consent is granted.
 
 ## VersionOverrides
 

--- a/docs/publish/deploy-office-add-in-sso-to-azure.md
+++ b/docs/publish/deploy-office-add-in-sso-to-azure.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy a single sign-on (SSO) Office Add-in to Microsoft Azure App Service | Microsoft Docs
 description: Learn how to deploy an Office Add-in that uses single sign-on (SSO) to Microsoft Azure App Service from Visual Studio Code.
-ms.date: 01/12/2020
+ms.date: 01/23/2023
 ms.localizationpriority: medium
 ---
 
@@ -272,6 +272,8 @@ Sideload the **./dist/manifest.xml** file and test the functionality of the add-
 > If your app registration is on a different tenant than where you sideload the add-in, the add-in will not have admin consent for Microsoft Graph. To test in this scenario you need an admin to centrally deploy the add-in on the Microsoft 365 tenant. For more information, see [Deploy add-ins in the Microsoft 365 admin center](/microsoft-365/admin/manage/manage-deployment-of-add-ins)
 
 If you encounter any deployment issues, see the [Azure App Service troubleshooting documentation](/troubleshoot/azure/app-service/welcome-app-service). If you use central deployment, or plan to deploy to App Source, we recommend you [validate the Office Add-in's manifest](../testing/troubleshoot-manifest.md#office-store-validation) using the '-p' option for production.
+
+[!INCLUDE [deploy-updates-that-require-admin-consent](../includes/deploy-updates-that-require-admin-consent.md)]
 
 ## Next steps
 

--- a/docs/publish/deploy-office-add-in-sso-to-azure.md
+++ b/docs/publish/deploy-office-add-in-sso-to-azure.md
@@ -264,6 +264,10 @@ Once the files and app registration are updated, you can deploy the add-in.
 
 If you make additional code changes, you'll need to run `npm run build` again and redeploy the project.
 
+### Deploy updates
+
+[!INCLUDE [deploy-updates-that-require-admin-consent](../includes/deploy-updates-that-require-admin-consent.md)]
+
 ## Test the deployment
 
 Sideload the **./dist/manifest.xml** file and test the functionality of the add-in in Office. For more information, see [Sideload an Office Add-in for testing](../testing/test-debug-office-add-ins.md#sideload-an-office-add-in-for-testing).
@@ -272,8 +276,6 @@ Sideload the **./dist/manifest.xml** file and test the functionality of the add-
 > If your app registration is on a different tenant than where you sideload the add-in, the add-in will not have admin consent for Microsoft Graph. To test in this scenario you need an admin to centrally deploy the add-in on the Microsoft 365 tenant. For more information, see [Deploy add-ins in the Microsoft 365 admin center](/microsoft-365/admin/manage/manage-deployment-of-add-ins)
 
 If you encounter any deployment issues, see the [Azure App Service troubleshooting documentation](/troubleshoot/azure/app-service/welcome-app-service). If you use central deployment, or plan to deploy to App Source, we recommend you [validate the Office Add-in's manifest](../testing/troubleshoot-manifest.md#office-store-validation) using the '-p' option for production.
-
-[!INCLUDE [deploy-updates-that-require-admin-consent](../includes/deploy-updates-that-require-admin-consent.md)]
 
 ## Next steps
 

--- a/docs/publish/host-an-office-add-in-on-microsoft-azure.md
+++ b/docs/publish/host-an-office-add-in-on-microsoft-azure.md
@@ -1,7 +1,7 @@
 ---
 title: Host an Office Add-in on Microsoft Azure | Microsoft Docs
 description: Learn how to deploy an add-in web app to Azure and sideload the add-in for testing in an Office client application.
-ms.date: 07/07/2020
+ms.date: 01/23/2023
 ms.localizationpriority: medium
 ---
 
@@ -153,6 +153,8 @@ Visual Studio creates a basic Word add-in that you'll be able to publish as-is, 
 5. On the ribbon of the **Home** tab, choose the **Show Taskpane** button. The add-in opens in a task pane to the right of the current document.
 
 6. Verify that the add-in works by selecting some text in the document and choosing the **Highlight!** button in the task pane.
+
+[!INCLUDE [deploy-updates-that-require-admin-consent](../includes/deploy-updates-that-require-admin-consent.md)]
 
 ## See also
 

--- a/docs/publish/host-an-office-add-in-on-microsoft-azure.md
+++ b/docs/publish/host-an-office-add-in-on-microsoft-azure.md
@@ -154,6 +154,8 @@ Visual Studio creates a basic Word add-in that you'll be able to publish as-is, 
 
 6. Verify that the add-in works by selecting some text in the document and choosing the **Highlight!** button in the task pane.
 
+## Deploy updates
+
 [!INCLUDE [deploy-updates-that-require-admin-consent](../includes/deploy-updates-that-require-admin-consent.md)]
 
 ## See also

--- a/docs/publish/maintain-breaking-changes.md
+++ b/docs/publish/maintain-breaking-changes.md
@@ -58,6 +58,8 @@ The [office-js NPM package](https://www.npmjs.com/package/@microsoft/office-js) 
 
 While we strive to maintain backwards compatibility, the patterns and practices we recommend continually evolve. Our documentation strives to present the current best practices. To stay informed of new features that may improve your existing functionality, join our monthly [Office Add-ins Community Call](../overview/office-add-ins-community-call.md).
 
+## Deploy updates
+
 [!INCLUDE [deploy-updates-that-require-admin-consent](../includes/deploy-updates-that-require-admin-consent.md)]
 
 ## Community engagement

--- a/docs/publish/maintain-breaking-changes.md
+++ b/docs/publish/maintain-breaking-changes.md
@@ -1,7 +1,7 @@
 ---
 title: Maintain your Office Add-in
 description: Understand our commitments to compatibility and how to keep your add-in up to date.
-ms.date: 05/03/2022
+ms.date: 01/23/2023
 ms.localizationpriority: medium
 ---
 
@@ -57,6 +57,8 @@ The [office-js NPM package](https://www.npmjs.com/package/@microsoft/office-js) 
 ## Current best practices
 
 While we strive to maintain backwards compatibility, the patterns and practices we recommend continually evolve. Our documentation strives to present the current best practices. To stay informed of new features that may improve your existing functionality, join our monthly [Office Add-ins Community Call](../overview/office-add-ins-community-call.md).
+
+[!INCLUDE [deploy-updates-that-require-admin-consent](../includes/deploy-updates-that-require-admin-consent.md)]
 
 ## Community engagement
 

--- a/docs/publish/package-your-add-in-using-visual-studio.md
+++ b/docs/publish/package-your-add-in-using-visual-studio.md
@@ -1,7 +1,7 @@
 ---
 title: Publish your add-in using Visual Studio
 description: How to deploy your web project and package your add-in by using Visual Studio 2019.
-ms.date: 12/02/2019
+ms.date: 01/23/2023
 ms.localizationpriority: medium
 ---
 
@@ -41,6 +41,8 @@ Complete the following steps to package your add-in using Visual Studio 2019.
 You can now upload your XML manifest to the appropriate location to [publish your add-in](../publish/publish.md). You can find the XML manifest in `OfficeAppManifests` in the `app.publish` folder. For example:
 
  `%UserProfile%\Documents\Visual Studio 2019\Projects\MyApp\bin\Debug\app.publish\OfficeAppManifests`
+
+[!INCLUDE [deploy-updates-that-require-admin-consent](../includes/deploy-updates-that-require-admin-consent.md)]
 
 ## See also
 

--- a/docs/publish/package-your-add-in-using-visual-studio.md
+++ b/docs/publish/package-your-add-in-using-visual-studio.md
@@ -42,6 +42,8 @@ You can now upload your XML manifest to the appropriate location to [publish you
 
  `%UserProfile%\Documents\Visual Studio 2019\Projects\MyApp\bin\Debug\app.publish\OfficeAppManifests`
 
+## Deploy updates
+
 [!INCLUDE [deploy-updates-that-require-admin-consent](../includes/deploy-updates-that-require-admin-consent.md)]
 
 ## See also

--- a/docs/publish/publish-add-in-vs-code.md
+++ b/docs/publish/publish-add-in-vs-code.md
@@ -118,6 +118,8 @@ Next, add a MIME type for JSON files.
 
 1. To deploy, in the VS Code **Explorer**, Right-click the **dist** folder, and select **Deploy to Static Website via Azure Storage**. When prompted, select the storage account you created previously. If you already deployed the **dist** folder, you'll be prompted if you want to overwrite the files in the Azure storage with the latest changes.
 
+## Deploy updates
+
 [!INCLUDE [deploy-updates-that-require-admin-consent](../includes/deploy-updates-that-require-admin-consent.md)]
 
 ## See also

--- a/docs/publish/publish-add-in-vs-code.md
+++ b/docs/publish/publish-add-in-vs-code.md
@@ -1,7 +1,7 @@
 ---
 title: Publish an add-in using Visual Studio Code and Azure
 description: How to publish an add-in using Visual Studio Code and Azure Active Directory
-ms.date: 09/07/2022
+ms.date: 01/23/2023
 ms.custom: vscode-azure-extension-update-completed
 ms.localizationpriority: medium
 ---
@@ -117,6 +117,8 @@ Next, add a MIME type for JSON files.
     When the build completes, the **dist** folder in the root directory of your add-in project will contain the files that you'll deploy.
 
 1. To deploy, in the VS Code **Explorer**, Right-click the **dist** folder, and select **Deploy to Static Website via Azure Storage**. When prompted, select the storage account you created previously. If you already deployed the **dist** folder, you'll be prompted if you want to overwrite the files in the Azure storage with the latest changes.
+
+[!INCLUDE [deploy-updates-that-require-admin-consent](../includes/deploy-updates-that-require-admin-consent.md)]
 
 ## See also
 

--- a/docs/publish/publish.md
+++ b/docs/publish/publish.md
@@ -45,11 +45,9 @@ The deployment options that are available depend on the Office application that 
 
 The following sections provide additional information about the deployment methods that are most commonly used to distribute production Office Add-ins to users within an organization.
 
-> [!IMPORTANT]
-> If you deploy updates to an already deployed add-in, some changes in the manifest require admin consent. Users are unable to use the updated add-in until consent is granted. The following changes in the manifest will require the admin to consent to them.
-> - Changes to requested [permissions](/javascript/api/manifest/permissions).
-> - Adding new [scopes](/javascript/api/manifest/scopes).
-> - Adding new [Outlook events](../outlook/autolaunch.md).
+### Deploy updates
+
+[!INCLUDE [deploy-updates-that-require-admin-consent](../includes/deploy-updates-that-require-admin-consent.md)]
 
 For information about how end users acquire, insert, and run add-ins, see [Start using your Office Add-in](https://support.microsoft.com/office/82e665c4-6700-4b56-a3f3-ef5441996862).
 

--- a/docs/publish/publish.md
+++ b/docs/publish/publish.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy and publish Office Add-ins
 description: Methods and options to deploy your Office Add-in for testing or distribution to users.
-ms.date: 06/13/2022
+ms.date: 01/23/2023
 ms.localizationpriority: high
 ---
 
@@ -44,6 +44,12 @@ The deployment options that are available depend on the Office application that 
 ## Production deployment methods
 
 The following sections provide additional information about the deployment methods that are most commonly used to distribute production Office Add-ins to users within an organization.
+
+> [!IMPORTANT]
+> If you deploy updates to an already deployed add-in, some changes in the manifest require admin consent. Users are unable to use the updated add-in until consent is granted. The following changes in the manifest will require the admin to consent to them.
+> - Changes to requested [permissions](/javascript/api/manifest/permissions).
+> - Adding new [scopes](/javascript/api/manifest/scopes).
+> - Adding new [Outlook events](../outlook/autolaunch.md).
 
 For information about how end users acquire, insert, and run add-ins, see [Start using your Office Add-in](https://support.microsoft.com/office/82e665c4-6700-4b56-a3f3-ef5441996862).
 

--- a/docs/testing/testing-and-troubleshooting.md
+++ b/docs/testing/testing-and-troubleshooting.md
@@ -84,11 +84,9 @@ Office.context.ui.displayDialogAsync(startAddress, {displayInIFrame:true}, callb
 
 ## Add-in won't upgrade
 
-You may see the following error when deploying an updated manifest for your add-in: `ADD-IN WARNING: This add-in is currently upgrading. Please close the current message or appointment, and re-open in a few moments.` If your add-in is deployed by one or more admins to their organizations, some manifest changes require the admin to consent to the updates. Users will be blocked from the add-in and see this error message until consent is granted. The following manifest changes require the admin to consent again.
+You may see the following error when deploying an updated manifest for your add-in: `ADD-IN WARNING: This add-in is currently upgrading. Please close the current message or appointment, and re-open in a few moments.`
 
-- Changes to requested [permissions](/javascript/api/manifest/permissions).
-- Additional [scopes](/javascript/api/manifest/scopes).
-- Additional [Outlook events](../outlook/autolaunch.md).
+[!INCLUDE [deploy-updates-that-require-admin-consent](../includes/deploy-updates-that-require-admin-consent.md)]
 
 ## See also
 

--- a/docs/testing/testing-and-troubleshooting.md
+++ b/docs/testing/testing-and-troubleshooting.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshoot user errors with Office Add-ins
 description: Learn how to troubleshoot user errors in Office Add-ins.
-ms.date: 06/10/2022
+ms.date: 01/23/2023
 ms.localizationpriority: medium
 ---
 
@@ -81,6 +81,14 @@ This issue occurs when the Dialog API is used in pop-up mode. To prevent this is
 ```js
 Office.context.ui.displayDialogAsync(startAddress, {displayInIFrame:true}, callback);
 ```
+
+## Add-in won't upgrade
+
+You may see the following error if you are deploying an updated manifest for your add-in. `ADD-IN WARNING: This add-in is currently upgrading. Please close the current message or appointment, and re-open in a few moments.` If your add-in is deployed by one or more admins to their organizations, some manifest changes require the admin to consent to the updates. Users will be blocked from the add-in and see this error message until consent is granted. The following manifest changes will require the admin to consent again.
+
+- Changes to requested [permissions](/javascript/api/manifest/permissions).
+- Adding new [scopes](/javascript/api/manifest/scopes).
+- Adding new [Outlook events](../outlook/autolaunch.md).
 
 ## See also
 

--- a/docs/testing/testing-and-troubleshooting.md
+++ b/docs/testing/testing-and-troubleshooting.md
@@ -84,11 +84,11 @@ Office.context.ui.displayDialogAsync(startAddress, {displayInIFrame:true}, callb
 
 ## Add-in won't upgrade
 
-You may see the following error when deploying an updated manifest for your add-in. `ADD-IN WARNING: This add-in is currently upgrading. Please close the current message or appointment, and re-open in a few moments.` If your add-in is deployed by one or more admins to their organizations, some manifest changes require the admin to consent to the updates. Users will be blocked from the add-in and see this error message until consent is granted. The following manifest changes require the admin to consent again.
+You may see the following error when deploying an updated manifest for your add-in: `ADD-IN WARNING: This add-in is currently upgrading. Please close the current message or appointment, and re-open in a few moments.` If your add-in is deployed by one or more admins to their organizations, some manifest changes require the admin to consent to the updates. Users will be blocked from the add-in and see this error message until consent is granted. The following manifest changes require the admin to consent again.
 
 - Changes to requested [permissions](/javascript/api/manifest/permissions).
-- Adding new [scopes](/javascript/api/manifest/scopes).
-- Adding new [Outlook events](../outlook/autolaunch.md).
+- Additional [scopes](/javascript/api/manifest/scopes).
+- Additional [Outlook events](../outlook/autolaunch.md).
 
 ## See also
 

--- a/docs/testing/testing-and-troubleshooting.md
+++ b/docs/testing/testing-and-troubleshooting.md
@@ -84,7 +84,7 @@ Office.context.ui.displayDialogAsync(startAddress, {displayInIFrame:true}, callb
 
 ## Add-in won't upgrade
 
-You may see the following error if you are deploying an updated manifest for your add-in. `ADD-IN WARNING: This add-in is currently upgrading. Please close the current message or appointment, and re-open in a few moments.` If your add-in is deployed by one or more admins to their organizations, some manifest changes require the admin to consent to the updates. Users will be blocked from the add-in and see this error message until consent is granted. The following manifest changes will require the admin to consent again.
+You may see the following error when deploying an updated manifest for your add-in. `ADD-IN WARNING: This add-in is currently upgrading. Please close the current message or appointment, and re-open in a few moments.` If your add-in is deployed by one or more admins to their organizations, some manifest changes require the admin to consent to the updates. Users will be blocked from the add-in and see this error message until consent is granted. The following manifest changes require the admin to consent again.
 
 - Changes to requested [permissions](/javascript/api/manifest/permissions).
 - Adding new [scopes](/javascript/api/manifest/scopes).


### PR DESCRIPTION
This adds information to relevant articles on when you deploy an updated manifest, and what changes will require the admin to consent again when centrally deployed.