### PR TITLE
Added  "http://" prefix to 'helpUrl' parameter example

### DIFF
--- a/docs/excel/custom-functions-json-autogeneration.md
+++ b/docs/excel/custom-functions-json-autogeneration.md
@@ -135,7 +135,7 @@ Syntax: @helpurl *url*
 
 The provided *url* is displayed in Excel.
 
-In the following example, the `helpurl` is `www.contoso.com/weatherhelp`.
+In the following example, the `helpurl` is `http://www.contoso.com/weatherhelp`.
 
 ```js
 /**


### PR DESCRIPTION
The code example provided for the @helpurl parameter does not use the "http://" prefix. If the developer implements it like this it won't work. The automatically created functions.json file does not include the http prefix and Excel fails to recognise it when clicking on it on the desktop app.

The documentation for manually creating the functions.json file correctly indicates the use of the "http://" prefix. See https://learn.microsoft.com/en-us/office/dev/add-ins/excel/custom-functions-json#json-metadata-example