### PR TITLE
[All hosts] (insider program) Update references to the Office Insider program

### DIFF
--- a/docs/develop/install-latest-office-version.md
+++ b/docs/develop/install-latest-office-version.md
@@ -11,12 +11,12 @@ New developer features, including those still in preview, are delivered first to
 
 ## Opt in to getting the latest builds of Office
 
-- If you're a Microsoft 365 Family, Personal, or University subscriber, see [Be an Office Insider](https://insider.office.com).
+- If you're a Microsoft 365 Family, Personal, or University subscriber, see [Be a Microsoft 365 Insider](https://insider.microsoft365.com).
 - If you're a Microsoft 365 Apps for business customer, see [Install the First Release build for Microsoft 365 Apps for business customers](https://support.office.com/article/4dd8ba40-73c0-4468-b778-c7b744d03ead).
 - If you're running Office on a Mac:
   - Start an Office application.
   - Select **Check for Updates** on the Help menu.
-  - In the Microsoft AutoUpdate box, check the box to join the Office Insider program.
+  - In the Microsoft AutoUpdate box, check the box to join the Microsoft 365 Insider program.
 
 ## Get the latest build of Office
 

--- a/docs/includes/excel-shared-runtime-preview-note.md
+++ b/docs/includes/excel-shared-runtime-preview-note.md
@@ -1,3 +1,3 @@
 > [!IMPORTANT]
-> The features described in this article are currently in preview and subject to change. They are not currently supported for use in production environments. To try the preview features, you will need to [join Office Insider](https://insider.office.com/join).
+> The features described in this article are currently in preview and subject to change. They are not currently supported for use in production environments. To try the preview features, you will need to [join the Microsoft 365 Insider program](https://insider.microsoft365.com/join).
 > A good way to try out preview features is by using a Microsoft 365 subscription. If you don't already have a Microsoft 365 subscription, you can get one by joining the [Microsoft 365 developer program](https://aka.ms/M365devprogram).

--- a/docs/includes/use-legacy-edge-or-ie.md
+++ b/docs/includes/use-legacy-edge-or-ie.md
@@ -1,7 +1,7 @@
 If your project is node.js-based (that is, not developed with Visual Studio and Internet Information server (IIS)), you can force Office on Windows to use Edge Legacy or Internet Explorer to run add-ins, even if you have a combination of Windows and Office versions that would normally use a more recent browser. For more information about which browsers are used by various combinations of Windows and Office versions, see [Browsers used by Office Add-ins](../concepts/browsers-used-by-office-web-add-ins.md).
 
 > [!NOTE]
-> The tool that is used to force the change in browser is supported only in the Beta subscription channel of Microsoft 365. Join the [Office Insider program](https://insider.office.com/join/windows) and select the **Beta Channel** option to access Office Beta builds. See also [About Office: What version of Office am I using?](https://support.microsoft.com/office/932788b8-a3ce-44bf-bb09-e334518b8b19).
+> The tool that is used to force the change in browser is supported only in the Beta subscription channel of Microsoft 365. Join the [Microsoft 365 Insider program](https://insider.microsoft365.com/join/windows) and select the **Beta Channel** option to access Office Beta builds. See also [About Office: What version of Office am I using?](https://support.microsoft.com/office/932788b8-a3ce-44bf-bb09-e334518b8b19).
 >
 > Strictly, it is the `webview` switch of this tool (see **Step 2**) that requires the Beta channel. The tool has other switches that do not have this requirement.
 

--- a/docs/includes/use-legacy-edge-or-ie.md
+++ b/docs/includes/use-legacy-edge-or-ie.md
@@ -1,7 +1,7 @@
 If your project is node.js-based (that is, not developed with Visual Studio and Internet Information server (IIS)), you can force Office on Windows to use Edge Legacy or Internet Explorer to run add-ins, even if you have a combination of Windows and Office versions that would normally use a more recent browser. For more information about which browsers are used by various combinations of Windows and Office versions, see [Browsers used by Office Add-ins](../concepts/browsers-used-by-office-web-add-ins.md).
 
 > [!NOTE]
-> The tool that is used to force the change in browser is supported only in the Beta subscription channel of Microsoft 365. Join the [Microsoft 365 Insider program](https://insider.microsoft365.com/join/windows) and select the **Beta Channel** option to access Office Beta builds. See also [About Office: What version of Office am I using?](https://support.microsoft.com/office/932788b8-a3ce-44bf-bb09-e334518b8b19).
+> The tool that is used to force the change in browser is supported only in the Beta subscription channel of Microsoft 365. Join the [Microsoft 365 Insider program](https://insider.microsoft365.com/join/Windows) and select the **Beta Channel** option to access Office Beta builds. See also [About Office: What version of Office am I using?](https://support.microsoft.com/office/932788b8-a3ce-44bf-bb09-e334518b8b19).
 >
 > Strictly, it is the `webview` switch of this tool (see **Step 2**) that requires the Beta channel. The tool has other switches that do not have this requirement.
 

--- a/docs/includes/using-preview-apis-host.md
+++ b/docs/includes/using-preview-apis-host.md
@@ -4,4 +4,4 @@
 > To use preview APIs:
 >
 > - You must use the preview version of the Office JavaScript API library from the [Office.js content delivery network (CDN)](https://appsforoffice.microsoft.com/lib/beta/hosted/office.js). The [type definition file](https://appsforoffice.microsoft.com/lib/beta/hosted/office.d.ts) for TypeScript compilation and IntelliSense is found at the CDN and [DefinitelyTyped](https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/master/types/office-js-preview/index.d.ts). You can install these types with `npm install --save-dev @types/office-js-preview`.
-> - You may need to join the [Office Insider program](https://insider.office.com) for access to more recent Office builds.
+> - You may need to join the [Microsoft 365 Insider program](https://insider.microsoft365.com/join) for access to more recent Office builds.

--- a/docs/outlook/append-on-send.md
+++ b/docs/outlook/append-on-send.md
@@ -25,8 +25,8 @@ In this walkthrough, you'll develop an add-in that prepends a header and appends
 
 To preview the prepend-on-send feature, set up your preferred Outlook client.
 
-- For Outlook on Windows, install Version 2209 (Build 15707.36127) or later. Then, join the [Office Insider program](https://insider.office.com/join/windows) and select the **Beta Channel** option to access Office beta builds.
-- For Outlook on Mac, install Version 16.70.212.0 or later. Then, join the [Office Insider program](https://insider.office.com/join/Mac) and select the **Beta Channel** option to access Office beta builds.
+- For Outlook on Windows, install Version 2209 (Build 15707.36127) or later. Then, join the [Microsoft 365 Insider program](https://insider.microsoft365.com/join/windows) and select the **Beta Channel** option to access Office beta builds.
+- For Outlook on Mac, install Version 16.70.212.0 or later. Then, join the [Microsoft 365 Insider program](https://insider.microsoft365.com/join/Mac) and select the **Beta Channel** option to access Office beta builds.
 - For Outlook on the web, ensure that the **Targeted release** option is set up on your Microsoft 365 tenant. To learn more, see the "Targeted release" section of [Set up the Standard or Targeted release options](/microsoft-365/admin/manage/release-options-in-office-365#targeted-release).
 
 ## Set up your environment

--- a/docs/outlook/append-on-send.md
+++ b/docs/outlook/append-on-send.md
@@ -25,7 +25,7 @@ In this walkthrough, you'll develop an add-in that prepends a header and appends
 
 To preview the prepend-on-send feature, set up your preferred Outlook client.
 
-- For Outlook on Windows, install Version 2209 (Build 15707.36127) or later. Then, join the [Microsoft 365 Insider program](https://insider.microsoft365.com/join/windows) and select the **Beta Channel** option to access Office beta builds.
+- For Outlook on Windows, install Version 2209 (Build 15707.36127) or later. Then, join the [Microsoft 365 Insider program](https://insider.microsoft365.com/join/Windows) and select the **Beta Channel** option to access Office beta builds.
 - For Outlook on Mac, install Version 16.70.212.0 or later. Then, join the [Microsoft 365 Insider program](https://insider.microsoft365.com/join/Mac) and select the **Beta Channel** option to access Office beta builds.
 - For Outlook on the web, ensure that the **Targeted release** option is set up on your Microsoft 365 tenant. To learn more, see the "Targeted release" section of [Set up the Standard or Targeted release options](/microsoft-365/admin/manage/release-options-in-office-365#targeted-release).
 

--- a/docs/outlook/contextless.md
+++ b/docs/outlook/contextless.md
@@ -15,7 +15,7 @@ With a simple manifest configuration, you can create Outlook add-ins for the Mes
 
 ## Prerequisites to preview the feature
 
-To preview this feature, install Outlook on Windows, starting with Version 2304 (Build 16313.10000). Once installed, join the [Microsoft 365 Insider program](https://insider.microsoft365.com/join/windows) and select the **Beta Channel** option to access Office beta builds.
+To preview this feature, install Outlook on Windows, starting with Version 2304 (Build 16313.10000). Once installed, join the [Microsoft 365 Insider program](https://insider.microsoft365.com/join/Windows) and select the **Beta Channel** option to access Office beta builds.
 
 ## Set up your environment
 

--- a/docs/outlook/contextless.md
+++ b/docs/outlook/contextless.md
@@ -15,7 +15,7 @@ With a simple manifest configuration, you can create Outlook add-ins for the Mes
 
 ## Prerequisites to preview the feature
 
-To preview this feature, install Outlook on Windows, starting with Version 2304 (Build 16313.10000). Once installed, join the [Office Insider program](https://insider.office.com/join/windows) and select the **Beta Channel** option to access Office beta builds.
+To preview this feature, install Outlook on Windows, starting with Version 2304 (Build 16313.10000). Once installed, join the [Microsoft 365 Insider program](https://insider.microsoft365.com/join/windows) and select the **Beta Channel** option to access Office beta builds.
 
 ## Set up your environment
 

--- a/docs/outlook/item-multi-select.md
+++ b/docs/outlook/item-multi-select.md
@@ -20,7 +20,7 @@ The following sections walk you through how to configure your add-in to retrieve
 
 ## Prerequisites to preview item multi-select
 
-To preview the multi-select feature, install Outlook on Windows, starting with Version 2209 (Build 15629.20110). Once installed, join the [Microsoft 365 Insider program](https://insider.microsoft365.com/join/windows) and select the **Beta Channel** option to access Office beta builds.
+To preview the multi-select feature, install Outlook on Windows, starting with Version 2209 (Build 15629.20110). Once installed, join the [Microsoft 365 Insider program](https://insider.microsoft365.com/join/Windows) and select the **Beta Channel** option to access Office beta builds.
 
 ## Set up your environment
 

--- a/docs/outlook/item-multi-select.md
+++ b/docs/outlook/item-multi-select.md
@@ -20,7 +20,7 @@ The following sections walk you through how to configure your add-in to retrieve
 
 ## Prerequisites to preview item multi-select
 
-To preview the multi-select feature, install Outlook on Windows, starting with Version 2209 (Build 15629.20110). Once installed, join the [Office Insider program](https://insider.office.com/join/windows) and select the **Beta Channel** option to access Office beta builds.
+To preview the multi-select feature, install Outlook on Windows, starting with Version 2209 (Build 15629.20110). Once installed, join the [Microsoft 365 Insider program](https://insider.microsoft365.com/join/windows) and select the **Beta Channel** option to access Office beta builds.
 
 ## Set up your environment
 

--- a/docs/outlook/one-outlook.md
+++ b/docs/outlook/one-outlook.md
@@ -60,7 +60,7 @@ Test your Outlook web add-in in the new Outlook on Windows today! To switch to t
 
 - Have a minimum OS installation of Windows 10 Version 1809 (Build 17763).
 
-- Be a member of the [Microsoft 365 Insider program](https://insider.microsoft365.com/join/windows).
+- Be a member of the [Microsoft 365 Insider program](https://insider.microsoft365.com/join/Windows).
 
 To help you sign up and install the Outlook desktop client, see [Getting started with the new Outlook for Windows](https://support.microsoft.com/office/656bb8d9-5a60-49b2-a98b-ba7822bc7627).
 

--- a/docs/outlook/one-outlook.md
+++ b/docs/outlook/one-outlook.md
@@ -60,7 +60,7 @@ Test your Outlook web add-in in the new Outlook on Windows today! To switch to t
 
 - Have a minimum OS installation of Windows 10 Version 1809 (Build 17763).
 
-- Be a member of the [Office Insider Program](https://insider.office.com/join/windows).
+- Be a member of the [Microsoft 365 Insider program](https://insider.microsoft365.com/join/windows).
 
 To help you sign up and install the Outlook desktop client, see [Getting started with the new Outlook for Windows](https://support.microsoft.com/office/656bb8d9-5a60-49b2-a98b-ba7822bc7627).
 

--- a/docs/outlook/onmessagefromchanged-onappointmentfromchanged-events.md
+++ b/docs/outlook/onmessagefromchanged-onappointmentfromchanged-events.md
@@ -52,7 +52,7 @@ The following tables list client-server combinations that support the `OnMessage
 
 To preview the `OnMessageFromChanged` and `OnAppointmentFromChanged` events, set up your preferred client accordingly.
 
-- For Outlook on Windows, install Version 2212 (Build 15919.10000) or later. Once installed, join the [Office Insider program](https://insider.office.com/join/windows) and select the **Beta Channel** option to access Office beta builds.
+- For Outlook on Windows, install Version 2212 (Build 15919.10000) or later. Once installed, join the [Microsoft 365 Insider program](https://insider.microsoft365.com/join/windows) and select the **Beta Channel** option to access Office beta builds.
 - For Outlook on Mac, install Version 16.69.116 or later.
 - For Outlook on the web, ensure that the Targeted release option is set up on your Microsoft 365 tenant. To learn more, see the "Targeted release" section of [Set up the Standard or Targeted release options](/microsoft-365/admin/manage/release-options-in-office-365#targeted-release).
 

--- a/docs/outlook/onmessagefromchanged-onappointmentfromchanged-events.md
+++ b/docs/outlook/onmessagefromchanged-onappointmentfromchanged-events.md
@@ -52,7 +52,7 @@ The following tables list client-server combinations that support the `OnMessage
 
 To preview the `OnMessageFromChanged` and `OnAppointmentFromChanged` events, set up your preferred client accordingly.
 
-- For Outlook on Windows, install Version 2212 (Build 15919.10000) or later. Once installed, join the [Microsoft 365 Insider program](https://insider.microsoft365.com/join/windows) and select the **Beta Channel** option to access Office beta builds.
+- For Outlook on Windows, install Version 2212 (Build 15919.10000) or later. Once installed, join the [Microsoft 365 Insider program](https://insider.microsoft365.com/join/Windows) and select the **Beta Channel** option to access Office beta builds.
 - For Outlook on Mac, install Version 16.69.116 or later.
 - For Outlook on the web, ensure that the Targeted release option is set up on your Microsoft 365 tenant. To learn more, see the "Targeted release" section of [Set up the Standard or Targeted release options](/microsoft-365/admin/manage/release-options-in-office-365#targeted-release).
 

--- a/docs/outlook/pinnable-taskpane.md
+++ b/docs/outlook/pinnable-taskpane.md
@@ -15,8 +15,8 @@ However, by default, if a user has an add-in task pane open for a message in the
 > [!NOTE]
 > Although the pinnable task panes feature was introduced in [requirement set 1.5](/javascript/api/requirement-sets/outlook/requirement-set-1.5/outlook-requirement-set-1.5), it's currently only available to Microsoft 365 subscribers using the following:
 >
-> - Outlook 2016 or later on Windows (build 7668.2000 or later for users in the Current or Office Insider Channels, build 7900.xxxx or later for users in Deferred channels)
-> - Outlook 2016 or later on Mac (version 16.13.503 or later)
+> - Outlook 2016 or later on Windows (Build 7668.2000 or later for users in the Current or Microsoft 365 Insider Channels, Build 7900.xxxx or later for users in Deferred channels)
+> - Outlook 2016 or later on Mac (Version 16.13.503 or later)
 > - Modern Outlook on the web
 
 > [!IMPORTANT]

--- a/docs/outlook/sensitivity-label.md
+++ b/docs/outlook/sensitivity-label.md
@@ -25,7 +25,7 @@ To preview the sensitivity label feature in your add-in, you must have a Microso
 
 You must also set up your preferred Outlook client as follows.
 
-- For Outlook on Windows, install Version 2302 (Build 16130.20020) or later. Then, join the [Microsoft 365 Insider program](https://insider.microsoft365.com/join/windows) and select the **Beta Channel** option to access Office beta builds.
+- For Outlook on Windows, install Version 2302 (Build 16130.20020) or later. Then, join the [Microsoft 365 Insider program](https://insider.microsoft365.com/join/Windows) and select the **Beta Channel** option to access Office beta builds.
 - For Outlook on Mac, install Version 16.71.312.0 or later. Then, join the [Microsoft 365 Insider program](https://insider.microsoft365.com/join/Mac) and select the **Beta Channel** option to access Office beta builds.
 - For Outlook on the web, ensure that the **Targeted release** option is set up on your Microsoft 365 tenant. To learn more, see the "Targeted release" section of [Set up the Standard or Targeted release options](/microsoft-365/admin/manage/release-options-in-office-365#targeted-release).
 

--- a/docs/outlook/sensitivity-label.md
+++ b/docs/outlook/sensitivity-label.md
@@ -25,8 +25,8 @@ To preview the sensitivity label feature in your add-in, you must have a Microso
 
 You must also set up your preferred Outlook client as follows.
 
-- For Outlook on Windows, install Version 2302 (Build 16130.20020) or later. Then, join the [Office Insider program](https://insider.office.com/join/windows) and select the **Beta Channel** option to access Office beta builds.
-- For Outlook on Mac, install Version 16.71.312.0 or later. Then, join the [Office Insider program](https://insider.office.com/join/Mac) and select the **Beta Channel** option to access Office beta builds.
+- For Outlook on Windows, install Version 2302 (Build 16130.20020) or later. Then, join the [Microsoft 365 Insider program](https://insider.microsoft365.com/join/windows) and select the **Beta Channel** option to access Office beta builds.
+- For Outlook on Mac, install Version 16.71.312.0 or later. Then, join the [Microsoft 365 Insider program](https://insider.microsoft365.com/join/Mac) and select the **Beta Channel** option to access Office beta builds.
 - For Outlook on the web, ensure that the **Targeted release** option is set up on your Microsoft 365 tenant. To learn more, see the "Targeted release" section of [Set up the Standard or Targeted release options](/microsoft-365/admin/manage/release-options-in-office-365#targeted-release).
 
 ### Supported clients and platforms

--- a/docs/overview/explore-with-script-lab.md
+++ b/docs/overview/explore-with-script-lab.md
@@ -39,7 +39,7 @@ Get started quickly with a collection of built-in sample snippets that show how 
 In addition to JavaScript or TypeScript code that calls the Office JS API, each snippet also contains HTML markup that defines content of the task pane and CSS that defines the appearance of the task pane. You can customize the HTML markup and CSS to experiment with element placement and styling as you prototype task pane design for your own add-in.
 
 > [!TIP]
-> To call preview APIs within a snippet, you'll need to update the snippet's libraries to use the beta content delivery network (CDN) (`https://appsforoffice.microsoft.com/lib/beta/hosted/office.js`) and the preview type definitions `@types/office-js-preview`. Additionally, some preview APIs are only accessible if you've signed up for the [Office Insider program](https://insider.office.com) and are running an Insider build of Office.
+> To call preview APIs within a snippet, you'll need to update the snippet's libraries to use the beta content delivery network (CDN) (`https://appsforoffice.microsoft.com/lib/beta/hosted/office.js`) and the preview type definitions `@types/office-js-preview`. Additionally, some preview APIs are only accessible if you've signed up for the [Microsoft 365 Insider program](https://insider.microsoft365.com) and are running an Insider build of Office.
 
 ### Save and share snippets
 


### PR DESCRIPTION
The Office Insider program is now referred to as the Microsoft 365 Insider program (https://insider.microsoft365.com). This PR updates references in our documentation.