### PR TITLE
Update "Web browser - modern Outlook" blog post link

### DIFF
--- a/docs/outlook/delegate-access.md
+++ b/docs/outlook/delegate-access.md
@@ -49,7 +49,7 @@ An Exchange Server feature known as "automapping" is on by default which means t
 
 #### Shared folders
 
-The mailbox owner must first [provide access to a delegate](https://www.microsoft.com/microsoft-365/blog/2013/09/04/configuring-delegate-access-in-outlook-web-app/) by updating the mailbox folder permissions. The delegate must then follow the instructions outlined in the "Add another person’s mailbox to your folder list in Outlook Web App" section of the article [Access another person's mailbox](https://support.microsoft.com/office/a909ad30-e413-40b5-a487-0ea70b763081).
+The mailbox owner must first [provide access to a delegate](https://www.microsoft.com/en-us/microsoft-365/blog/2013/09/04/configuring-delegate-access-in-outlook-web-app/) by updating the mailbox folder permissions. The delegate must then follow the instructions outlined in the "Add another person’s mailbox to your folder list in Outlook Web App" section of the article [Access another person's mailbox](https://support.microsoft.com/office/a909ad30-e413-40b5-a487-0ea70b763081).
 
 #### Shared mailboxes
 


### PR DESCRIPTION
"Web Browser - modern Outlook" documentation has a broken link to blog post from 2013/09/04 configuring-delegate-access-in-outlook-web-app Current: (relative) /microsoft-365/blog/2013/09/04/configuring-delegate-access-in-outlook-web-app/ Changed to: (relative) /en-us/microsoft-365/blog/2013/09/04/configuring-delegate-access-in-outlook-web-app/