### PR TITLE
[Outlook] (TOC) Update keywords for Outlook mobile articles

### DIFF
--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -681,16 +681,16 @@ items:
         displayName: outlook, add-ins, mobile
       - name: Add support for Outlook on mobile devices
         href: outlook/add-mobile-support.md
-        displayName: outlook add-ins on mobile
+        displayName: outlook, add-ins, mobile
       - name: Outlook JavaScript API support on mobile devices
         href: outlook/outlook-mobile-apis.md
-        displayName: outlook add-ins on mobile
+        displayName: outlook, add-ins, mobile
       - name: Log appointment notes on mobile
         href: outlook/mobile-log-appointments.md
-        displayName: outlook add-ins on mobile
+        displayName: outlook, add-ins, mobile
       - name: Event-based activation in Outlook on mobile devices
         href: outlook/mobile-event-based.md
-        displayName: outlook add-ins on mobile, event-based activation
+        displayName: outlook, add-ins, mobile, event-based activation
     - name: Create an online meeting add-in
       href: outlook/online-meeting.md
     - name: On-send add-ins


### PR DESCRIPTION
Updates the displayName attribute of Outlook mobile articles in the TOC based on a review suggestion from https://github.com/OfficeDev/office-js-docs-pr/pull/4078.