### PR TITLE
[All Hosts] (auth) typo in node sso tutorial

### DIFF
--- a/docs/develop/create-sso-office-add-ins-nodejs.md
+++ b/docs/develop/create-sso-office-add-ins-nodejs.md
@@ -111,7 +111,7 @@ Use the following values for placeholders for the subsequent app registration st
 
     ```javascript
     try {
-        const jsonResponse = await callServerAPI('GET', '/getuserfilenames');
+        const jsonResponse = await callWebServerAPI('GET', '/getuserfilenames');
         if (jsonResponse === null) {
             // Null is returned when a message was displayed to the user
             // regarding an authentication error that cannot be resolved.


### PR DESCRIPTION
Typo fix that doesn't need a review.

Fixes [3953](https://github.com/OfficeDev/office-js-docs-pr/issues/3953)