### PR TITLE
[Outlook] (manifest) add MobileFormFactor to element ordering article

### DIFF
--- a/docs/develop/manifest-element-ordering.md
+++ b/docs/develop/manifest-element-ordering.md
@@ -544,8 +544,7 @@ The following sections show the manifest elements in the order in which they mus
                 <SourceLocation>
                 <Label>
                 <Rule>
-                <CommandSurface>
-        
+                <CommandSurface>        
     <Resources>
         <Images>
             <Image>

--- a/docs/develop/manifest-element-ordering.md
+++ b/docs/develop/manifest-element-ordering.md
@@ -475,18 +475,14 @@ The following sections show the manifest elements in the order in which they mus
                         <Icon>
                             <Image>
                         <Action>
-                            <TaskpaneId>
                             <SourceLocation>
-                            <Title>
                             <FunctionName>
                 <Control>
                     <Label>
                     <Icon>
                         <Image>
                     <Action>
-                        <TaskpaneId>
                         <SourceLocation>
-                        <Title>
                         <FunctionName>
     <Resources>
         <Images>

--- a/docs/develop/manifest-element-ordering.md
+++ b/docs/develop/manifest-element-ordering.md
@@ -470,81 +470,17 @@ The following sections show the manifest elements in the order in which they mus
         <MobileFormFactor>
             <ExtensionPoint>
                 <Group>
-                <Control>
-                <Event>
-                <OfficeTab>
-                    <Group>
-                        <Label>
-                        <Control>
-                            <Label>
-                            <Supertip>
-                                <Title>
-                                <Description>
-                            <Icon>
-                                <Image>
-                            <Action>
-                                <SourceLocation>
-                                <FunctionName>
-                <CustomTab>
-                    <Group>
+                    <Label>
+                    <Control>
                         <Label>
                         <Icon>
                             <Image>
-                        <Control>
-                            <Label>
-                            <Supertip>
-                                <Title>
-                                <Description>
-                            <Icon>
-                                <Image>  
-                            <Action>
-                                <TaskpaneId>
-                                <SourceLocation>
-                                <Title>
-                                <FunctionName>
-                            <Items>
-                                <Item>
-                                    <Label>
-                                    <Supertip>
-                                        <Title>
-                                        <Description>
-                                    <Action>
-                                        <TaskpaneId>
-                                        <SourceLocation>
-                                        <Title>
-                                        <FunctionName>
-                    <Label>
-                <OfficeMenu>
-                    <Control>
-                        <Label>
-                        <Supertip>
-                            <Title>
-                            <Description>
-                        <Icon>
-                            <Image>  
                         <Action>
-                            <TaskpaneId>
-                            <SourceLocation>
-                            <Title>
-                            <FunctionName>
-                        <Items>
-                            <Item>
-                                <Label>
-                                <Supertip>
-                                    <Title>
-                                    <Description>
-                                <Action>
-                                    <TaskpaneId>
-                                    <SourceLocation>
-                                    <Title>
-                                    <FunctionName>
-                                    <SourceLocation>
-                <LaunchEvents>
-                    <LaunchEvent>
-                <SourceLocation>
-                <Label>
-                <Rule>
-                <CommandSurface>        
+                <Control>
+                    <Label>
+                    <Icon>
+                        <Image>
+                    <Action>
     <Resources>
         <Images>
             <Image>

--- a/docs/develop/manifest-element-ordering.md
+++ b/docs/develop/manifest-element-ordering.md
@@ -1,7 +1,7 @@
 ---
 title: How to find the proper order of manifest elements
 description: Learn how to find the correct order in which to place child elements in a parent element.
-ms.date: 10/25/2021
+ms.date: 03/20/2023
 ms.localizationpriority: medium
 ---
 

--- a/docs/develop/manifest-element-ordering.md
+++ b/docs/develop/manifest-element-ordering.md
@@ -463,7 +463,6 @@ The following sections show the manifest elements in the order in which they mus
                                     <SourceLocation>
                                     <Title>
                                     <FunctionName>
-                                    <SourceLocation>
                 <SourceLocation>
                 <Label>
                 <CommandSurface>
@@ -476,11 +475,19 @@ The following sections show the manifest elements in the order in which they mus
                         <Icon>
                             <Image>
                         <Action>
+                            <TaskpaneId>
+                            <SourceLocation>
+                            <Title>
+                            <FunctionName>
                 <Control>
                     <Label>
                     <Icon>
                         <Image>
                     <Action>
+                        <TaskpaneId>
+                        <SourceLocation>
+                        <Title>
+                        <FunctionName>
     <Resources>
         <Images>
             <Image>

--- a/docs/develop/manifest-element-ordering.md
+++ b/docs/develop/manifest-element-ordering.md
@@ -467,6 +467,85 @@ The following sections show the manifest elements in the order in which they mus
                 <SourceLocation>
                 <Label>
                 <CommandSurface>
+        <MobileFormFactor>
+            <ExtensionPoint>
+                <Group>
+                <Control>
+                <Event>
+                <OfficeTab>
+                    <Group>
+                        <Label>
+                        <Control>
+                            <Label>
+                            <Supertip>
+                                <Title>
+                                <Description>
+                            <Icon>
+                                <Image>
+                            <Action>
+                                <SourceLocation>
+                                <FunctionName>
+                <CustomTab>
+                    <Group>
+                        <Label>
+                        <Icon>
+                            <Image>
+                        <Control>
+                            <Label>
+                            <Supertip>
+                                <Title>
+                                <Description>
+                            <Icon>
+                                <Image>  
+                            <Action>
+                                <TaskpaneId>
+                                <SourceLocation>
+                                <Title>
+                                <FunctionName>
+                            <Items>
+                                <Item>
+                                    <Label>
+                                    <Supertip>
+                                        <Title>
+                                        <Description>
+                                    <Action>
+                                        <TaskpaneId>
+                                        <SourceLocation>
+                                        <Title>
+                                        <FunctionName>
+                    <Label>
+                <OfficeMenu>
+                    <Control>
+                        <Label>
+                        <Supertip>
+                            <Title>
+                            <Description>
+                        <Icon>
+                            <Image>  
+                        <Action>
+                            <TaskpaneId>
+                            <SourceLocation>
+                            <Title>
+                            <FunctionName>
+                        <Items>
+                            <Item>
+                                <Label>
+                                <Supertip>
+                                    <Title>
+                                    <Description>
+                                <Action>
+                                    <TaskpaneId>
+                                    <SourceLocation>
+                                    <Title>
+                                    <FunctionName>
+                                    <SourceLocation>
+                <LaunchEvents>
+                    <LaunchEvent>
+                <SourceLocation>
+                <Label>
+                <Rule>
+                <CommandSurface>
+        
     <Resources>
         <Images>
             <Image>


### PR DESCRIPTION
For some reason, the `<MobileFormFactor>` element was left out of this article.