### PR TITLE
[all hosts] (Support) Following Teams support page format

### DIFF
--- a/docs/resources/resources-links-help.md
+++ b/docs/resources/resources-links-help.md
@@ -15,9 +15,9 @@ Use **Azure Admin Center** or **Microsoft 365 Admin Center** for any **business-
 
 | **Product support** | **Contact** |
 |:------------|:------------|
-| **Microsoft 365 product issues and failures** | If you have a Premier support contract for :::image type="icon" source="assets/icons/microsoft-icon.png"::: Microsoft 365, visit the Microsoft 365 Admin Center and use the Support menu to [open a service request](https://admin.microsoft.com/). |
+| **Microsoft 365 product issues and failures** | If you have a Premier support contract for Microsoft 365, visit the Microsoft 365 Admin Center and use the Support menu to [open a service request](https://admin.microsoft.com/). |
 | **Azure help and support** | If you have a paid Azure subscription, visit the Azure Admin Center to [open a ticket](https://ms.portal.azure.com/#blade/Microsoft_Azure_Support/HelpAndSupportBlade/newsupportreq). |
-| **General questions about Microsoft 365** | If you have general questions about Microsoft 365 or Office, submit your questions on :::image type="icon" source="assets/icons/microsoft-icon.png"::: [Microsoft 365 and Office Community](https://answers.microsoft.com/msoffice/forum).|
+| **General questions about Microsoft 365** | If you have general questions about Microsoft 365 or Office, submit your questions on [Microsoft 365 and Office Community](https://answers.microsoft.com/msoffice/forum).|
 
 ## Developer community help
 
@@ -30,7 +30,7 @@ Post your questions and help other community members by sharing and responding t
 | **Community channel**|   **Contact**  |
 |:---------------------|:---------------|
 | **Office JavaScript API questions** | Post API questions to [Stack Overflow](https://stackoverflow.com/questions/tagged/office-js) using the `office-js` tag, and also include the `outlook-web-addins` tag if your question relates to Outlook add-ins. Please note that Stack Overflow has guidelines such as requiring a descriptive title, a complete and concise problem statement, and sufficient details to reproduce your issue. Feature requests or overly broad questions are off-topic; new users should visit the [Stack Overflow Help Center](https://stackoverflow.com/help/how-to-ask) for more details.|
-| **Documentation gaps** | If the documentation is missing something that would help you understand how to create add-ins, please submit an issue to the :::image type="icon" source="assets/icons/GitHub-icon.png"::: [Office Add-ins documentation GitHub repository](https://github.com/officedev/office-js-docs-pr/issues)|
+| **Documentation gaps** | If the documentation is missing something that would help you understand how to create add-ins, please submit an issue to the [Office Add-ins documentation GitHub repository](https://github.com/officedev/office-js-docs-pr/issues)|
 
 ### Report issues
 
@@ -39,8 +39,8 @@ Submit issues and ask general questions related to SDK and samples using the com
 | **Community channel** | **Contact** |
 |:----------------------|:------------|
 | **Platform outages** | ??? |
-| **Samples** | Submit issues with samples to the :::image type="icon" source="assets/icons/GitHub-icon.png"::: [Office Add-ins code samples](https://github.com/OfficeDev/Office-Add-in-samples) repository.|
-|**Office JavaScript API issues**| If you encounter an issue (bug) with the Office JavaScript API, please submit an issue to the :::image type="icon" source="assets/icons/GitHub-icon.png"::: [Office JavaScript APIs GitHub repository](https://github.com/officedev/office-js/issues)|
+| **Samples** | Submit issues with samples to the [Office Add-ins code samples](https://github.com/OfficeDev/Office-Add-in-samples) repository.|
+|**Office JavaScript API issues**| If you encounter an issue (bug) with the Office JavaScript API, please submit an issue to the [Office JavaScript APIs GitHub repository](https://github.com/officedev/office-js/issues)|
 
 ### Documentation feedback
 
@@ -48,8 +48,8 @@ Submit documentation feedback or updates using the community help channels.
 
 | **Community channel** | **Contact** |
 |:--------------------------|:--------------------------|
-|**Documentation issues**| If you encounter an issue (bug) with the documentation, please submit an issue to the :::image type="icon" source="assets/icons/GitHub-icon.png"::: [Office Add-ins documentation GitHub repository](https://github.com/officedev/office-js-docs-pr/issues)|
-|**Documentation updates**| To make changes to the documentation yourself, choose the **Edit** link on an article and submit a pull request to the :::image type="icon" source="assets/icons/GitHub-icon.png"::: [Office Add-ins documentation GitHub repository](https://github.com/officedev/office-js-docs-pr)|
+|**Documentation issues**| If you encounter an issue (bug) with the documentation, please submit an issue to the [Office Add-ins documentation GitHub repository](https://github.com/officedev/office-js-docs-pr/issues)|
+|**Documentation updates**| To make changes to the documentation yourself, choose the **Edit** link on an article and submit a pull request to the [Office Add-ins documentation GitHub repository](https://github.com/officedev/office-js-docs-pr)|
 
 ### Feature request and general help
 

--- a/docs/resources/resources-links-help.md
+++ b/docs/resources/resources-links-help.md
@@ -1,7 +1,7 @@
 ---
 title: Office Add-ins additional resources
 description: Useful resources about Office Add-ins.
-ms.date: 04/14/2021
+ms.date: 02/22/2023
 ms.localizationpriority: medium
 ---
 
@@ -9,17 +9,69 @@ ms.localizationpriority: medium
 
 These resources provide additional information and support for developing Office Add-ins.
 
+## Product support and service issues
+
+Use **Azure Admin Center** or **Microsoft 365 Admin Center** for any **business-critical issues** that need SLA-based support.
+
+| **Product support** | **Contact** |
+|:------------|:------------|
+| **Microsoft 365 product issues and failures** | If you have a Premier support contract for :::image type="icon" source="assets/icons/microsoft-icon.png"::: Microsoft 365, visit the Microsoft 365 Admin Center and use the Support menu to [open a service request](https://admin.microsoft.com/). |
+| **Azure help and support** | If you have a paid Azure subscription, visit the Azure Admin Center to [open a ticket](https://ms.portal.azure.com/#blade/Microsoft_Azure_Support/HelpAndSupportBlade/newsupportreq). |
+| **General questions about Microsoft 365** | If you have general questions about Microsoft 365 or Office, submit your questions on :::image type="icon" source="assets/icons/microsoft-icon.png"::: [Microsoft 365 and Office Community](https://answers.microsoft.com/msoffice/forum).|
+
+## Developer community help
+
+Our community of developers use Stack Overflow and Microsoft Q&A to connect with other developers to ideate, get clarifications, and submit queries. In addition, you can also use other contacts or sites, depending on the type of community help required to raise issues, limitations, and general questions.
+
+### Developer community forums
+
+Post your questions and help other community members by sharing and responding to Teams App Development questions.
+
+| **Community channel**|   **Contact**  |
+|:---------------------|:---------------|
+| **Office JavaScript API questions** | Post API questions to [Stack Overflow](https://stackoverflow.com/questions/tagged/office-js) using the `office-js` tag, and also include the `outlook-web-addins` tag if your question relates to Outlook add-ins. Please note that Stack Overflow has guidelines such as requiring a descriptive title, a complete and concise problem statement, and sufficient details to reproduce your issue. Feature requests or overly broad questions are off-topic; new users should visit the [Stack Overflow Help Center](https://stackoverflow.com/help/how-to-ask) for more details.|
+| **Documentation gaps** | If the documentation is missing something that would help you understand how to create add-ins, please submit an issue to the :::image type="icon" source="assets/icons/GitHub-icon.png"::: [Office Add-ins documentation GitHub repository](https://github.com/officedev/office-js-docs-pr/issues)|
+
+### Report issues
+
+Submit issues and ask general questions related to SDK and samples using the community help channels.
+
+| **Community channel** | **Contact** |
+|:----------------------|:------------|
+| **Platform outages** | ??? |
+| **Samples** | Submit issues with samples to the :::image type="icon" source="assets/icons/GitHub-icon.png"::: [Office Add-ins code samples](https://github.com/OfficeDev/Office-Add-in-samples) repository.|
+|**Office JavaScript API issues**| If you encounter an issue (bug) with the Office JavaScript API, please submit an issue to the :::image type="icon" source="assets/icons/GitHub-icon.png"::: [Office JavaScript APIs GitHub repository](https://github.com/officedev/office-js/issues)|
+
+### Documentation feedback
+
+Submit documentation feedback or updates using the community help channels.
+
+| **Community channel** | **Contact** |
+|:--------------------------|:--------------------------|
+|**Documentation issues**| If you encounter an issue (bug) with the documentation, please submit an issue to the :::image type="icon" source="assets/icons/GitHub-icon.png"::: [Office Add-ins documentation GitHub repository](https://github.com/officedev/office-js-docs-pr/issues)|
+|**Documentation updates**| To make changes to the documentation yourself, choose the **Edit** link on an article and submit a pull request to the :::image type="icon" source="assets/icons/GitHub-icon.png"::: [Office Add-ins documentation GitHub repository](https://github.com/officedev/office-js-docs-pr)|
+
+### Feature request and general help
+
+Suggest a feature or vote up existing feature requests.
+
+| **Community channel** | **Contact** |
+|:----------------------|:------------|
+|**Office JavaScript API feature requests**| To submit a feature request for the Office JavaScript API, please post your idea to the [Microsoft 365 Developer Platform Tech Community](https://techcommunity.microsoft.com/t5/microsoft-365-developer-platform/idb-p/Microsoft365DeveloperPlatform).|
+| **General questions** | ???? |
+| **Feedback interview** | ??? |
+
+## External learning resources
+
+The following books and classes provide add-ins information from a different perspective.
+
 |**Resource type**|**Guidance**|
 |-----------------|------------|
-|**Office JavaScript API questions** | Post API questions to [Stack Overflow](https://stackoverflow.com/questions/tagged/office-js) using the `office-js` tag, and also include the `outlook-web-addins` tag if your question relates to Outlook add-ins. Please note that Stack Overflow has guidelines such as requiring a descriptive title, a complete and concise problem statement, and sufficient details to reproduce your issue. Feature requests or overly broad questions are off-topic; new users should visit the [Stack Overflow Help Center](https://stackoverflow.com/help/how-to-ask) for more details.|
-|**Office JavaScript API issues**| If you encounter an issue (bug) with the Office JavaScript API, please submit an issue to the <a href="https://github.com/officedev/office-js/issues" target="_blank">OfficeDev/office-js</a> GitHub repository.|
-|**Office JavaScript API feature requests**| To submit a feature request for the Office JavaScript API, please post your idea to the [Microsoft 365 Developer Platform Tech Community](https://techcommunity.microsoft.com/t5/microsoft-365-developer-platform/idb-p/Microsoft365DeveloperPlatform).|
-|**Documentation issues**| If you encounter an issue (bug) with the documentation, please submit an issue to the <a href="https://github.com/officedev/office-js-docs-pr/issues" target="_blank">OfficeDev/office-js-docs-pr</a> GitHub repository.|
-|**Documentation updates**| To make changes to the documentation yourself, choose the **Edit** link on an article and submit a pull request to the <a href="https://github.com/officedev/office-js-docs-pr" target="_blank">OfficeDev/office-js-docs-pr</a> GitHub repository.|
-|**Script Lab**| If you want to explore Office JavaScript APIs or try out preview APIs, you can use Script Lab in Excel, Outlook, PowerPoint, and Word. To learn more, see [Explore Office JavaScript API using Script Lab](../overview/explore-with-script-lab.md). |
 |**Pluralsight course about Office Add-ins**| <a href="https://www.pluralsight.com/courses/build-office-addins-js-api" target="_blank">John Brown's course "Fundamentals of Building Office Add-ins with Office JavaScript APIs"</a> teaches you how to develop a PowerPoint add-in from scratch, including information about how to communicate with Trello and publish the add-in to the Office Store.|
 |**LinkedIn course about Office Add-ins**| <a href="https://www.linkedin.com/learning/microsoft-office-add-ins-for-developers/microsoft-office-add-ins?u=3322">Bill Ayer's course "Microsoft Office Add-Ins for Developers"</a> gives an overview of the platform and explains many of the major concepts of Office Add-ins.|
 |***Building Office Add-ins using Office.js* book**| <a href="https://leanpub.com/buildingofficeaddins">Michael Zlatkovsky's book *Building Office Add-ins using Office.js*</a> describes the principles and design patterns shared by the 2016 APIs for Excel, Word, and OneNote. At the time of writing, Michael was a member of the Office Extensibility team at Microsoft, but this book is independently authored without input from Microsoft. Neither Microsoft nor Michael collect any profit on this book, as proceeds are donated to disaster-relief and humanitarian charitable causes.|
 
 ## See also
+
 - [Learn about the Microsoft 365 Developer Program](https://developer.microsoft.com/microsoft-365/dev-program)
+- [Explore Office JavaScript API using Script Lab](../overview/explore-with-script-lab.md)

--- a/docs/resources/resources-links-help.md
+++ b/docs/resources/resources-links-help.md
@@ -21,7 +21,7 @@ Use **Azure Admin Center** or **Microsoft 365 Admin Center** for any **business-
 
 ## Developer community help
 
-Our community of developers use Stack Overflow and Microsoft Q&A to connect with other developers to ideate, get clarifications, and submit queries. In addition, you can also use other contacts or sites, depending on the type of community help required to raise issues, limitations, and general questions.
+Our community of developers use Stack Overflow, GitHub, and Microsoft Q&A to connect with other developers to ideate, get clarifications, and submit queries.
 
 ### Developer community forums
 
@@ -29,18 +29,20 @@ Post your questions and help other community members by sharing and responding t
 
 | **Community channel**|   **Contact**  |
 |:---------------------|:---------------|
-| **Office JavaScript API questions** | Post API questions to [Stack Overflow](https://stackoverflow.com/questions/tagged/office-js) using the `office-js` tag, and also include the `outlook-web-addins` tag if your question relates to Outlook add-ins. Please note that Stack Overflow has guidelines such as requiring a descriptive title, a complete and concise problem statement, and sufficient details to reproduce your issue. Feature requests or overly broad questions are off-topic; new users should visit the [Stack Overflow Help Center](https://stackoverflow.com/help/how-to-ask) for more details.|
+| **Office Add-in / Office JavaScript API questions** | <ul> <li> Post API questions to [Stack Overflow](https://stackoverflow.com/questions/tagged/office-js) using the `office-js` tag, and also include the `outlook-web-addins` tag if your question relates to Outlook add-ins. Please note that Stack Overflow has guidelines such as requiring a descriptive title, a complete and concise problem statement, and sufficient details to reproduce your issue. Feature requests or overly broad questions are off-topic; new users should visit the [Stack Overflow Help Center](https://stackoverflow.com/help/how-to-ask) for more details. </li> <li> You can also post questions using the `Office Development` tag on [Microsoft Q&A](/answers/tags/321/office-development)</li> |
 | **Documentation gaps** | If the documentation is missing something that would help you understand how to create add-ins, please submit an issue to the [Office Add-ins documentation GitHub repository](https://github.com/officedev/office-js-docs-pr/issues)|
 
 ### Report issues
 
-Submit issues and ask general questions related to SDK and samples using the community help channels.
+Submit issues and ask general questions related to add-ins, documentation, and samples using the community help channels.
 
 | **Community channel** | **Contact** |
 |:----------------------|:------------|
-| **Platform outages** | ??? |
-| **Samples** | Submit issues with samples to the [Office Add-ins code samples](https://github.com/OfficeDev/Office-Add-in-samples) repository.|
-|**Office JavaScript API issues**| If you encounter an issue (bug) with the Office JavaScript API, please submit an issue to the [Office JavaScript APIs GitHub repository](https://github.com/officedev/office-js/issues)|
+| **Office Add-in / Office JavaScript API issues** | If you encounter an issue (bug) with the Office JavaScript API, please submit an issue to the [Office JavaScript APIs GitHub repository](https://github.com/officedev/office-js/issues)|
+|**Documentation issues**| If you encounter an issue (bug) with the documentation, please submit an issue to the [Office Add-ins documentation GitHub repository](https://github.com/officedev/office-js-docs-pr/issues)|
+| **Issues with code samples** | Submit issues with samples to the [Office Add-ins code samples](https://github.com/OfficeDev/Office-Add-in-samples) repository. |
+
+
 
 ### Documentation feedback
 
@@ -57,9 +59,8 @@ Suggest a feature or vote up existing feature requests.
 
 | **Community channel** | **Contact** |
 |:----------------------|:------------|
-|**Office JavaScript API feature requests**| To submit a feature request for the Office JavaScript API, please post your idea to the [Microsoft 365 Developer Platform Tech Community](https://techcommunity.microsoft.com/t5/microsoft-365-developer-platform/idb-p/Microsoft365DeveloperPlatform).|
-| **General questions** | ???? |
-| **Feedback interview** | ??? |
+|**Office Addin / Office JavaScript API feature requests**| To submit a feature request for the Office JavaScript API, please post your idea to the [Microsoft 365 Developer Platform Tech Community](https://techcommunity.microsoft.com/t5/microsoft-365-developer-platform/idb-p/Microsoft365DeveloperPlatform).|
+| **General questions** | Send general questions about the Office add-in platform to [Office Add-in Community Help](mailto:officeaddin. We encourage posting questions on the channels mentioned here and using email only if no other mode of communication is applicable. |
 
 ## External learning resources
 

--- a/docs/resources/resources-links-help.md
+++ b/docs/resources/resources-links-help.md
@@ -1,7 +1,7 @@
 ---
 title: Office Add-ins additional resources
 description: Useful resources about Office Add-ins.
-ms.date: 02/22/2023
+ms.date: 02/24/2023
 ms.localizationpriority: medium
 ---
 
@@ -11,7 +11,7 @@ These resources provide additional information and support for developing Office
 
 ## Product support and service issues
 
-Use **Azure Admin Center** or **Microsoft 365 Admin Center** for any **business-critical issues** that need SLA-based support.
+Use **Microsoft 365 Admin Center** or **Azure Admin Center**  for any **business-critical issues** that need SLA-based support.
 
 | Product support | Contact |
 |:------------|:------------|
@@ -58,7 +58,7 @@ Suggest a feature or vote up existing feature requests.
 | Support need | Contact |
 |:----------------------|:------------|
 |**Office Add-ins or Office JavaScript API feature requests**| To submit a feature request for the Office JavaScript API, please post your idea to the [Microsoft 365 Developer Platform Tech Community](https://techcommunity.microsoft.com/t5/microsoft-365-developer-platform/idb-p/Microsoft365DeveloperPlatform).|
-| **General questions** | Send general questions about the Office Add-ins platform to [Office Add-ins Community Help](mailto:officeaddin). We encourage posting questions on the channels mentioned here and using email only if no other mode of communication is applicable. |
+| **General questions** | Send general questions about the Office Add-ins platform to [Office Add-ins Community Help](mailto:officeaddinsdev@microsoft.com). We encourage posting questions on the channels mentioned here and using email only if no other mode of communication is applicable. |
 
 ## External learning resources
 

--- a/docs/resources/resources-links-help.md
+++ b/docs/resources/resources-links-help.md
@@ -27,7 +27,7 @@ Our community of developers use Stack Overflow, GitHub, and Microsoft Q&A to con
 
 Post your questions and help other community members by sharing and responding to Teams App Development questions.
 
-| **Community channel**|   **Contact**  |
+| **Developer need**|   **Contact**  |
 |:---------------------|:---------------|
 | **Office Add-in / Office JavaScript API questions** | <ul> <li> Post API questions to [Stack Overflow](https://stackoverflow.com/questions/tagged/office-js) using the `office-js` tag, and also include the `outlook-web-addins` tag if your question relates to Outlook add-ins. Please note that Stack Overflow has guidelines such as requiring a descriptive title, a complete and concise problem statement, and sufficient details to reproduce your issue. Feature requests or overly broad questions are off-topic; new users should visit the [Stack Overflow Help Center](https://stackoverflow.com/help/how-to-ask) for more details. </li> <li> You can also post questions using the `Office Development` tag on [Microsoft Q&A](/answers/tags/321/office-development)</li> |
 | **Documentation gaps** | If the documentation is missing something that would help you understand how to create add-ins, please submit an issue to the [Office Add-ins documentation GitHub repository](https://github.com/officedev/office-js-docs-pr/issues)|
@@ -36,19 +36,17 @@ Post your questions and help other community members by sharing and responding t
 
 Submit issues and ask general questions related to add-ins, documentation, and samples using the community help channels.
 
-| **Community channel** | **Contact** |
+| **Issue type** | **Contact** |
 |:----------------------|:------------|
-| **Office Add-in / Office JavaScript API issues** | If you encounter an issue (bug) with the Office JavaScript API, please submit an issue to the [Office JavaScript APIs GitHub repository](https://github.com/officedev/office-js/issues)|
+| **Office Add-ins or Office JavaScript API issues** | If you encounter an issue (bug) with the Office JavaScript API, please submit an issue to the [Office JavaScript APIs GitHub repository](https://github.com/officedev/office-js/issues)|
 |**Documentation issues**| If you encounter an issue (bug) with the documentation, please submit an issue to the [Office Add-ins documentation GitHub repository](https://github.com/officedev/office-js-docs-pr/issues)|
 | **Issues with code samples** | Submit issues with samples to the [Office Add-ins code samples](https://github.com/OfficeDev/Office-Add-in-samples) repository. |
-
-
 
 ### Documentation feedback
 
 Submit documentation feedback or updates using the community help channels.
 
-| **Community channel** | **Contact** |
+| **Feedback type** | **Contact** |
 |:--------------------------|:--------------------------|
 |**Documentation issues**| If you encounter an issue (bug) with the documentation, please submit an issue to the [Office Add-ins documentation GitHub repository](https://github.com/officedev/office-js-docs-pr/issues)|
 |**Documentation updates**| To make changes to the documentation yourself, choose the **Edit** link on an article and submit a pull request to the [Office Add-ins documentation GitHub repository](https://github.com/officedev/office-js-docs-pr)|
@@ -57,9 +55,9 @@ Submit documentation feedback or updates using the community help channels.
 
 Suggest a feature or vote up existing feature requests.
 
-| **Community channel** | **Contact** |
+| **Support need** | **Contact** |
 |:----------------------|:------------|
-|**Office Addin / Office JavaScript API feature requests**| To submit a feature request for the Office JavaScript API, please post your idea to the [Microsoft 365 Developer Platform Tech Community](https://techcommunity.microsoft.com/t5/microsoft-365-developer-platform/idb-p/Microsoft365DeveloperPlatform).|
+|**Office Add-ins or Office JavaScript API feature requests**| To submit a feature request for the Office JavaScript API, please post your idea to the [Microsoft 365 Developer Platform Tech Community](https://techcommunity.microsoft.com/t5/microsoft-365-developer-platform/idb-p/Microsoft365DeveloperPlatform).|
 | **General questions** | Send general questions about the Office add-in platform to [Office Add-in Community Help](mailto:officeaddin. We encourage posting questions on the channels mentioned here and using email only if no other mode of communication is applicable. |
 
 ## External learning resources
@@ -68,9 +66,9 @@ The following books and classes provide add-ins information from a different per
 
 |**Resource**|**More information**|
 |-----------------|------------|
-|**Pluralsight course about Office Add-ins**| <a href="https://www.pluralsight.com/courses/build-office-addins-js-api" target="_blank">John Brown's course "Fundamentals of Building Office Add-ins with Office JavaScript APIs"</a> teaches you how to develop a PowerPoint add-in from scratch, including information about how to communicate with Trello and publish the add-in to the Office Store.|
-|**LinkedIn course about Office Add-ins**| <a href="https://www.linkedin.com/learning/microsoft-office-add-ins-for-developers/microsoft-office-add-ins?u=3322">Bill Ayer's course "Microsoft Office Add-Ins for Developers"</a> gives an overview of the platform and explains many of the major concepts of Office Add-ins.|
-|***Building Office Add-ins using Office.js* book**| <a href="https://leanpub.com/buildingofficeaddins">Michael Zlatkovsky's book *Building Office Add-ins using Office.js*</a> describes the principles and design patterns shared by the 2016 APIs for Excel, Word, and OneNote. At the time of writing, Michael was a member of the Office Extensibility team at Microsoft, but this book is independently authored without input from Microsoft. Neither Microsoft nor Michael collect any profit on this book, as proceeds are donated to disaster-relief and humanitarian charitable causes.|
+|**Pluralsight course about Office Add-ins**| [John Brown's course "Fundamentals of Building Office Add-ins with Office JavaScript APIs"](https://www.pluralsight.com/courses/build-office-addins-js-api) teaches you how to develop a PowerPoint add-in from scratch, including information about how to communicate with Trello and publish the add-in to the Office Store.|
+|**LinkedIn course about Office Add-ins**| [Bill Ayer's course "Microsoft Office Add-Ins for Developers"](https://www.linkedin.com/learning/microsoft-office-add-ins-for-developers/microsoft-office-add-ins?u=3322) gives an overview of the platform and explains many of the major concepts of Office Add-ins.|
+|***Building Office Add-ins using Office.js* book**| [Michael Zlatkovsky's book *Building Office Add-ins using Office.js*](https://leanpub.com/buildingofficeaddins) describes the principles and design patterns shared by the 2016 APIs for Excel, Word, and OneNote. At the time of writing, Michael was a member of the Office Extensibility team at Microsoft, but this book is independently authored without input from Microsoft. Neither Microsoft nor Michael collect any profit on this book, as proceeds are donated to disaster-relief and humanitarian charitable causes.|
 
 ## See also
 

--- a/docs/resources/resources-links-help.md
+++ b/docs/resources/resources-links-help.md
@@ -65,7 +65,7 @@ Suggest a feature or vote up existing feature requests.
 
 The following books and classes provide add-ins information from a different perspective.
 
-|**Resource type**|**Guidance**|
+|**Resource**|**More information**|
 |-----------------|------------|
 |**Pluralsight course about Office Add-ins**| <a href="https://www.pluralsight.com/courses/build-office-addins-js-api" target="_blank">John Brown's course "Fundamentals of Building Office Add-ins with Office JavaScript APIs"</a> teaches you how to develop a PowerPoint add-in from scratch, including information about how to communicate with Trello and publish the add-in to the Office Store.|
 |**LinkedIn course about Office Add-ins**| <a href="https://www.linkedin.com/learning/microsoft-office-add-ins-for-developers/microsoft-office-add-ins?u=3322">Bill Ayer's course "Microsoft Office Add-Ins for Developers"</a> gives an overview of the platform and explains many of the major concepts of Office Add-ins.|

--- a/docs/resources/resources-links-help.md
+++ b/docs/resources/resources-links-help.md
@@ -13,7 +13,7 @@ These resources provide additional information and support for developing Office
 
 Use **Azure Admin Center** or **Microsoft 365 Admin Center** for any **business-critical issues** that need SLA-based support.
 
-| **Product support** | **Contact** |
+| Product support | Contact |
 |:------------|:------------|
 | **Microsoft 365 product issues and failures** | If you have a Premier support contract for Microsoft 365, visit the Microsoft 365 Admin Center and use the Support menu to [open a service request](https://admin.microsoft.com/). |
 | **Azure help and support** | If you have a paid Azure subscription, visit the Azure Admin Center to [open a ticket](https://ms.portal.azure.com/#blade/Microsoft_Azure_Support/HelpAndSupportBlade/newsupportreq). |
@@ -25,46 +25,46 @@ Our community of developers use Stack Overflow, GitHub, and Microsoft Q&A to con
 
 ### Developer community forums
 
-Post your questions and help other community members by sharing and responding to Teams App Development questions.
+Post your questions and help other community members by sharing and responding to Office Add-in Development questions.
 
-| **Developer need**|   **Contact**  |
+| Developer need | Contact |
 |:---------------------|:---------------|
-| **Office Add-in / Office JavaScript API questions** | <ul> <li> Post API questions to [Stack Overflow](https://stackoverflow.com/questions/tagged/office-js) using the `office-js` tag, and also include the `outlook-web-addins` tag if your question relates to Outlook add-ins. Please note that Stack Overflow has guidelines such as requiring a descriptive title, a complete and concise problem statement, and sufficient details to reproduce your issue. Feature requests or overly broad questions are off-topic; new users should visit the [Stack Overflow Help Center](https://stackoverflow.com/help/how-to-ask) for more details. </li> <li> You can also post questions using the `Office Development` tag on [Microsoft Q&A](/answers/tags/321/office-development)</li> |
+| **Office Add-in / Office JavaScript API questions** | <ul> <li> Post API questions to [Stack Overflow](https://stackoverflow.com/questions/tagged/office-js) using the `office-js` tag, and also include the `outlook-web-addins` tag if your question relates to Outlook add-ins. Please note that Stack Overflow has guidelines such as requiring a descriptive title, a complete and concise problem statement, and sufficient details to reproduce your issue. Feature requests or overly broad questions are off-topic; new users should visit the [Stack Overflow Help Center](https://stackoverflow.com/help/how-to-ask) for more details. </li> <li> You can also post questions using the `Office Development` tag on [Microsoft Q&A](/answers/tags/321/office-development).</li></ul> |
 | **Documentation gaps** | If the documentation is missing something that would help you understand how to create add-ins, please submit an issue to the [Office Add-ins documentation GitHub repository](https://github.com/officedev/office-js-docs-pr/issues)|
 
 ### Report issues
 
 Submit issues and ask general questions related to add-ins, documentation, and samples using the community help channels.
 
-| **Issue type** | **Contact** |
+| Issue type | Contact |
 |:----------------------|:------------|
-| **Office Add-ins or Office JavaScript API issues** | If you encounter an issue (bug) with the Office JavaScript API, please submit an issue to the [Office JavaScript APIs GitHub repository](https://github.com/officedev/office-js/issues)|
-|**Documentation issues**| If you encounter an issue (bug) with the documentation, please submit an issue to the [Office Add-ins documentation GitHub repository](https://github.com/officedev/office-js-docs-pr/issues)|
+| **Office Add-ins or Office JavaScript API issues** | If you encounter an issue (bug) with the Office JavaScript API, please submit an issue to the [Office JavaScript APIs GitHub repository](https://github.com/officedev/office-js/issues).|
+|**Documentation issues**| If you encounter an issue (bug) with the documentation, please submit an issue to the [Office Add-ins documentation GitHub repository](https://github.com/officedev/office-js-docs-pr/issues).|
 | **Issues with code samples** | Submit issues with samples to the [Office Add-ins code samples](https://github.com/OfficeDev/Office-Add-in-samples) repository. |
 
 ### Documentation feedback
 
 Submit documentation feedback or updates using the community help channels.
 
-| **Feedback type** | **Contact** |
+| Feedback type | Contact |
 |:--------------------------|:--------------------------|
-|**Documentation issues**| If you encounter an issue (bug) with the documentation, please submit an issue to the [Office Add-ins documentation GitHub repository](https://github.com/officedev/office-js-docs-pr/issues)|
-|**Documentation updates**| To make changes to the documentation yourself, choose the **Edit** link on an article and submit a pull request to the [Office Add-ins documentation GitHub repository](https://github.com/officedev/office-js-docs-pr)|
+|**Documentation issues**| If you encounter an issue (bug) with the documentation, please submit an issue to the [Office Add-ins documentation GitHub repository](https://github.com/officedev/office-js-docs-pr/issues).|
+|**Documentation updates**| To make changes to the documentation yourself, choose the **Edit** link on an article and submit a pull request to the [Office Add-ins documentation GitHub repository](https://github.com/officedev/office-js-docs-pr).|
 
 ### Feature request and general help
 
 Suggest a feature or vote up existing feature requests.
 
-| **Support need** | **Contact** |
+| Support need | Contact |
 |:----------------------|:------------|
 |**Office Add-ins or Office JavaScript API feature requests**| To submit a feature request for the Office JavaScript API, please post your idea to the [Microsoft 365 Developer Platform Tech Community](https://techcommunity.microsoft.com/t5/microsoft-365-developer-platform/idb-p/Microsoft365DeveloperPlatform).|
-| **General questions** | Send general questions about the Office add-in platform to [Office Add-in Community Help](mailto:officeaddin. We encourage posting questions on the channels mentioned here and using email only if no other mode of communication is applicable. |
+| **General questions** | Send general questions about the Office Add-ins platform to [Office Add-ins Community Help](mailto:officeaddin). We encourage posting questions on the channels mentioned here and using email only if no other mode of communication is applicable. |
 
 ## External learning resources
 
 The following books and classes provide add-ins information from a different perspective.
 
-|**Resource**|**More information**|
+|Resource|More information|
 |-----------------|------------|
 |**Pluralsight course about Office Add-ins**| [John Brown's course "Fundamentals of Building Office Add-ins with Office JavaScript APIs"](https://www.pluralsight.com/courses/build-office-addins-js-api) teaches you how to develop a PowerPoint add-in from scratch, including information about how to communicate with Trello and publish the add-in to the Office Store.|
 |**LinkedIn course about Office Add-ins**| [Bill Ayer's course "Microsoft Office Add-Ins for Developers"](https://www.linkedin.com/learning/microsoft-office-add-ins-for-developers/microsoft-office-add-ins?u=3322) gives an overview of the platform and explains many of the major concepts of Office Add-ins.|


### PR DESCRIPTION
As per @TristanD-MSFT's request, we want our support page to look like [that of Teams](https://learn.microsoft.com/en-us/microsoftteams/platform/feedback). This PR merges our information with that format.