### PR TITLE
[all hosts] (Manifest) Remove duplicate validate reference

### DIFF
--- a/docs/testing/troubleshoot-manifest.md
+++ b/docs/testing/troubleshoot-manifest.md
@@ -1,7 +1,7 @@
 ---
 title: Validate an Office Add-in's manifest
 description: Learn how to validate the manifest of an Office Add-in using the XML schema and other tools.
-ms.date: 03/24/2022
+ms.date: 04/14/2023
 ms.localizationpriority: medium
 ---
 
@@ -24,8 +24,6 @@ npm run validate
 
 > [!NOTE]
 > To access this functionality, your add-in project must be created using the [Yeoman generator for Office Add-ins](../develop/yeoman-generator-overview.md) version 1.1.17 or later.
-
-[!INCLUDE [validate also runs Office Store validation](../includes/office-store-validate.md)]
 
 ## Validate your manifest with office-addin-manifest
 


### PR DESCRIPTION
The instructions for running `npm run validate` are listed twice in this article.

@Rick-Kirkham, I might be missing something, so please let me know if there's a good reason to have this include in both places.