### PR TITLE
[Outlook] (multi-select) Add note about additional message properties in preview

### DIFF
--- a/docs/outlook/item-multi-select.md
+++ b/docs/outlook/item-multi-select.md
@@ -1,7 +1,7 @@
 ---
 title: Activate your Outlook add-in on multiple messages
 description: Learn how to activate your Outlook add-in when multiple messages are selected.
-ms.date: 05/19/2023
+ms.date: 06/15/2023
 ms.topic: how-to
 ms.localizationpriority: medium
 ---
@@ -152,6 +152,9 @@ To alert your add-in when the `SelectedItemsChanged` event occurs, you must regi
 ## Retrieve the subject line of selected messages
 
 Now that you've registered an event handler, you then call the [getSelectedItemsAsync](/javascript/api/outlook/office.mailbox#outlook-office-mailbox-getselecteditemsasync-member(1)) method to retrieve the subject line of the selected messages and log them to the task pane. The `getSelectedItemsAsync` method can also be used to get other message properties, such as the item ID, item type (`Message` is the only supported type at this time), and item mode (`Read` or `Compose`).
+
+> [!NOTE]
+> Additional properties returned by the `getSelectedItemsAsync` method, such as `conversationId`, `internetMessageId`, and `hasAttachment`, are in preview in Outlook on Windows. To preview these properties, you must install Version 2305 (Build 16501.20210) or later.
 
 1. In **taskpane.js**, navigate to the `run` function and insert the following code.
 

--- a/docs/outlook/item-multi-select.md
+++ b/docs/outlook/item-multi-select.md
@@ -154,7 +154,7 @@ To alert your add-in when the `SelectedItemsChanged` event occurs, you must regi
 Now that you've registered an event handler, you then call the [getSelectedItemsAsync](/javascript/api/outlook/office.mailbox#outlook-office-mailbox-getselecteditemsasync-member(1)) method to retrieve the subject line of the selected messages and log them to the task pane. The `getSelectedItemsAsync` method can also be used to get other message properties, such as the item ID, item type (`Message` is the only supported type at this time), and item mode (`Read` or `Compose`).
 
 > [!NOTE]
-> Additional message properties, such as `conversationId`, `internetMessageId`, and `hasAttachment`, are in preview in Outlook on Windows. To preview these properties, you must install Version 2305 (Build 16501.20210) or later. For more information on these properties, see [Office.SelectedItemDetails](/javascript/api/outlook/office.selecteditemdetails).
+> Additional message properties, such as `conversationId`, `internetMessageId`, and `hasAttachment`, are in preview in Outlook on Windows. To preview these properties, you must install Version 2305 (Build 16501.20210) or later. For more information on these properties, see [Office.SelectedItemDetails](/javascript/api/outlook/office.selecteditemdetails?view=outlook-js-preview&preserve-view=true).
 
 1. In **taskpane.js**, navigate to the `run` function and insert the following code.
 

--- a/docs/outlook/item-multi-select.md
+++ b/docs/outlook/item-multi-select.md
@@ -154,7 +154,7 @@ To alert your add-in when the `SelectedItemsChanged` event occurs, you must regi
 Now that you've registered an event handler, you then call the [getSelectedItemsAsync](/javascript/api/outlook/office.mailbox#outlook-office-mailbox-getselecteditemsasync-member(1)) method to retrieve the subject line of the selected messages and log them to the task pane. The `getSelectedItemsAsync` method can also be used to get other message properties, such as the item ID, item type (`Message` is the only supported type at this time), and item mode (`Read` or `Compose`).
 
 > [!NOTE]
-> Additional properties returned by the `getSelectedItemsAsync` method, such as `conversationId`, `internetMessageId`, and `hasAttachment`, are in preview in Outlook on Windows. To preview these properties, you must install Version 2305 (Build 16501.20210) or later.
+> Additional message properties, such as `conversationId`, `internetMessageId`, and `hasAttachment`, are in preview in Outlook on Windows. To preview these properties, you must install Version 2305 (Build 16501.20210) or later. For more information on these properties, see [Office.SelectedItemDetails](/javascript/api/outlook/office.selecteditemdetails).
 
 1. In **taskpane.js**, navigate to the `run` function and insert the following code.
 

--- a/docs/outlook/item-multi-select.md
+++ b/docs/outlook/item-multi-select.md
@@ -1,7 +1,7 @@
 ---
 title: Activate your Outlook add-in on multiple messages
 description: Learn how to activate your Outlook add-in when multiple messages are selected.
-ms.date: 06/15/2023
+ms.date: 06/19/2023
 ms.topic: how-to
 ms.localizationpriority: medium
 ---


### PR DESCRIPTION
Adds a note about additional message properties in preview. The link to the Office.SelectedItemDetails page should be resolved after merging DT changes and running the reference build script.

Related PRs:
- https://github.com/OfficeDev/office-js-docs-reference/pull/1614
- https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65784