### PR TITLE
[Outlook] (prepend-on-send) Clarify feature description

### DIFF
--- a/docs/outlook/append-on-send.md
+++ b/docs/outlook/append-on-send.md
@@ -207,6 +207,9 @@ The following shows how to configure your JSON manifest to enable the append-on-
 ---
 
 > [!TIP]
+> The prepend-on-send and append-on-send features must be activated by the user through a task pane or function command button. If you want content to be prepended or appended on send without additional action from the user, you can implement these features in an [event-based activation add-in](autolaunch.md).
+
+> [!TIP]
 > To learn more about manifests for Outlook add-ins, see [Outlook add-in manifests](manifests.md).
 
 ## Implement the prepend-on-send handler (preview)
@@ -258,9 +261,6 @@ In this section, you'll implement the JavaScript code to prepend a sample compan
 
 1. Save your changes.
 
-> [!TIP]
-> The [prependOnSendAsync](/javascript/api/outlook/office.body?view=outlook-js-preview&preserve-view=true#outlook-office-body-prependasync-member(1)) method must be activated by the user through a task pane or function command button. If you want content to be prepended on send without additional action from the user, you can call `prependOnSendAsync` from an [event-based activated handler](autolaunch.md).
-
 ## Implement the append-on-send handler
 
 In this section, you'll implement the JavaScript code to append a sample company disclaimer to a mail item when it's sent.
@@ -306,9 +306,6 @@ In this section, you'll implement the JavaScript code to append a sample company
     ```
 
 1. Save your changes.
-
-> [!TIP]
-> The [appendOnSendAsync](/javascript/api/outlook/office.body#outlook-office-body-appendonsendasync-member(1)) method must be activated by the user through a task pane or function command button. If you want content to be appended on send without additional action from the user, you can call `appendOnSendAsync` from an [event-based activated handler](autolaunch.md).
 
 ## Register the JavaScript functions
 

--- a/docs/outlook/append-on-send.md
+++ b/docs/outlook/append-on-send.md
@@ -259,7 +259,7 @@ In this section, you'll implement the JavaScript code to prepend a sample compan
 1. Save your changes.
 
 > [!TIP]
-> The `prependOnSendAsync` method must be activated by the user through a task pane or function command button. If you want content to be prepended on send without additional action from the user, you can call `prependOnSendAsync` from an [event-based activated handler](autolaunch.md).
+> The [prependOnSendAsync](/javascript/api/outlook/office.body?view=outlook-js-preview&preserve-view=true#outlook-office-body-prependasync-member(1)) method must be activated by the user through a task pane or function command button. If you want content to be prepended on send without additional action from the user, you can call `prependOnSendAsync` from an [event-based activated handler](autolaunch.md).
 
 ## Implement the append-on-send handler
 
@@ -308,7 +308,7 @@ In this section, you'll implement the JavaScript code to append a sample company
 1. Save your changes.
 
 > [!TIP]
-> The `appendOnSendAsync` method must be activated by the user through a task pane or function command button. If you want content to be appended on send without additional action from the user, you can call `appendOnSendAsync` from an [event-based activated handler](autolaunch.md).
+> The [appendOnSendAsync](/javascript/api/outlook/office.body#outlook-office-body-appendonsendasync-member(1)) method must be activated by the user through a task pane or function command button. If you want content to be appended on send without additional action from the user, you can call `appendOnSendAsync` from an [event-based activated handler](autolaunch.md).
 
 ## Register the JavaScript functions
 

--- a/docs/outlook/append-on-send.md
+++ b/docs/outlook/append-on-send.md
@@ -351,7 +351,7 @@ In this section, you'll implement the JavaScript code to append a sample company
     ![A sample of a sent message with the Contoso header prepended and the disclaimer appended to its body.](../images/outlook-prepend-append-on-send.png)
 
     > [!TIP]
-    > Because content is only prepended or appended once the message is sent, the sender will only be able to view the added content from their Inbox or Sent Items folder. If you require the sender to view the added content before the message is sent, see [Insert data in the body when composing an appointment or message in Outlook](insert-data-in-the-body.md).
+    > Because content is only prepended or appended once the message is sent, the sender will only be able to view the added content from their **Inbox** or **Sent Items** folder. If you require the sender to view the added content before the message is sent, see [Insert data in the body when composing an appointment or message in Outlook](insert-data-in-the-body.md).
 
 ## Review feature behavior and limitations
 

--- a/docs/outlook/append-on-send.md
+++ b/docs/outlook/append-on-send.md
@@ -1,7 +1,7 @@
 ---
 title: Prepend or append content to a message or appointment body on send
 description: Learn how to prepend or append content to a message or appointment body when the mail item is sent.
-ms.date: 03/13/2023
+ms.date: 03/14/2023
 ms.localizationpriority: medium
 ---
 
@@ -124,8 +124,6 @@ To enable the prepend-on-send and append-on-send features in your add-in, you mu
           <bt:Urls>
             <bt:Url id="Commands.Url" DefaultValue="https://localhost:3000/commands.html" />
             <bt:Url id="Taskpane.Url" DefaultValue="https://localhost:3000/taskpane.html" />
-            <bt:Url id="WebViewRuntime.Url" DefaultValue="https://localhost:3000/commands.html" />
-            <bt:Url id="JSRuntime.Url" DefaultValue="https://localhost:3000/runtime.js" />
           </bt:Urls>
           <bt:ShortStrings>
             <bt:String id="GroupLabel" DefaultValue="Contoso Add-in"/>
@@ -150,6 +148,11 @@ To enable the prepend-on-send and append-on-send features in your add-in, you mu
 1. Save your changes.
 
 # [Teams Manifest (developer preview)](#tab/jsonmanifest)
+
+The following shows how to configure your JSON manifest to enable the append-on-send feature.
+
+> [!IMPORTANT]
+> The prepend-on-send feature in preview isn't yet supported for the [Teams manifest for Office Add-ins (preview)](../develop/json-manifest-overview.md).
 
 1. Open the manifest.json file.
 
@@ -210,9 +213,6 @@ To enable the prepend-on-send and append-on-send features in your add-in, you mu
 
 In this section, you'll implement the JavaScript code to prepend a sample company header to a mail item when it's sent.
 
-> [!IMPORTANT]
-> The prepend-on-send feature isn't supported in an add-in that implements an [ItemSend event handler](outlook-on-send-addins.md). As an alternative, consider using [Smart Alerts](smart-alerts-onmessagesend-walkthrough.md), the newer version of the on-send feature.
-
 1. Navigate to the **./src/commands** folder of your project and open the **commands.js** file.
 
 1. Insert the following function at the end of the file.
@@ -258,12 +258,12 @@ In this section, you'll implement the JavaScript code to prepend a sample compan
 
 1. Save your changes.
 
+> [!TIP]
+> The `prependOnSendAsync` method must be activated by the user through a task pane or function command button. If you want content to be prepended on send without additional action from the user, you can call `prependOnSendAsync` from an [event-based activated handler](autolaunch.md).
+
 ## Implement the append-on-send handler
 
 In this section, you'll implement the JavaScript code to append a sample company disclaimer to a mail item when it's sent.
-
-> [!IMPORTANT]
-> The append-on-send feature isn't supported in an add-in that implements an [ItemSend event handler](outlook-on-send-addins.md). As an alternative, consider using [Smart Alerts](smart-alerts-onmessagesend-walkthrough.md), the newer version of the on-send feature.
 
 1. In the same **commands.js** file, insert the following function after the `prependHeaderOnSend` function.
 
@@ -307,6 +307,9 @@ In this section, you'll implement the JavaScript code to append a sample company
 
 1. Save your changes.
 
+> [!TIP]
+> The `appendOnSendAsync` method must be activated by the user through a task pane or function command button. If you want content to be appended on send without additional action from the user, you can call `appendOnSendAsync` from an [event-based activated handler](autolaunch.md).
+
 ## Register the JavaScript functions
 
 1. In the same **commands.js** file, insert the following after the `appendDisclaimerOnSend` function. These calls map the function name specified in the manifest's **\<FunctionName\>** element to its JavaScript counterpart.
@@ -349,6 +352,9 @@ In this section, you'll implement the JavaScript code to append a sample company
 1. Send the message, then open it from your **Inbox** or **Sent Items** folder to view the inserted content.
 
     ![A sample of a sent message with the Contoso header prepended and the disclaimer appended to its body.](../images/outlook-prepend-append-on-send.png)
+
+    > [!TIP]
+    > Because content is only prepended or appended once the message is sent, the sender will only be able to view the added content from their Inbox or Sent Items folder. If you require the sender to view the added content before the message is sent, see [Insert data in the body when composing an appointment or message in Outlook](insert-data-in-the-body.md).
 
 ## Review feature behavior and limitations
 


### PR DESCRIPTION
Based on feedback in #3904:
- Removes `WebViewRuntime.Url` and `JSRuntime.Url` resources from the manifest, as these aren't required for the walkthrough to work.
- Clarifies how the `prependOnSendAsync` and `appendOnSendAsync` methods are activated.