### PR TITLE
[Outlook] (permissions) Clarify description of read permissions

### DIFF
--- a/docs/includes/outlook-permission-levels-table.md
+++ b/docs/includes/outlook-permission-levels-table.md
@@ -1,7 +1,7 @@
 |**Permission level</br>canonical name**|**XML manifest name**|**Teams manifest name**|**Summary description**|
 |:-----|:-----|:-----|:-----|
 |**restricted**|Restricted|MailboxItem.Restricted.User|Allows use of entities, but not regular expressions. |
-|**read item**|ReadItem|MailboxItem.Read.User|In addition to what is allowed in **restricted**, it allows:<ul><li>regular expressions</li><li>Outlook add-in API read access</li><li>getting the item properties and the callback token</li></ul> |
+|**read item**|ReadItem|MailboxItem.Read.User|In addition to what is allowed in **restricted**, it allows:<ul><li>regular expressions</li><li>Outlook add-in API read access</li><li>getting the item properties and the callback token</li><li>writing custom properties</li></ul> |
 |**read/write item**|ReadWriteItem|MailboxItem.ReadWrite.User|In addition to what is allowed in **read item**, it allows:<ul><li>full Outlook add-in API access except `makeEwsRequestAsync`</li><li>setting the item properties</li></ul> |
 |**read/write mailbox**|ReadWriteMailbox|Mailbox.ReadWrite.User|In addition to what is allowed in **read/write item**, it allows:<ul><li>creating, reading, writing items and folders</li><li>sending items</li><li>calling [makeEwsRequestAsync](/javascript/api/requirement-sets/outlook/preview-requirement-set/office.context.mailbox#methods)</li></ul> |
 


### PR DESCRIPTION
Reflects the actions allowed with read permissions as described in [Understanding Outlook add-in permissions](https://learn.microsoft.com/office/dev/add-ins/outlook/understanding-outlook-add-in-permissions#can-do-1).