### PR TITLE
[Outlook] (event-based activation) Add CORS guidance

### DIFF
--- a/docs/outlook/authenticate-a-user-with-an-sso-token.md
+++ b/docs/outlook/authenticate-a-user-with-an-sso-token.md
@@ -59,7 +59,7 @@ In most scenarios, there would be little point to obtaining the access token, if
 
 ## SSO for event-based activation
 
-There are additional steps to take if your add-in uses event-based activation. For more information, see [Enable single sign-on (SSO) in Outlook add-ins that use event-based activation](use-sso-in-event-based-activation.md).
+There are additional steps to take if your add-in uses event-based activation. For more information, see [Enable single sign-on (SSO) or cross-origin resource sharing (CORS) in your event-based Outlook add-in](use-sso-in-event-based-activation.md).
 
 ## See also
 
@@ -67,4 +67,4 @@ There are additional steps to take if your add-in uses event-based activation. F
 - For a sample Outlook add-in that uses the SSO token to access the Microsoft Graph API, see [Outlook Add-in SSO](https://github.com/OfficeDev/Office-Add-in-samples/tree/main/Samples/auth/Outlook-Add-in-SSO).
 - [SSO API reference](/javascript/api/office/office.auth#office-office-auth-getaccesstoken-member(1))
 - [IdentityAPI requirement set](/javascript/api/requirement-sets/common/identity-api-requirement-sets)
-- [Enable single sign-on (SSO) in Outlook add-ins that use event-based activation](use-sso-in-event-based-activation.md)
+- [Enable single sign-on (SSO) or cross-origin resource sharing (CORS) in your event-based Outlook add-in](use-sso-in-event-based-activation.md)

--- a/docs/outlook/autolaunch.md
+++ b/docs/outlook/autolaunch.md
@@ -480,7 +480,7 @@ Some Office.js APIs that change or alter the UI aren't allowed from event-based 
   - `getAccessToken`
   - `getAccessTokenAsync`
     > [!NOTE]
-    > [OfficeRuntime.auth](/javascript/api/office-runtime/officeruntime.auth) is supported in all Outlook versions that support event-based activation and single sign-on (SSO), while [Office.auth](/javascript/api/office/office.auth) is only supported in certain Outlook builds. For more information, see [Enable single sign-on (SSO) in Outlook add-ins that use event-based activation](use-sso-in-event-based-activation.md).
+    > [OfficeRuntime.auth](/javascript/api/office-runtime/officeruntime.auth) is supported in all Outlook versions that support event-based activation and single sign-on (SSO), while [Office.auth](/javascript/api/office/office.auth) is only supported in certain Outlook builds. For more information, see [Enable single sign-on (SSO) or cross-origin resource sharing (CORS) in your event-based Outlook add-in](use-sso-in-event-based-activation.md).
 - Under `Office.context.mailbox`:
   - `displayAppointmentForm`
   - `displayMessageForm`

--- a/docs/outlook/autolaunch.md
+++ b/docs/outlook/autolaunch.md
@@ -1,7 +1,7 @@
 ---
 title: Configure your Outlook add-in for event-based activation
 description: Learn how to configure your Outlook add-in for event-based activation.
-ms.date: 06/28/2023
+ms.date: 07/06/2023
 ms.topic: how-to
 ms.localizationpriority: medium
 ---
@@ -501,6 +501,10 @@ Outlook on Windows includes a local copy of the production and beta versions of 
 
     ![The EnableBetaAPIsInJavaScript registry value is set to 1."](../images/outlook-beta-registry-key.png)
 
+### Enable single sign-on (SSO)
+
+To enable SSO in your event-based add-in, you must add its JavaScript file to a well-known URI. For guidance on how to configure this resource, see [Enable single sign-on (SSO) or cross-origin resource sharing (CORS) in your event-based Outlook add-in](use-sso-in-event-based-activation.md).
+
 ### Request external data
 
 You can request external data by using an API like [Fetch](https://developer.mozilla.org/docs/Web/API/Fetch_API) or by using [XMLHttpRequest (XHR)](https://developer.mozilla.org/docs/Web/API/XMLHttpRequest), a standard web API that issues HTTP requests to interact with servers.
@@ -516,8 +520,10 @@ A [simple CORS](https://developer.mozilla.org/docs/Web/HTTP/CORS#simple_requests
 - Can't have event listeners registered on the object returned by `XMLHttpRequest.upload`.
 - Can't use `ReadableStream` objects in requests.
 
+To enable your event-based add-in to make CORS request, you must add the add-in and its JavaScript file to a well-known URI. For guidance on how to configure this resource, see [Enable single sign-on (SSO) or cross-origin resource sharing (CORS) in your event-based Outlook add-in](use-sso-in-event-based-activation.md).
+
 > [!NOTE]
-> Full CORS support is available in Outlook on the web, Mac, and Windows (starting in version 2201, build 16.0.14813.10000).
+> Full CORS support is available in Outlook on the web, Mac, and Windows (starting in Version 2201, Build 16.0.14813.10000).
 
 ## See also
 

--- a/docs/outlook/use-sso-in-event-based-activation.md
+++ b/docs/outlook/use-sso-in-event-based-activation.md
@@ -1,27 +1,22 @@
 ---
-title: Enable single sign-on (SSO) in Outlook add-ins that use event-based activation
-description: Learn how to enable SSO when working in an event-based activation add-in.
-ms.date: 06/17/2022
+title: Enable single sign-on (SSO) or cross-origin resource sharing (CORS) in your event-based Outlook add-in
+description: Learn how to enable SSO or CORS when working in an event-based activation add-in.
+ms.date: 07/06/2023
 ms.localizationpriority: medium
 ---
 
-# Enable single sign-on (SSO) in Outlook add-ins that use event-based activation
+# Enable single sign-on (SSO) or cross-origin resource sharing (CORS) in your event-based Outlook add-in
 
-When an Outlook add-in uses event-based activation, the events run in a separate [runtime](../testing/runtimes.md). After completing the steps in [Authenticate a user with a single-sign-on token in an Outlook add-in](authenticate-a-user-with-an-sso-token.md), follow the additional steps described in this article to enable SSO for your event handling code. Once you enable SSO you can call the [getAccessToken() API](/javascript/api/office-runtime/officeruntime.auth) to get an access token with the user's identity.
-
-> [!IMPORTANT]
-> While `OfficeRuntime.auth.getAccessToken` and `Office.auth.getAccessToken` perform the same functionality of retrieving an access token, we recommend calling `OfficeRuntime.auth.getAccessToken` in your event-based add-in. This API is supported in all Outlook client versions that support event-based activation and SSO. On the other hand, `Office.auth.getAccessToken` is only supported in Outlook on Windows starting from Version 2111 (Build 14701.20000).
-
-For Outlook on Windows, in the manifest for your Outlook add-in, you identify a single JavaScript file to load for event-based activation. You also need to specify to Office that this file is allowed to support SSO. You do this by creating a list of all add-ins, and their JavaScript files, to provide to Office through a well-known URI.
+When an Outlook add-in uses event-based activation, the events run in a separate [runtime](../testing/runtimes.md). To enable single sign-on (SSO) in your event-based add-in or allow it to request external data through cross-origin resource sharing (CORS), you must configure a well-known URI. Through this resource, Office will be able to identify the add-ins, including their JavaScript files, that support SSO or CORS requests.
 
 > [!NOTE]
-> The steps in this article only apply when running your Outlook add-in on Windows. This is because Outlook on Windows uses a JavaScript file, while Outlook on the web uses an HTML file that can reference the same JavaScript file.
+> The steps in this article only apply when running your Outlook add-in on Windows. This is because Outlook on Windows uses a JavaScript file, while Outlook on Mac and on the web use an HTML file that references the same JavaScript file. To learn more about event-based activation in Outlook add-ins, see [Configure your Outlook add-in for event-based activation](autolaunch.md).
 
-## List allowed add-ins with a well-known URI
+## List allowed add-ins in a well-known URI
 
-To list which add-ins are allowed to work with SSO, create a JSON file that identifies each JavaScript file for each add-in. Then host that JSON file at a well-known URI. A well-known URI allows the specification of all hosted JS files that are authorized to obtain tokens for the current web origin. This ensures that the owner of the origin has full control over which hosted JS files are meant to be used in an add-in and which ones are not, preventing any security vulnerabilities around impersonation, for example.
+To list which add-ins are allowed to work with SSO or CORS, create a JSON file that identifies each JavaScript file for each add-in. Then, host that JSON file at a well-known URI. A well-known URI allows the specification of all hosted JS files that are authorized to obtain tokens for the current web origin. This ensures that the owner of the origin has full control over which hosted JavaScript files are meant to be used in an add-in and which ones are not, preventing any security vulnerabilities around impersonation, for example.
 
-The following example shows how to enable SSO for two add-ins (a main version and beta version). You can list as many add-ins as necessary depending on how many you provide from your web server.
+The following example shows how to enable SSO or CORS for two add-ins (a main version and beta version). You can list as many add-ins as necessary depending on how many you provide from your web server.
 
 ```json
 {
@@ -36,6 +31,11 @@ The following example shows how to enable SSO for two add-ins (a main version an
 Host the JSON file under a location named `.well-known` in the URI at the root of the origin. For example, if the origin is `https://addin.contoso.com:8000/`, then the well-known URI is `https://addin.contoso.com:8000/.well-known/microsoft-officeaddins-allowed.json`.
 
 The origin refers to a pattern of scheme + subdomain + domain + port. The name of the location **must** be `.well-known`, and the name of the resource file **must** be `microsoft-officeaddins-allowed.json`. This file must contain a JSON object with an attribute named `allowed` whose value is an array of all JavaScript files authorized for SSO for their respective add-ins.
+
+After you configure the well-known URI, if your add-in implements SSO, you can then call the [getAccessToken() API](/javascript/api/office-runtime/officeruntime.auth) to get an access token with the user's identity.
+
+> [!IMPORTANT]
+> While `OfficeRuntime.auth.getAccessToken` and `Office.auth.getAccessToken` perform the same functionality of retrieving an access token, we recommend calling `OfficeRuntime.auth.getAccessToken` in your event-based add-in. This API is supported in all Outlook client versions that support event-based activation and SSO. On the other hand, `Office.auth.getAccessToken` is only supported in Outlook on Windows starting from Version 2111 (Build 14701.20000).
 
 ## See also
 


### PR DESCRIPTION
Rewrites [Enable single sign-on (SSO) in Outlook add-ins that use event-based activation](https://learn.microsoft.com/office/dev/add-ins/outlook/use-sso-in-event-based-activation) to include CORS requests.