### PR TITLE
[all hosts] (SSO) Fix example API link text

### DIFF
--- a/docs/develop/register-sso-add-in-aad-v2.md
+++ b/docs/develop/register-sso-add-in-aad-v2.md
@@ -1,7 +1,7 @@
 ---
 title: Register an Office Add-in that uses SSO with the Microsoft identity platform
 description: Learn how to register an Office Add-in with the Microsoft identity platform to use SSO with Word, Excel, PowerPoint, and Outlook.
-ms.date:04/18/2023
+ms.date: 04/18/2023
 ms.localizationpriority: medium
 ---
 

--- a/docs/develop/register-sso-add-in-aad-v2.md
+++ b/docs/develop/register-sso-add-in-aad-v2.md
@@ -1,7 +1,7 @@
 ---
 title: Register an Office Add-in that uses SSO with the Microsoft identity platform
 description: Learn how to register an Office Add-in with the Microsoft identity platform to use SSO with Word, Excel, PowerPoint, and Outlook.
-ms.date: 12/13/2022
+ms.date:04/18/2023
 ms.localizationpriority: medium
 ---
 

--- a/docs/includes/register-sso-add-in-aad-v2-include.md
+++ b/docs/includes/register-sso-add-in-aad-v2-include.md
@@ -74,7 +74,7 @@ Sometimes called an _application password_, a client secret is a string value yo
     * The **Application ID URI** is pre-filled with app ID (GUID) in the format `api://<app-id>`.
     * The application ID URI format should be: `api://<fully-qualified-domain-name>/<app-id>`
     * Insert the `fully-qualified-domain-name` between `api://` and `<app-id>` (which is a GUID). For example, `api://contoso.com/<app-id>`.
-    * If you're using localhost, then the format should be `api://localhost:<port>/<app-id>`. For example, `api://<fully-qualified-domain-name>/c6c1f32b-5e55-4997-881a-753cc1d563b7`.
+    * If you're using localhost, then the format should be `api://localhost:<port>/<app-id>`. For example, `api://localhost:3000/c6c1f32b-5e55-4997-881a-753cc1d563b7`.
 
     For additional application ID URI details, see [Application manifest identifierUris attribute](/azure/active-directory/develop/reference-app-manifest#identifieruris-attribute).
 


### PR DESCRIPTION
The "for example" text in this include file seems like it should use an example, rather than the placeholder text.