### PR TITLE
[all hosts] (Support) Windows Server support notes

### DIFF
--- a/docs/concepts/browsers-used-by-office-web-add-ins.md
+++ b/docs/concepts/browsers-used-by-office-web-add-ins.md
@@ -58,18 +58,18 @@ To determine whether Office 2016 or Office 2019 is retail or volume-licensed, us
 
 | Office version | Retail vs. Volume-licensed | Edge WebView2 (Chromium-based) installed? | Browser |
 |:-----|:-----|:-----|:-----|
-| Office 2013 | Doesn't matter | Doesn't matter | Internet Explorer 11 |
-| Office 2016 | Volume-licensed | Doesn't matter | Internet Explorer 11 |
+| Office 2021 | Doesn't matter | Yes<sup>1</sup> | Microsoft Edge<sup>2</sup> with WebView2 (Chromium-based) |
+| Office 2016,<br>Office 2019 | Retail | Yes<sup>1</sup> | Microsoft Edge<sup>2</sup> with WebView2 (Chromium-based) |
+| Office 2016,<br>Office 2019 | Retail | No | Microsoft Edge Legacy (EdgeHTML)<sup>2, 3</sup></br>If Edge isn't installed, Internet Explorer 11 is used. |
 | Office 2019 | Volume-licensed | Doesn't matter | Internet Explorer 11 |
-| Office 2016 to Office 2019 | Retail | No | Microsoft Edge Legacy (EdgeHTML)<sup>1, 2</sup></br>If Edge isn't installed, Internet Explorer 11 is used. |
-| Office 2016 to Office 2019 | Retail | Yes<sup>3</sup> | Microsoft Edge<sup>1</sup> with WebView2 (Chromium-based) |
-| Office 2021 | Doesn't matter | Yes<sup>3</sup> | Microsoft Edge<sup>1</sup> with WebView2 (Chromium-based) |
+| Office 2016 | Volume-licensed | Doesn't matter | Internet Explorer 11 |
+| Office 2013 | Doesn't matter | Doesn't matter | Internet Explorer 11 |
 
-<sup>1</sup> When you use Microsoft Edge, the Windows Narrator (sometimes called a "screen reader") reads the `<title>` tag in the page that opens in the task pane. In Internet Explorer 11, the Narrator reads the title bar of the task pane, which comes from the **\<DisplayName\>** value in the add-in's manifest.
+<sup>1</sup> On Windows versions prior to Windows 11, the WebView2 control must be installed so that Office can embed it. It's installed with perpetual Office 2021 or later; but it isn't automatically installed with Microsoft Edge. If you have an earlier version of perpetual Office, use the instructions for installing the control at [Microsoft Edge WebView2 / Embed web content ... with Microsoft Edge WebView2](https://developer.microsoft.com/microsoft-edge/webview2/).
 
-<sup>2</sup> If your add-in includes the **\<Runtimes\>** element in the manifest, then it will not use Microsoft Edge Legacy (EdgeHTML). If the conditions for using Microsoft Edge with WebView2 (Chromium-based) are met, then the add-in uses that browser. Otherwise, it uses Internet Explorer 11. For more information, see [Runtimes](/javascript/api/manifest/runtimes).
+<sup>2</sup> When you use Microsoft Edge, the Windows Narrator (sometimes called a "screen reader") reads the `<title>` tag in the page that opens in the task pane. In Internet Explorer 11, the Narrator reads the title bar of the task pane, which comes from the **\<DisplayName\>** value in the add-in's manifest.
 
-<sup>3</sup> On Windows versions prior to Windows 11, the WebView2 control must be installed so that Office can embed it. It's installed with perpetual Office 2021 or later; but it isn't automatically installed with Microsoft Edge. If you have an earlier version of perpetual Office, use the instructions for installing the control at [Microsoft Edge WebView2 / Embed web content ... with Microsoft Edge WebView2](https://developer.microsoft.com/microsoft-edge/webview2/).
+<sup>3</sup> If your add-in includes the **\<Runtimes\>** element in the manifest, then it will not use Microsoft Edge Legacy (EdgeHTML). If the conditions for using Microsoft Edge with WebView2 (Chromium-based) are met, then the add-in uses that browser. Otherwise, it uses Internet Explorer 11. For more information, see [Runtimes](/javascript/api/manifest/runtimes).
 
 ## Microsoft 365 subscription versions of Office on Windows
 
@@ -77,20 +77,20 @@ For subscription Office on Windows, the browser that is used is determined by th
 
 |OS|Office version|Edge WebView2 (Chromium-based) installed?|Browser|
 |:-----|:-----|:-----|:-----|
-|Windows 7 | Microsoft 365| Doesn't matter | Internet Explorer 11|
+|Windows 11,<br>Windows 10,<br>Windows 8.1,<br>Windows Server 2022,<br>Windows Server 2019,<br>Windows Server 2016| Microsoft 365 ver.&nbsp;>=&nbsp;16.0.13530.20424<sup>1</sup>| Yes<sup>2</sup>|  Microsoft Edge<sup>3</sup> with WebView2 (Chromium-based) |
+|Window 11,<br>Windows 10 ver.&nbsp;>=&nbsp;1903 | Microsoft 365 ver.&nbsp;>=&nbsp;16.0.13530.20424<sup>1</sup>| No |Microsoft Edge Legacy (EdgeHTML)<sup>3, 4</sup>|
+|Windows 11,<br>Windows 10 ver.&nbsp;>=&nbsp;1903 | Microsoft 365 ver.&nbsp;>=&nbsp;16.0.11629&nbsp;*AND*&nbsp;<&nbsp;16.0.13530.20424<sup>1</sup>| Doesn't matter|Microsoft Edge Legacy (EdgeHTML)<sup>3, 4</sup>|
+|Windows 11,<br>Windows 10 ver.&nbsp;>=&nbsp;1903 | Microsoft 365 ver.&nbsp;<&nbsp;16.0.11629<sup>1</sup>| Doesn't matter|Internet Explorer 11|
 |Windows 10 ver.&nbsp;<&nbsp;1903,<br>Windows 8.1| Microsoft 365 | No| Internet Explorer 11|
-|Windows 11,<br>Windows 10 ver.&nbsp;>=&nbsp;1903 | Microsoft 365 ver.&nbsp;<&nbsp;16.0.11629<sup>2</sup>| Doesn't matter|Internet Explorer 11|
-|Windows 11,<br>Windows 10 ver.&nbsp;>=&nbsp;1903 | Microsoft 365 ver.&nbsp;>=&nbsp;16.0.11629&nbsp;*AND*&nbsp;<&nbsp;16.0.13530.20424<sup>2</sup>| Doesn't matter|Microsoft Edge Legacy (EdgeHTML)<sup>1, 3</sup>|
-|Window 11,<br>Windows 10 ver.&nbsp;>=&nbsp;1903 | Microsoft 365 ver.&nbsp;>=&nbsp;16.0.13530.20424<sup>2</sup>| No |Microsoft Edge Legacy (EdgeHTML)<sup>1, 3</sup>|
-|Windows 11,<br>Windows 10,<br>Windows 8.1,<br>Windows Server 2022,<br>Windows Server 2019,<br>Windows Server 2016| Microsoft 365 ver.&nbsp;>=&nbsp;16.0.13530.20424<sup>2</sup>| Yes<sup>4</sup>|  Microsoft Edge<sup>1</sup> with WebView2 (Chromium-based) |
+|Windows 7 | Microsoft 365| Doesn't matter | Internet Explorer 11|
 
-<sup>1</sup> When you use Microsoft Edge, the Windows Narrator (sometimes called a "screen reader") reads the `<title>` tag in the page that opens in the task pane. In Internet Explorer 11, the Narrator reads the title bar of the task pane, which comes from the **\<DisplayName\>** value in the add-in's manifest.
+<sup>1</sup> See the [update history page](/officeupdates/update-history-office365-proplus-by-date) and how to [find your Office client version and update channel](https://support.microsoft.com/office/932788b8-a3ce-44bf-bb09-e334518b8b19) for more details.
 
-<sup>2</sup> See the [update history page](/officeupdates/update-history-office365-proplus-by-date) and how to [find your Office client version and update channel](https://support.microsoft.com/office/932788b8-a3ce-44bf-bb09-e334518b8b19) for more details.
+<sup>2</sup> On Windows versions prior to Windows 11, the WebView2 control must be installed so that Office can embed it. It's installed with Microsoft 365, Version 2101 or later, but it isn't automatically installed with Microsoft Edge. If you have an earlier version of Microsoft 365, use the instructions for installing the control at [Microsoft Edge WebView2 / Embed web content ... with Microsoft Edge WebView2](https://developer.microsoft.com/microsoft-edge/webview2/). On Microsoft 365 builds before 16.0.14326.xxxxx, you must also create the registry key **HKEY_CURRENT_USER\SOFTWARE\Microsoft\Office\16.0\WEF\Win32WebView2** and set its value to `dword:00000001`.
 
-<sup>3</sup> If your add-in includes the **\<Runtimes\>** element in the manifest, then it will not use Microsoft Edge Legacy (EdgeHTML). If the conditions for using Microsoft Edge with WebView2 (Chromium-based) are met, then the add-in uses that browser. Otherwise, it uses Internet Explorer 11 regardless of the Windows or Microsoft 365 version. For more information, see [Runtimes](/javascript/api/manifest/runtimes).
+<sup>3</sup> When you use Microsoft Edge, the Windows Narrator (sometimes called a "screen reader") reads the `<title>` tag in the page that opens in the task pane. In Internet Explorer 11, the Narrator reads the title bar of the task pane, which comes from the **\<DisplayName\>** value in the add-in's manifest.
 
-<sup>4</sup> On Windows versions prior to Windows 11, the WebView2 control must be installed so that Office can embed it. It's installed with Microsoft 365, Version 2101 or later, but it isn't automatically installed with Microsoft Edge. If you have an earlier version of Microsoft 365, use the instructions for installing the control at [Microsoft Edge WebView2 / Embed web content ... with Microsoft Edge WebView2](https://developer.microsoft.com/microsoft-edge/webview2/). On Microsoft 365 builds before 16.0.14326.xxxxx, you must also create the registry key **HKEY_CURRENT_USER\SOFTWARE\Microsoft\Office\16.0\WEF\Win32WebView2** and set its value to `dword:00000001`.
+<sup>4</sup> If your add-in includes the **\<Runtimes\>** element in the manifest, then it will not use Microsoft Edge Legacy (EdgeHTML). If the conditions for using Microsoft Edge with WebView2 (Chromium-based) are met, then the add-in uses that browser. Otherwise, it uses Internet Explorer 11 regardless of the Windows or Microsoft 365 version. For more information, see [Runtimes](/javascript/api/manifest/runtimes).
 
 ## Working with Internet Explorer
 

--- a/docs/concepts/browsers-used-by-office-web-add-ins.md
+++ b/docs/concepts/browsers-used-by-office-web-add-ins.md
@@ -1,7 +1,7 @@
 ---
 title: Browsers used by Office Add-ins
 description: Specifies how the operating system and Office version determine what browser is used by Office Add-ins.
-ms.date: 01/18/2023
+ms.date: 02/03/2023
 ms.localizationpriority: medium
 ---
 
@@ -78,11 +78,11 @@ For subscription Office on Windows, the browser that is used is determined by th
 |OS|Office version|Edge WebView2 (Chromium-based) installed?|Browser|
 |:-----|:-----|:-----|:-----|
 |Windows 7 | Microsoft 365| Doesn't matter | Internet Explorer 11|
-|Windows 8.1,<br>Windows 10 ver.&nbsp;<&nbsp;1903| Microsoft 365 | No| Internet Explorer 11|
-|Windows 10 ver.&nbsp;>=&nbsp;1903,<br>Windows 11 | Microsoft 365 ver.&nbsp;<&nbsp;16.0.11629<sup>2</sup>| Doesn't matter|Internet Explorer 11|
-|Windows 10 ver.&nbsp;>=&nbsp;1903,<br>Windows 11 | Microsoft 365 ver.&nbsp;>=&nbsp;16.0.11629&nbsp;*AND*&nbsp;<&nbsp;16.0.13530.20424<sup>2</sup>| Doesn't matter|Microsoft Edge Legacy (EdgeHTML)<sup>1, 3</sup>|
-|Windows 10 ver.&nbsp;>=&nbsp;1903,<br>Window 11 | Microsoft 365 ver.&nbsp;>=&nbsp;16.0.13530.20424<sup>2</sup>| No |Microsoft Edge Legacy (EdgeHTML)<sup>1, 3</sup>|
-|Windows 8.1<br>Windows 10,<br>Windows 11| Microsoft 365 ver.&nbsp;>=&nbsp;16.0.13530.20424<sup>2</sup>| Yes<sup>4</sup>|  Microsoft Edge<sup>1</sup> with WebView2 (Chromium-based) |
+|Windows 10 ver.&nbsp;<&nbsp;1903,<br>Windows 8.1| Microsoft 365 | No| Internet Explorer 11|
+|Windows 11,<br>Windows 10 ver.&nbsp;>=&nbsp;1903 | Microsoft 365 ver.&nbsp;<&nbsp;16.0.11629<sup>2</sup>| Doesn't matter|Internet Explorer 11|
+|Windows 11,<br>Windows 10 ver.&nbsp;>=&nbsp;1903 | Microsoft 365 ver.&nbsp;>=&nbsp;16.0.11629&nbsp;*AND*&nbsp;<&nbsp;16.0.13530.20424<sup>2</sup>| Doesn't matter|Microsoft Edge Legacy (EdgeHTML)<sup>1, 3</sup>|
+|Window 11,<br>Windows 10 ver.&nbsp;>=&nbsp;1903 | Microsoft 365 ver.&nbsp;>=&nbsp;16.0.13530.20424<sup>2</sup>| No |Microsoft Edge Legacy (EdgeHTML)<sup>1, 3</sup>|
+|Windows 11,<br>Windows 10,<br>Windows 8.1,<br>Windows Server 2022,<br>Windows Server 2019,<br>Windows Server 2016| Microsoft 365 ver.&nbsp;>=&nbsp;16.0.13530.20424<sup>2</sup>| Yes<sup>4</sup>|  Microsoft Edge<sup>1</sup> with WebView2 (Chromium-based) |
 
 <sup>1</sup> When you use Microsoft Edge, the Windows Narrator (sometimes called a "screen reader") reads the `<title>` tag in the page that opens in the task pane. In Internet Explorer 11, the Narrator reads the title bar of the task pane, which comes from the **\<DisplayName\>** value in the add-in's manifest.
 


### PR DESCRIPTION
This is based on the original question in https://github.com/OfficeDev/office-js-docs-pr/issues/3783. Windows Server 2016+ does support Office Add-ins and WebView2.

This PR also arranges the tables to match the newer-first ordering in [other MSFT documentation](https://learn.microsoft.com/en-us/microsoft-edge/webview2/#supported-platforms). Happy to reverse that change if folks disagree with it. I personally think it helps people understand the current (and most likely) situation quicker.