### PR TITLE
[Outlook] (mobile) Replace Outlook Mobile references

### DIFF
--- a/docs/develop/develop-office-add-ins-for-the-ipad.md
+++ b/docs/develop/develop-office-add-ins-for-the-ipad.md
@@ -14,7 +14,7 @@ If your add-in uses only Office APIs that are supported on the iPad, then custom
 The following table lists the tasks to perform.
 
 > [!NOTE]
-> For information about designing Outlook add-ins that look good and work well on Outlook Mobile, see [Add-ins for Outlook Mobile](../outlook/outlook-mobile-addins.md).
+> For information about designing Outlook add-ins that look good and work well in Outlook on mobile devices, see [Add-ins for Outlook on mobile devices](../outlook/outlook-mobile-addins.md).
 
 |Task|Description|Resources|
 |:-----|:-----|:-----|

--- a/docs/outlook/add-mobile-support.md
+++ b/docs/outlook/add-mobile-support.md
@@ -1,19 +1,19 @@
 ---
 title: Add mobile support to an Outlook add-in
-description: Learn how to add support for Outlook Mobile including how to update the add-in manifest and change your code for mobile scenarios, if necessary.
+description: Learn how to add support for Outlook on mobile devices including how to update the add-in manifest and change your code for mobile scenarios, if necessary.
 ms.date: 10/17/2022
 ms.localizationpriority: medium
 ---
 
-# Add support for add-in commands for Outlook Mobile
+# Add support for add-in commands in Outlook on mobile devices
 
-Using add-in commands in Outlook Mobile allows your users to access the same functionality (with some [limitations](#code-considerations)) that they already have in Outlook on the web, Windows, and Mac. Adding support for Outlook Mobile requires updating the add-in manifest and possibly changing your code for mobile scenarios.
+Using add-in commands in Outlook on mobile devices allows your users to access the same functionality (with some [limitations](#code-considerations)) that they already have in Outlook on the web, on Windows, and on Mac. Adding support for Outlook mobile requires updating the add-in manifest and possibly changing your code for mobile scenarios.
 
 ## Updating the manifest
 
 [!INCLUDE [Unified Microsoft 365 manifest not supported on mobile devices](../includes/no-mobile-with-json-note.md)]
 
-The first step to enabling add-in commands in Outlook Mobile is to define them in the add-in manifest. The [VersionOverrides](/javascript/api/manifest/versionoverrides) v1.1 schema defines a new form factor for mobile, [MobileFormFactor](/javascript/api/manifest/mobileformfactor).
+The first step to enabling add-in commands in Outlook mobile is to define them in the add-in manifest. The [VersionOverrides](/javascript/api/manifest/versionoverrides) v1.1 schema defines a new form factor for mobile, [MobileFormFactor](/javascript/api/manifest/mobileformfactor).
 
 This element contains all of the information for loading the add-in in mobile clients. This enables you to define completely different UI elements and JavaScript files for the mobile experience.
 
@@ -55,10 +55,10 @@ The following example shows a single task pane button in a `MobileFormFactor` el
 
 This is very similar to the elements that appear in a [DesktopFormFactor](/javascript/api/manifest/desktopformfactor) element, with some notable differences.
 
-- The [OfficeTab](/javascript/api/manifest/officetab) element is not used.
+- The [OfficeTab](/javascript/api/manifest/officetab) element isn't used.
 - The [ExtensionPoint](/javascript/api/manifest/extensionpoint) element must have only one child element. If the add-in only adds one button, the child element should be a [Control](/javascript/api/manifest/control) element. If the add-in adds more than one button, the child element should be a [Group](/javascript/api/manifest/group) element that contains multiple `Control` elements.
 - There is no `Menu` type equivalent for the `Control` element.
-- The [Supertip](/javascript/api/manifest/supertip) element is not used.
+- The [Supertip](/javascript/api/manifest/supertip) element isn't used.
 - The required icon sizes are different. Mobile add-ins minimally must support 25x25, 32x32 and 48x48 pixel icons.
 
 ## Code considerations
@@ -67,28 +67,28 @@ Designing an add-in for mobile introduces some additional considerations.
 
 ### Use REST instead of Exchange Web Services
 
-The [Office.context.mailbox.makeEwsRequestAsync](/javascript/api/requirement-sets/outlook/preview-requirement-set/office.context.mailbox#methods) method is not supported in Outlook Mobile. Add-ins should prefer to get information from the Office.js API when possible. If add-ins require information not exposed by the Office.js API, then they should use the [Outlook REST APIs](/outlook/rest/) to access the user's mailbox.
+The [Office.context.mailbox.makeEwsRequestAsync](/javascript/api/requirement-sets/outlook/preview-requirement-set/office.context.mailbox#methods) method isn't supported in Outlook mobile. Add-ins should prefer to get information from the Office.js API when possible. If add-ins require information not exposed by the Office.js API, then they should use the [Outlook REST APIs](/outlook/rest/) to access the user's mailbox.
 
 Mailbox requirement set 1.5 introduced a new version of [Office.context.mailbox.getCallbackTokenAsync](/javascript/api/requirement-sets/outlook/preview-requirement-set/office.context.mailbox#methods) that can request an access token compatible with the REST APIs, and a new [Office.context.mailbox.restUrl](/javascript/api/requirement-sets/outlook/preview-requirement-set/office.context.mailbox#properties) property that can be used to find the REST API endpoint for the user.
 
 ### Pinch zoom
 
-By default users can use the "pinch zoom" gesture to zoom in on task panes. If this does not make sense for your scenario, be sure to disable pinch zoom in your HTML.
+By default users can use the "pinch zoom" gesture to zoom in on task panes. If this doesn't make sense for your scenario, be sure to disable pinch zoom in your HTML.
 
 ### Close task panes
 
-In Outlook Mobile, task panes take up the entire screen and by default require the user to close them to return to the message. Consider using the [Office.context.ui.closeContainer](/javascript/api/office/office.ui#office-office-ui-closecontainer-member(1)) method to close the task pane when your scenario is complete.
+In Outlook mobile, task panes take up the entire screen and by default require the user to close them to return to the message. Consider using the [Office.context.ui.closeContainer](/javascript/api/office/office.ui#office-office-ui-closecontainer-member(1)) method to close the task pane when your scenario is complete.
 
 ### Compose mode and appointments
 
-Currently, add-ins in Outlook Mobile only support activation when reading messages. Add-ins are not activated when composing messages or when viewing or composing appointments. However, there are two exceptions:
+Currently, add-ins in Outlook mobile only support activation when reading messages. Add-ins aren't activated when composing messages or when viewing or composing appointments. However, there are two exceptions:
 
 1. Online meeting provider integrated add-ins can be activated in Appointment Organizer mode. For more about this exception (including available APIs), refer to [Create an Outlook mobile add-in for an online-meeting provider](online-meeting.md#available-apis).
 1. Add-ins that log appointment notes and other details to customer relationship management (CRM) or note-taking services can be activated in Appointment Attendee mode. For more about this exception (including available APIs), refer to [Log appointment notes to an external application in Outlook mobile add-ins](mobile-log-appointments.md#available-apis).
 
 ### Unsupported APIs
 
-APIs introduced in requirement set 1.6 or later are not supported by Outlook Mobile. The following APIs from earlier requirement sets are also not supported.
+APIs introduced in requirement set 1.6 or later aren't supported by Outlook mobile. The following APIs from earlier requirement sets are also not supported.
 
 - [Office.context.officeTheme](/javascript/api/requirement-sets/outlook/preview-requirement-set/office.context#officetheme-officetheme)
 - [Office.context.mailbox.ewsUrl](/javascript/api/requirement-sets/outlook/preview-requirement-set/office.context.mailbox#properties)

--- a/docs/outlook/manifests.md
+++ b/docs/outlook/manifests.md
@@ -228,12 +228,11 @@ The following is an example of the XML manifest.
 
 Not all Outlook clients support the latest features, and some Outlook users will have an older version of Outlook. Having schema versions lets developers build add-ins that are backwards compatible, using the newest features where they are available but still functioning on older versions.
 
-The **\<VersionOverrides\>** element in the manifest is an example of this. All elements defined inside **\<VersionOverrides\>** will override the same element in the other part of the manifest. This means that, whenever possible, Outlook will use what is in the **\<VersionOverrides\>** section to set up the add-in. However, if the version of Outlook doesn't support a certain version of **\<VersionOverrides\>**, Outlook will ignore it and depend on the information in the rest of the manifest. 
+The **\<VersionOverrides\>** element in the manifest is an example of this. All elements defined inside **\<VersionOverrides\>** will override the same element in the other part of the manifest. This means that, whenever possible, Outlook will use what is in the **\<VersionOverrides\>** section to set up the add-in. However, if the version of Outlook doesn't support a certain version of **\<VersionOverrides\>**, Outlook will ignore it and depend on the information in the rest of the manifest.
 
 This approach means that developers don't have to create multiple individual manifests, but rather keep everything defined in one file.
 
 The current versions of the schema are:
-
 
 |Version|Description|
 |:-----|:-----|
@@ -250,7 +249,6 @@ This article will cover the requirements for a v1.1 manifest. Even if your add-i
 ## Root element
 
 The root element for the Outlook add-in manifest is **\<OfficeApp\>**. This element also declares the default namespace, schema version and the type of add-in. Place all other elements in the manifest within its open and close tags. The following is an example of the root element.
-
 
 ```XML
 <OfficeApp
@@ -280,7 +278,6 @@ This element is also where add-ins define support for [mobile add-ins](add-mobil
 ## Localization
 
 Some aspects of the add-in need to be localized for different locales, such as the name, description and the URL that's loaded. These elements can easily be localized by specifying the default value and then locale overrides in the **\<Resources\>** element within the **\<VersionOverrides\>** element. The following shows how to override an image, a URL, and a string.
-
 
 ```XML
 <Resources>
@@ -424,7 +421,7 @@ For an example add-in that defines add-in commands, see [command-demo](https://g
 
 ## Next steps: Add mobile support
 
-Add-ins can optionally add support for Outlook mobile. Outlook mobile supports add-in commands in a similar fashion to Outlook on Windows and Mac. For more information, see [Add support for add-in commands for Outlook Mobile](add-mobile-support.md).
+Add-ins can optionally add support for Outlook mobile. Outlook mobile supports add-in commands in a similar fashion to Outlook on Windows and on Mac. For more information, see [Add support for add-in commands in Outlook on mobile devices](add-mobile-support.md).
 
 ## See also
 

--- a/docs/outlook/mobile-log-appointments.md
+++ b/docs/outlook/mobile-log-appointments.md
@@ -123,7 +123,7 @@ To enable users to log appointment notes with your add-in, you must configure th
     ```
 
 > [!TIP]
-> To learn more about manifests for Outlook add-ins, see [Outlook add-in manifests](manifests.md) and [Add support for add-in commands for Outlook Mobile](add-mobile-support.md).
+> To learn more about manifests for Outlook add-ins, see [Outlook add-in manifests](manifests.md) and [Add support for add-in commands in Outlook on mobile devices](add-mobile-support.md).
 
 ### Capture appointment notes
 
@@ -375,7 +375,7 @@ To enable users to log appointment notes with your add-in, you must configure th
     ```
 
 > [!TIP]
-> To learn more about manifests for Outlook add-ins, see [Outlook add-in manifests](manifests.md) and [Add support for add-in commands for Outlook Mobile](add-mobile-support.md).
+> To learn more about manifests for Outlook add-ins, see [Outlook add-in manifests](manifests.md) and [Add support for add-in commands in Outlook on mobile devices](add-mobile-support.md).
 
 ### Capture appointment notes
 
@@ -557,5 +557,5 @@ Several restrictions apply.
 
 ## See also
 
-- [Add-ins for Outlook Mobile](outlook-mobile-addins.md)
-- [Add support for add-in commands for Outlook Mobile](add-mobile-support.md)
+- [Add-ins for Outlook on mobile devices](outlook-mobile-addins.md)
+- [Add support for add-in commands in Outlook on mobile devices](add-mobile-support.md)

--- a/docs/outlook/online-meeting.md
+++ b/docs/outlook/online-meeting.md
@@ -337,7 +337,7 @@ To allow users to create an online meeting from their mobile device, the [Mobile
 ---
 
 > [!TIP]
-> To learn more about manifests for Outlook add-ins, see [Outlook add-in manifests](manifests.md) and [Add support for add-in commands for Outlook Mobile](add-mobile-support.md).
+> To learn more about manifests for Outlook add-ins, see [Outlook add-in manifests](manifests.md) and [Add support for add-in commands in Outlook on mobile devices](add-mobile-support.md).
 
 ## Implement adding online meeting details
 
@@ -469,5 +469,5 @@ Several restrictions apply.
 
 ## See also
 
-- [Add-ins for Outlook Mobile](outlook-mobile-addins.md)
-- [Add support for add-in commands for Outlook Mobile](add-mobile-support.md)
+- [Add-ins for Outlook on mobile devices](outlook-mobile-addins.md)
+- [Add support for add-in commands in Outlook on mobile devices](add-mobile-support.md)

--- a/docs/outlook/outlook-add-ins-overview.md
+++ b/docs/outlook/outlook-add-ins-overview.md
@@ -64,7 +64,7 @@ Outlook add-ins activate when the user is composing or reading a message or appo
 
 In general, Outlook can activate add-ins in read form for items in the Sent Items folder, with the exception of add-ins that activate based on string matches of well-known entities. For more information about the reasons behind this, see [Support for well-known entities](match-strings-in-an-item-as-well-known-entities.md#support-for-well-known-entities).
 
-Currently, there are additional considerations when designing and implementing add-ins for mobile clients. To learn more, see [Add mobile support to an Outlook add-in](add-mobile-support.md#compose-mode-and-appointments).
+Currently, there are additional considerations when designing and implementing add-ins for mobile clients. To learn more, see [Add support for add-in commands in Outlook on mobile devices](add-mobile-support.md).
 
 ## Supported clients
 

--- a/docs/outlook/outlook-addin-design.md
+++ b/docs/outlook/outlook-addin-design.md
@@ -18,7 +18,7 @@ The following high-level guidelines will help you design and build a compelling 
 
 The best designed add-ins are simple to use, focused, and provide real value to users. Because your add-in will run inside of Outlook, there is additional emphasis placed on this principle. Outlook is a productivity app&mdash;it's where people go to get things done.
 
-You'll be an extension of our experience and it's important to make sure the scenarios you enable feel like a natural fit inside Outlook. Think carefully about which of your common use cases will benefit the most from having hooks to them from within our email and calendaring experiences.
+Your add-in will be an extension of our experience and it's important to make sure the scenarios you enable feel like a natural fit inside Outlook. Think carefully about which of your common use cases will benefit the most from having hooks to them from within our email and calendaring experiences.
 
 An add-in shouldn't attempt to do everything your app does. The focus should be on the most frequently used, and appropriate, actions in the context of Outlook content. Think about your call to action and make it clear what the user should do when your task pane opens.
 
@@ -114,7 +114,7 @@ Typography usage is aligned to Outlook on iOS and is kept simple for scannabilit
 
 ### Color palette
 
-Color usage is subtle in Outlook on iOS.  To align, we ask that usage of color is localized to actions and error states, with only the brand bar using a unique color.
+Color usage is subtle in Outlook on iOS. To align, we ask that usage of color is localized to actions and error states, with only the brand bar using a unique color.
 
 ![Color palette for iOS.](../images/outlook-mobile-design-color-palette.png)
 

--- a/docs/outlook/outlook-addin-design.md
+++ b/docs/outlook/outlook-addin-design.md
@@ -14,41 +14,41 @@ The following high-level guidelines will help you design and build a compelling 
 
 ## Principles
 
-1. **Focus on a few key tasks; do them well**
+### Focus on a few key tasks; do them well
 
-   The best designed add-ins are simple to use, focused, and provide real value to users. Because your add-in will run inside of Outlook, there is additional emphasis placed on this principle. Outlook is a productivity app&mdash;it's where people go to get things done.
+The best designed add-ins are simple to use, focused, and provide real value to users. Because your add-in will run inside of Outlook, there is additional emphasis placed on this principle. Outlook is a productivity app&mdash;it's where people go to get things done.
 
-   You will be an extension of our experience and it is important to make sure the scenarios you enable feel like a natural fit inside of Outlook. Think carefully about which of your common use cases will benefit the most from having hooks to them from within our email and calendaring experiences.
+You'll be an extension of our experience and it's important to make sure the scenarios you enable feel like a natural fit inside Outlook. Think carefully about which of your common use cases will benefit the most from having hooks to them from within our email and calendaring experiences.
 
-   An add-in should not attempt to do everything your app does. The focus should be on the most frequently used, and appropriate, actions in the context of Outlook content. Think about your call to action and make it clear what the user should do when your task pane opens.
+An add-in shouldn't attempt to do everything your app does. The focus should be on the most frequently used, and appropriate, actions in the context of Outlook content. Think about your call to action and make it clear what the user should do when your task pane opens.
 
-2. **Make it feel as native as possible**
+### Make it feel as native as possible
 
-   Your add-in should be designed using patterns native to the platform that Outlook is running on. To achieve this, be sure to respect and implement the interaction and visual guidelines set forth by each platform. Outlook has its own guidelines and those are also important to consider. A well-designed add-in will be an appropriate blend of your experience, the platform, and Outlook.
+Your add-in should be designed using patterns native to the platform that Outlook is running on. To achieve this, be sure to respect and implement the interaction and visual guidelines set forth by each platform. Outlook has its own guidelines and those are also important to consider. A well-designed add-in will be an appropriate blend of your experience, the platform, and Outlook.
 
-   This does mean that your add-in will have to visually be different when it runs in Outlook on iOS versus Android. 
+This does mean that your add-in will have to visually be different when it runs in Outlook on iOS versus on Android.
 
-3. **Make it enjoyable to use and get the details right**
+### Make it enjoyable to use and get the details right
 
-   People enjoy using products that are both functionally and visually appealing. You can help ensure the success of your add-in by crafting an experience where you've carefully considered every interaction and visual detail. The necessary steps to complete a task must be clear and relevant. Ideally, no action should be further than a click or two away. 
-   
-   Try not to take a user out of context to complete an action. A user should easily be able to get in and out of your add-in and back to whatever she was doing before. An add-in is not meant to be a destination to spend a lot of time in&mdash;it is an enhancement to our core functionality. If done properly, your add-in will help us deliver on the goal of making people more productive.
+People enjoy using products that are both functionally and visually appealing. You can help ensure the success of your add-in by crafting an experience where you've carefully considered every interaction and visual detail. The necessary steps to complete a task must be clear and relevant. Ideally, no action should be further than a click or two away.
 
-4. **Brand wisely**
+Try not to take a user out of context to complete an action. A user should easily be able to get in and out of your add-in and back to whatever they were doing before. An add-in isn't meant to be a destination to spend a lot of time in&mdash;it's an enhancement to our core functionality. If done properly, your add-in will help us deliver on the goal of making people more productive.
 
-   We value great branding, and we know it is important to provide users with your unique experience. But we feel the best way to ensure your add-in's success is to build an intuitive experience that subtly incorporates elements of your brand versus displaying persistent or obtrusive brand elements that only distract a user from moving through your system in an unencumbered manner. 
-    
-   A good way to incorporate your brand in a meaningful way is through the use of your brand colors, icons, and voice&mdash;assuming these don't conflict with the preferred platform patterns or accessibility requirements. Strive to keep the focus on content and task completion, not brand attention. 
-    
-   > [!NOTE]
-   >  Ads should not be shown within add-ins on iOS or Android.
+### Brand wisely
+
+We value great branding, and we know it's important to provide users with your unique experience. But we feel the best way to ensure your add-in's success is to build an intuitive experience that subtly incorporates elements of your brand versus displaying persistent or obtrusive brand elements that only distract a user from moving through your system in an unencumbered manner.
+
+A good way to incorporate your brand in a meaningful way is through the use of your brand colors, icons, and voice&mdash;assuming these don't conflict with the preferred platform patterns or accessibility requirements. Strive to keep the focus on content and task completion, not brand attention.
+
+> [!NOTE]
+> Ads should not be shown within add-ins in Outlook on iOS or on Android.
 
 ## Design patterns
 
 > [!NOTE]
-> While the above principles apply to all endpoints/platforms, the following patterns and examples are specific to mobile add-ins on the iOS platform.
+> While the above principles apply to all endpoints/platforms, the following patterns and examples are specific to mobile add-ins in Outlook on iOS.
 
-To help you create a well-designed add-in, we have [templates](../design/ux-design-pattern-templates.md) that contain iOS mobile patterns that work within the Outlook Mobile environment. Leveraging these specific patterns will help ensure your add-in feels native to both the iOS platform and Outlook Mobile. These patterns are also detailed below. While not exhaustive, this is the start of a library that we will continue to build upon as we uncover additional paradigms partners wish to include in their add-ins.  
+To help you create a well-designed add-in, we have [templates](../design/ux-design-pattern-templates.md) that contain iOS mobile patterns that work within the Outlook mobile environment. Leveraging these specific patterns will help ensure your add-in feels native to both the iOS platform and Outlook mobile. These patterns are also detailed later in this article. While not exhaustive, this is the start of a library that we'll continue to build upon as we uncover additional paradigms partners wish to include in their add-ins.  
 
 ### Overview
 
@@ -69,7 +69,6 @@ When a user taps on your add-in, the UX should display as quickly as possible. I
 **An example of loading pages on Android**
 
 ![Examples of a progress bar and an activity indicator on Android.](../images/outlook-mobile-design-loading-android.jpg)
-
 
 ### Sign in/Sign up
 
@@ -97,13 +96,13 @@ The first screen of your add-in should include your branding element. Designed f
 
 ### Margins
 
-Mobile margins should be set to 15px (8% of screen) for each side, to align with Outlook iOS and 16px for each side to align with Outlook Android.
+Mobile margins should be set to 15px (8% of screen) for each side, to align with Outlook on iOS and 16px for each side to align with Outlook on Android.
 
 ![Examples of margins on iOS.](../images/outlook-mobile-design-margins.png)
 
 ### Typography
 
-Typography usage is aligned to Outlook iOS and is kept simple for scannability.
+Typography usage is aligned to Outlook on iOS and is kept simple for scannability.
 
 **Typography on iOS**
 
@@ -115,7 +114,7 @@ Typography usage is aligned to Outlook iOS and is kept simple for scannability.
 
 ### Color palette
 
-Color usage is subtle in Outlook iOS.  To align, we ask that usage of color is localized to actions and error states, with only the brand bar using a unique color.
+Color usage is subtle in Outlook on iOS.  To align, we ask that usage of color is localized to actions and error states, with only the brand bar using a unique color.
 
 ![Color palette for iOS.](../images/outlook-mobile-design-color-palette.png)
 
@@ -187,7 +186,7 @@ Tabs can aid in content organization.
 
 ### Icons
 
-Icons should follow the current Outlook iOS design when possible. Use our standard size and color.
+Icons should follow the current Outlook on iOS design when possible. Use our standard size and color.
 
 **Examples of icons on iOS**
 
@@ -199,10 +198,10 @@ Icons should follow the current Outlook iOS design when possible. Use our standa
 
 ## End-to-end examples
 
-For our v1 Outlook Mobile Add-ins launch, we worked closely with our partners who were building add-ins. As a way to showcase the potential of their add-ins on Outlook Mobile, our designer put together end-to-end flows for each add-in, leveraging our guidelines and patterns.
+When Outlook mobile add-ins were launched, we worked closely with our partners who were building add-ins. As a way to showcase the potential of their add-ins on Outlook mobile, our designer put together end-to-end flows for each add-in, leveraging our guidelines and patterns.
 
 > [!IMPORTANT]
-> These examples are meant to highlight the ideal way to approach both the interaction and visual design of an add-in and may not match the exact feature sets in the shipped versions of the add-ins. 
+> These examples are meant to highlight the ideal way to approach both the interaction and visual design of an add-in and may not match the exact feature sets in the shipped versions of the add-ins.
 
 ### GIPHY
 

--- a/docs/outlook/outlook-mobile-addins.md
+++ b/docs/outlook/outlook-mobile-addins.md
@@ -1,67 +1,67 @@
 ---
-title: Outlook add-ins for Outlook Mobile
+title: Add-ins for Outlook on mobile devices
 description: Outlook mobile add-ins are supported on all Microsoft 365 business accounts and Outlook.com accounts.
 ms.date: 10/17/2022
 ms.localizationpriority: medium
 ---
 
-# Add-ins for Outlook Mobile
+# Add-ins for Outlook on mobile devices
 
-Add-ins now work on Outlook Mobile, using the same APIs available for other Outlook endpoints. If you've built an add-in for Outlook already, it's easy to get it working on Outlook Mobile.
+Add-ins now work in Outlook on mobile devices, using the same APIs available for other Outlook endpoints. If you've built an add-in for Outlook already, it's easy to get it working on Outlook mobile.
 
 Outlook mobile add-ins are supported on all Microsoft 365 business accounts and Outlook.com accounts. However, support is not currently available on Gmail accounts.
 
 **An example task pane in Outlook on iOS**
 
-![Screenshot of a task pane in Outlook on iOS.](../images/outlook-mobile-addin-taskpane.png)
+![A sample task pane in Outlook on iOS.](../images/outlook-mobile-addin-taskpane.png)
 
 <br/>
 
 **An example task pane in Outlook on Android**
 
-![Screenshot of a task pane in Outlook on Android.](../images/outlook-mobile-addin-taskpane-android.png)
+![A sample task pane in Outlook on Android.](../images/outlook-mobile-addin-taskpane-android.png)
 
 ## What's different on mobile?
 
-- The small size and quick interactions make designing for mobile a challenge. To ensure quality experiences for our customers, we are setting strict validation criteria that must be met by an add-in declaring mobile support, in order to be approved in AppSource.
+- The small size and quick interactions make designing for mobile a challenge. To ensure quality experiences for customers, any add-in declaring mobile support must meet certain validation criteria to be approved in AppSource.
   - The add-in **MUST** adhere to the [UI guidelines](outlook-addin-design.md).
-  - The scenario for the add-in **MUST** [make sense on mobile](#what-makes-a-good-scenario-for-mobile-add-ins).
+  - The scenario for the add-in **MUST** [make sense on mobile](#what-makes-a-good-scenario-for-outlook-mobile-add-ins).
 
 [!INCLUDE [Unified Microsoft 365 manifest not supported on mobile devices](../includes/no-mobile-with-json-note.md)]
 
-- In general, only Message Read mode is supported at this time. That means `MobileMessageReadCommandSurface` is the only [ExtensionPoint](/javascript/api/manifest/extensionpoint#mobilemessagereadcommandsurface) you should declare in the mobile section of your manifest. However, there are a couple of exceptions:
+- In general, only Message Read mode is supported at this time. That means `MobileMessageReadCommandSurface` is the only [ExtensionPoint](/javascript/api/manifest/extensionpoint#mobilemessagereadcommandsurface) you should declare in the mobile section of your manifest. However, there are a couple of exceptions.
   1. Appointment Organizer mode is supported for online meeting provider integrated add-ins which instead declare the [MobileOnlineMeetingCommandSurface extension point](/javascript/api/manifest/extensionpoint#mobileonlinemeetingcommandsurface). See the [Create an Outlook mobile add-in for an online-meeting provider](online-meeting.md) article for more about this scenario.
   1. Appointment Attendee mode is supported for integrated add-ins created by providers of note-taking and customer relationship management (CRM) applications. Such add-ins should instead declare the [MobileLogEventAppointmentAttendee extension point](/javascript/api/manifest/extensionpoint#mobilelogeventappointmentattendee). See the [Log appointment notes to an external application in Outlook mobile add-ins](mobile-log-appointments.md) article for more about this scenario.
 
-- The [makeEwsRequestAsync](/javascript/api/requirement-sets/outlook/preview-requirement-set/office.context.mailbox#methods) API is not supported on mobile since the mobile app uses REST APIs to communicate with the server. If your app backend needs to connect to the Exchange server, you can use the callback token to make REST API calls. For details, see [Use the Outlook REST APIs from an Outlook add-in](use-rest-api.md).
+- The [makeEwsRequestAsync](/javascript/api/requirement-sets/outlook/preview-requirement-set/office.context.mailbox#methods) API isn't supported on mobile since the mobile app uses REST APIs to communicate with the server. If your app backend needs to connect to the Exchange server, you can use the callback token to make REST API calls. For details, see [Use the Outlook REST APIs from an Outlook add-in](use-rest-api.md).
 
 - When you submit your add-in to the store with [MobileFormFactor](/javascript/api/manifest/mobileformfactor) in the manifest, you'll need to agree to our developer addendum for add-ins on iOS, and you must submit your Apple Developer ID for verification.
 
-- Finally, your manifest will need to declare `MobileFormFactor`, and have the correct types of [controls](/javascript/api/manifest/control) and [icon sizes](/javascript/api/manifest/icon) included.
+- Finally, your manifest needs to declare `MobileFormFactor`, and have the correct types of [controls](/javascript/api/manifest/control) and [icon sizes](/javascript/api/manifest/icon) included.
 
-## What makes a good scenario for mobile add-ins?
+## What makes a good scenario for Outlook mobile add-ins?
 
 Remember that the average Outlook session length on a phone is much shorter than on a PC. That means your add-in must be fast, and the scenario must allow the user to get in, get out, and get on with their email workflow.
 
-Here are examples of scenarios that make sense in Outlook Mobile.
+Here are examples of scenarios that make sense in Outlook mobile.
 
-- The add-in brings valuable information into Outlook, helping users triage their email and respond appropriately. Example: a CRM add-in that lets the user see customer information and share appropriate information.
+- The add-in brings valuable information into Outlook, helping users triage their email and respond appropriately. For example, a customer relationship management (CRM) add-in that lets the user see customer information and share appropriate information.
 
-- The add-in adds value to the user's email content by saving the information to a tracking, collaboration, or similar system. Example: an add-in that lets users turn emails into task items for project tracking, or help tickets for a support team.
+- The add-in adds value to the user's email content by saving the information to a tracking, collaboration, or similar system. For example, an add-in that lets users turn emails into task items for project tracking, or help tickets for a support team.
 
 **An example user interaction to create a Trello card from an email message on iOS**
 
-![Animated GIF showing user interaction with an Outlook Mobile add-in on iOS.](../images/outlook-mobile-addin-interaction.gif)
+![Animated GIF showing user interaction with an add-in in Outlook on iOS.](../images/outlook-mobile-addin-interaction.gif)
 
 <br/>
 
 **An example user interaction to create a Trello card from an email message on Android**
 
-![Animated GIF showing user interaction with an Outlook Mobile add-in on Android.](../images/outlook-mobile-addin-interaction-android.gif)
+![Animated GIF showing user interaction with an add-in in Outlook on Android.](../images/outlook-mobile-addin-interaction-android.gif)
 
 ## Testing your add-ins on mobile
 
-To test an add-in on Outlook Mobile, first [sideload an add-in](sideload-outlook-add-ins-for-testing.md) to a Microsoft 365 or Outlook.com account on the web, Windows, or Mac. Make sure your manifest is properly formatted to contain `MobileFormFactor` or it won't load in your Outlook client on mobile.
+To test an add-in on Outlook mobile, first [sideload an add-in](sideload-outlook-add-ins-for-testing.md) using a Microsoft 365 or Outlook.com account in Outlook on the web, on Windows, or on Mac. Make sure your manifest is properly formatted to contain `MobileFormFactor` or it won't load in Outlook mobile.
 
 After your add-in is working, make sure to test it on different screen sizes, including phones and tablets. You should make sure it meets accessibility guidelines for contrast, font size, and color, as well as being usable with a screen reader such as VoiceOver on iOS or TalkBack on Android.
 
@@ -74,6 +74,6 @@ Troubleshooting on mobile can be hard since you may not have the tools you're us
 
 Learn how to:
 
-- [Add mobile support to your add-in's manifest](add-mobile-support.md).
+- [Add support for add-in commands in Outlook on mobile devices](add-mobile-support.md).
 - [Design a great mobile experience for your add-in](outlook-addin-design.md).
 - [Get an access token and call Outlook REST APIs](use-rest-api.md) from your add-in.

--- a/docs/outlook/sideload-outlook-add-ins-for-testing.md
+++ b/docs/outlook/sideload-outlook-add-ins-for-testing.md
@@ -11,7 +11,7 @@ ms.localizationpriority: medium
 Sideload your Outlook add-in for testing without having to first put it in an add-in catalog.
 
 > [!IMPORTANT]
-> If your Outlook add-in supports mobile, sideload the manifest using the instructions in this article for your Outlook client on the web, Windows, or Mac, then follow the guidance in the **Testing your add-ins on mobile** section of the [Add-ins for Outlook Mobile](outlook-mobile-addins.md#testing-your-add-ins-on-mobile) article.
+> If your Outlook add-in supports mobile, sideload the manifest using the instructions in this article for your Outlook client on the web, on Windows, or on Mac, then follow the guidance in [Testing your add-ins on mobile](outlook-mobile-addins.md#testing-your-add-ins-on-mobile).
 
 ## Sideload automatically
 
@@ -152,4 +152,4 @@ To remove a sideloaded add-in from Outlook, use the steps previously described i
 
 ## See also
 
-- [Add-ins for Outlook Mobile](outlook-mobile-addins.md)
+- [Add-ins for Outlook on mobile devices](outlook-mobile-addins.md)

--- a/docs/outlook/use-regular-expressions-to-show-an-outlook-add-in.md
+++ b/docs/outlook/use-regular-expressions-to-show-an-outlook-add-in.md
@@ -44,7 +44,7 @@ Pay special attention to the following when you use regular expressions.
 
     Because different browsers use different ways to obtain the text body of a selected item, you should make sure that your regular expression supports the subtle differences that can be returned as part of the body text. For example, some browsers such as Internet Explorer 9 uses the `innerText` property of the DOM, and others such as Firefox uses the `.textContent()` method to obtain the text body of an item. Also, different browsers may return line breaks differently: a line break is `\r\n` on Internet Explorer, and `\n` on Firefox and Chrome. For more information, se [W3C DOM Compatibility - HTML](https://quirksmode.org/dom/html/).
 
-- The HTML body of an item is slightly different between an Outlook rich client, and Outlook on the web or Outlook mobile. Define your regular expressions carefully.
+- The HTML body of an item is slightly different between an Outlook rich client, and Outlook on the web or Outlook on mobile devices. Define your regular expressions carefully.
 
 - Depending on the Outlook client, type of device, or property that a regular expression is being applied on, there are other best practices and limits for each of the clients that you should be aware of when designing regular expressions as activation rules. See [Limits for activation and JavaScript API for Outlook add-ins](limits-for-activation-and-javascript-api-for-outlook-add-ins.md) for details.
 

--- a/docs/outlook/use-rest-api.md
+++ b/docs/outlook/use-rest-api.md
@@ -49,7 +49,7 @@ Office.context.mailbox.getCallbackTokenAsync({isRest: true}, function(result){
 
 To retrieve the current item via REST, your add-in will need the item's ID, properly formatted for REST. This is obtained from the [Office.context.mailbox.item.itemId](/javascript/api/requirement-sets/outlook/preview-requirement-set/office.context.mailbox.item#properties) property, but some checks should be made to ensure that it is a REST-formatted ID.
 
-- In Outlook Mobile, the value returned by `Office.context.mailbox.item.itemId` is a REST-formatted ID and can be used as-is.
+- In Outlook on mobile devices, the value returned by `Office.context.mailbox.item.itemId` is a REST-formatted ID and can be used as-is.
 - In other Outlook clients, the value returned by `Office.context.mailbox.item.itemId` is an EWS-formatted ID, and must be converted using the [Office.context.mailbox.convertToRestId](/javascript/api/requirement-sets/outlook/preview-requirement-set/office.context.mailbox#methods) method.
 - Note you must also convert Attachment ID to a REST-formatted ID in order to use it. The reason the IDs must be converted is that EWS IDs can contain non-URL safe values which will cause problems for REST.
 

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -667,7 +667,7 @@ items:
       displayName: preview
     - name: Pinnable task pane
       href: outlook/pinnable-taskpane.md
-    - name: Add-ins for Outlook Mobile
+    - name: Add-ins for Outlook on mobile devices
       href: outlook/outlook-mobile-addins.md
     - name: Create an online meeting add-in
       href: outlook/online-meeting.md
@@ -702,7 +702,7 @@ items:
         href: outlook/manifests.md
       - name: Activation rules
         href: outlook/activation-rules.md
-      - name: Add support for Outlook Mobile
+      - name: Add support for Outlook on mobile devices
         href: outlook/add-mobile-support.md
     - name: Add-in requirements
       href: outlook/add-in-requirements.md


### PR DESCRIPTION
Replaces "Outlook Mobile" references with "Outlook on mobile devices", "Outlook mobile" (for subsequent uses), "Outlook on Android", and "Outlook on iOS", where applicable. This change aligns the docs with internal guidelines.

Related PR: https://github.com/OfficeDev/office-js-docs-reference/pull/1565