### PR TITLE
[All hosts] (browser) Fix broken link

### DIFF
--- a/docs/concepts/browsers-used-by-office-web-add-ins.md
+++ b/docs/concepts/browsers-used-by-office-web-add-ins.md
@@ -111,7 +111,7 @@ Office Add-ins don't support Service Workers when the Microsoft Edge Legacy WebV
 
 ### Scroll bar doesn't appear in task pane
 
-By default, scroll bars in Microsoft Edge are hidden until hovered over. To ensure that the scroll bar is always visible, the CSS styling that applies to the `<body>` element of the pages in the task pane should include the [-ms-overflow-style](https://developer.mozilla.org/docs/Web/CSS/Microsoft_Extensions) property and it should be set to `scrollbar`.
+By default, scroll bars in Microsoft Edge are hidden until hovered over. To ensure that the scroll bar is always visible, the CSS styling that applies to the `<body>` element of the pages in the task pane should include the [-ms-overflow-style](https://reference.codeproject.com/css/-ms-overflow-style) property and it should be set to `scrollbar`.
 
 ### When debugging with the Microsoft Edge DevTools, the add-in crashes or reloads
 


### PR DESCRIPTION
Fixes the link to a deprecated MDN page. For more context about the deprecation, see https://github.com/mdn/content/pull/24787.