### PR TITLE
[All hosts] (SSO) Update link to modern authentication resource

### DIFF
--- a/docs/design/authentication-patterns.md
+++ b/docs/design/authentication-patterns.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication design guidelines for Office Add-ins
-ms.date: 02/09/2021
+ms.date: 08/14/2023
 ms.topic: best-practice
 description: Learn how to visually design a sign-on or sign-up page in an Office Add-in.
 
@@ -26,19 +26,19 @@ Add-ins may require users to sign-in or sign-up in order to access features and 
 
 1. First-Run Placemat - Place your sign-in button as a clear call-to action inside your add-in's first-run experience.
 
-    ![Screenshot showing an add-in task pane in an Office application.](../images/add-in-fre-value-placemat.png)
+    ![A sample add-in task pane in an Office application.](../images/add-in-fre-value-placemat.png)
 
 1. Identity Provider Choices Dialog - Display a clear list of identity providers including a username and password form if applicable. Your add-in UI may be blocked while the authentication dialog is open.
 
-    ![Screenshot showing the Identity Provider Choices dialog in an Office application.](../images/add-in-auth-choices-dialog.png)
+    ![The Identity Provider Choices dialog in an Office application.](../images/add-in-auth-choices-dialog.png)
 
 1. Identity Provider Sign-in - The identity provider will have their own UI. Microsoft Azure Active Directory allows customization of sign-in and access panel pages for consistent look and feel with your service. [Learn More](/azure/active-directory/fundamentals/customize-branding).
 
-    ![Screenshot showing the Identity Provider Sign-in dialog in an Office application.](../images/add-in-auth-identity-sign-in.png)
+    ![The Identity Provider Sign-in dialog in an Office application.](../images/add-in-auth-identity-sign-in.png)
 
 1. Progress - Indicate progress while settings and UI load.
 
-    ![Screenshot showing a dialog with a progress indicator in an Office application.](../images/add-in-auth-modal-interstitial.png)
+    ![A sample dialog with a progress indicator in an Office application.](../images/add-in-auth-modal-interstitial.png)
 
 > [!NOTE]
 > When using Microsoft's Identity service you'll have the opportunity to use a branded sign-in button that is customizable to light and dark themes. Learn more.
@@ -46,20 +46,20 @@ Add-ins may require users to sign-in or sign-up in order to access features and 
 ## Single Sign-On authentication flow
 
 > [!NOTE]
-> The single sign-on API is currently supported for Word, Excel, Outlook, and PowerPoint. For more information about single sign-on support, see [IdentityAPI requirement sets](/javascript/api/requirement-sets/common/identity-api-requirement-sets). If you are working with an Outlook add-in, be sure to enable Modern Authentication for the Microsoft 365 tenancy. For information about how to do this, see [Exchange Online: How to enable your tenant for modern authentication](https://social.technet.microsoft.com/wiki/contents/articles/32711.exchange-online-how-to-enable-your-tenant-for-modern-authentication.aspx).
+> The single sign-on API is currently supported for Word, Excel, Outlook, and PowerPoint. For more information about single sign-on support, see [IdentityAPI requirement sets](/javascript/api/requirement-sets/common/identity-api-requirement-sets). If you're working with an Outlook add-in, be sure to enable Modern Authentication for the Microsoft 365 tenancy. For information about how to do this, see [Enable or disable modern authentication for Outlook in Exchange Online](/exchange/clients-and-mobile-in-exchange-online/enable-or-disable-modern-authentication-in-exchange-online).
 
 Use single sign-on for a smoother end-user experience. The user's identity within Office (either a Microsoft account or a Microsoft 365 identity) is used to sign in to your add-in. As a result users only sign in once. This removes friction in the experience making it easier for your customers to get started.
 
 1. As an add-in is being installed, a user will see a consent window similar to the one following:
 
-    ![Screenshot showing the consent window in an Office application when an add-in is being installed.](../images/add-in-auth-SSO-consent-dialog.png)
+    ![The consent window in an Office application when an add-in is being installed.](../images/add-in-auth-SSO-consent-dialog.png)
 
     > [!NOTE]
     > The add-in publisher will have control over the logo, strings and permission scopes included in the consent window. The UI is pre-configured by Microsoft.
 
 1. The add-in will load after the user consents. It can extract and display any necessary user customized information.
 
-    ![Screenshot showing an Office application with add-in buttons displayed on the ribbon.](../images/add-in-ribbon.png)
+    ![An Office application with add-in buttons displayed on the ribbon.](../images/add-in-ribbon.png)
 
 ## See also
 

--- a/docs/develop/authorize-to-microsoft-graph.md
+++ b/docs/develop/authorize-to-microsoft-graph.md
@@ -1,7 +1,7 @@
 ---
 title: Authorize to Microsoft Graph with SSO
 description: Learn how users of an Office Add-in can use single sign-on (SSO) to fetch data from Microsoft Graph.
-ms.date: 06/10/2022
+ms.date: 08/14/2023
 ms.localizationpriority: medium
 ---
 
@@ -71,7 +71,7 @@ As a best practice, always pass `forMSGraphAccess` to `getAccessToken` when your
 
 If you develop an Outlook add-in that uses SSO and you sideload it for testing, Office will *always* return error 13012 when `forMSGraphAccess` is passed to `getAccessToken` even if administrator consent has been granted. For this reason, you should comment out the `forMSGraphAccess` option **when developing** an Outlook add-in. Be sure to uncomment the option when you deploy for production. The bogus 13012 only happens when you are sideloading in Outlook.
 
-For Outlook add-ins, be sure to enable Modern Authentication for the Microsoft 365 tenancy. For information about how to do this, see [Exchange Online: How to enable your tenant for modern authentication](https://social.technet.microsoft.com/wiki/contents/articles/32711.exchange-online-how-to-enable-your-tenant-for-modern-authentication.aspx).
+For Outlook add-ins, be sure to enable Modern Authentication for the Microsoft 365 tenancy. For information about how to do this, see [Enable or disable modern authentication for Outlook in Exchange Online](/exchange/clients-and-mobile-in-exchange-online/enable-or-disable-modern-authentication-in-exchange-online).
 
 ## See also
 

--- a/docs/develop/sso-in-office-add-ins.md
+++ b/docs/develop/sso-in-office-add-ins.md
@@ -1,7 +1,7 @@
 ---
 title: Enable single sign-on (SSO) in an Office Add-in
 description: Learn the key steps to enable single sign-on (SSO) for your Office Add-in using common Microsoft personal, work, or education accounts.
-ms.date: 05/05/2022
+ms.date: 08/14/2023
 ms.localizationpriority: high
 ---
 
@@ -34,7 +34,7 @@ Never cache or store the access token in your client-side code. Always call [get
 
 ### Enable modern authentication for Outlook
 
-If you are working with an **Outlook** add-in, be sure to enable Modern Authentication for the Microsoft 365 tenancy. For information about how to do this, see [Exchange Online: How to enable your tenant for modern authentication](https://social.technet.microsoft.com/wiki/contents/articles/32711.exchange-online-how-to-enable-your-tenant-for-modern-authentication.aspx).
+If you're working with an Outlook add-in, be sure to enable Modern Authentication for the Microsoft 365 tenancy. For information about how to do this, see [Enable or disable modern authentication for Outlook in Exchange Online](/exchange/clients-and-mobile-in-exchange-online/enable-or-disable-modern-authentication-in-exchange-online).
 
 ### Implement a fallback authentication system
 
@@ -135,7 +135,6 @@ async function getUserData() {
     }
 }
 ```
-
 
 #### When to call getAccessToken
 

--- a/docs/develop/troubleshoot-sso-in-office-add-ins.md
+++ b/docs/develop/troubleshoot-sso-in-office-add-ins.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshoot error messages for single sign-on (SSO)
 description: Guidance about how to troubleshoot problems with single sign-on (SSO) in Office Add-ins, and handle special conditions or errors.
-ms.date: 07/07/2023
+ms.date: 08/14/2023
 ms.localizationpriority: medium
 ---
 
@@ -11,7 +11,7 @@ This article provides some guidance about how to troubleshoot problems with sing
 
 > [!NOTE]
 > The Single Sign-on API is currently supported for Word, Excel, Outlook, and PowerPoint. For more information about where the Single Sign-on API is currently supported, see [IdentityAPI requirement sets](/javascript/api/requirement-sets/common/identity-api-requirement-sets).
-> If you are working with an Outlook add-in, be sure to enable Modern Authentication for the Microsoft 365 tenancy. For information about how to do this, see [Exchange Online: How to enable your tenant for modern authentication](https://social.technet.microsoft.com/wiki/contents/articles/32711.exchange-online-how-to-enable-your-tenant-for-modern-authentication.aspx).
+> If you're working with an Outlook add-in, be sure to enable Modern Authentication for the Microsoft 365 tenancy. For information about how to do this, see [Enable or disable modern authentication for Outlook in Exchange Online](/exchange/clients-and-mobile-in-exchange-online/enable-or-disable-modern-authentication-in-exchange-online).
 
 ## Debugging tools
 
@@ -23,6 +23,7 @@ We strongly recommend that you use a tool that can intercept and display the HTT
 ## Causes and handling of errors from getAccessToken
 
 For examples of the error handling described in this section, see:
+
 - [HomeES6.js in Office-Add-in-ASPNET-SSO](https://github.com/OfficeDev/Office-Add-in-samples/blob/main/Samples/auth/Office-Add-in-ASPNET-SSO/Complete/Office-Add-in-ASPNETCore-WebAPI/wwwroot/js/HomeES6.js)
 - [ssoAuthES6.js in Office-Add-in-NodeJS-SSO](https://github.com/OfficeDev/Office-Add-in-samples/tree/main/Samples/auth/Office-Add-in-NodeJS-SSO/Complete/public/javascripts/ssoAuthES6.js)
 
@@ -110,6 +111,7 @@ In a production add-in, the add-in should respond to this error by falling back 
 ## Errors on the server-side from Azure Active Directory
 
 For samples of the error-handling described in this section, see:
+
 - [Office-Add-in-ASPNET-SSO](https://github.com/OfficeDev/Office-Add-in-samples/tree/main/Samples/auth/Office-Add-in-ASPNET-SSO)
 - [Office-Add-in-NodeJS-SSO](https://github.com/OfficeDev/Office-Add-in-samples/tree/main/Samples/auth/Office-Add-in-NodeJS-SSO)
 

--- a/docs/outlook/authenticate-a-user-with-an-sso-token.md
+++ b/docs/outlook/authenticate-a-user-with-an-sso-token.md
@@ -1,7 +1,7 @@
 ---
 title: Authenticate a user with a single-sign-on token
 description: Learn about using the single-sign-on token provided by an Outlook add-in to implement SSO with your service.
-ms.date: 10/17/2022
+ms.date: 08/14/2023
 ms.topic: how-to
 ms.localizationpriority: medium
 ---
@@ -19,7 +19,7 @@ For an overview of SSO in Office Add-ins, see [Enable single sign-on for Office 
 
 ## Enable modern authentication in your Microsoft 365 tenancy
 
-To use SSO with an Outlook add-in, you must enable Modern Authentication for the Microsoft 365 tenancy. For information about how to do this, see [Exchange Online: How to enable your tenant for modern authentication](https://social.technet.microsoft.com/wiki/contents/articles/32711.exchange-online-how-to-enable-your-tenant-for-modern-authentication.aspx).
+To use SSO with an Outlook add-in, you must enable Modern Authentication for the Microsoft 365 tenancy. For information about how to do this, see [Enable or disable modern authentication for Outlook in Exchange Online](/exchange/clients-and-mobile-in-exchange-online/enable-or-disable-modern-authentication-in-exchange-online).
 
 ## Register your add-in
 

--- a/docs/outlook/authentication.md
+++ b/docs/outlook/authentication.md
@@ -1,7 +1,7 @@
 ---
 title: Authentication options in Outlook add-ins
 description: Outlook add-ins provide a number of different methods to authenticate, depending on your specific scenario.
-ms.date: 10/17/2022
+ms.date: 08/14/2023
 ms.topic: overview
 ms.localizationpriority: high
 ---
@@ -16,7 +16,7 @@ Single sign-on access tokens provide a seamless way for your add-in to authentic
 
 > [!NOTE]
 > The Single Sign-on API is currently supported for Word, Excel, Outlook, and PowerPoint. For more information about where the Single Sign-on API is currently supported, see [IdentityAPI requirement sets](/javascript/api/requirement-sets/common/identity-api-requirement-sets).
-> If you are working with an Outlook add-in, be sure to enable Modern Authentication for the Microsoft 365 tenancy. For information about how to do this, see [Exchange Online: How to enable your tenant for modern authentication](https://social.technet.microsoft.com/wiki/contents/articles/32711.exchange-online-how-to-enable-your-tenant-for-modern-authentication.aspx).
+> If you're working with an Outlook add-in, be sure to enable Modern Authentication for the Microsoft 365 tenancy. For information about how to do this, see [Enable or disable modern authentication for Outlook in Exchange Online](/exchange/clients-and-mobile-in-exchange-online/enable-or-disable-modern-authentication-in-exchange-online).
 
 Consider using SSO access tokens if your add-in:
 

--- a/docs/outlook/implement-sso-in-outlook-add-in.md
+++ b/docs/outlook/implement-sso-in-outlook-add-in.md
@@ -1,7 +1,7 @@
 ---
 title: Scenario - Implement single sign-on to your service
 description: Learn about using the single-sign-on token and Exchange identity token provided by an Outlook add-in to implement SSO with your service.
-ms.date: 05/18/2022
+ms.date: 08/14/2023
 ms.topic: example-scenario
 ms.localizationpriority: medium
 ---
@@ -12,7 +12,7 @@ In this article we'll explore a recommended method of using the [single sign-on 
 
 > [!NOTE]
 > The Single Sign-on API is currently supported for Word, Excel, Outlook, and PowerPoint. For more information about where the Single Sign-on API is currently supported, see [IdentityAPI requirement sets](/javascript/api/requirement-sets/common/identity-api-requirement-sets).
-> If you are working with an Outlook add-in, be sure to enable Modern Authentication for the Microsoft 365 tenancy. For information about how to do this, see [Exchange Online: How to enable your tenant for modern authentication](https://social.technet.microsoft.com/wiki/contents/articles/32711.exchange-online-how-to-enable-your-tenant-for-modern-authentication.aspx).
+> If you're working with an Outlook add-in, be sure to enable Modern Authentication for the Microsoft 365 tenancy. For information about how to do this, see [Enable or disable modern authentication for Outlook in Exchange Online](/exchange/clients-and-mobile-in-exchange-online/enable-or-disable-modern-authentication-in-exchange-online).
 
 ## Why use the SSO access token?
 


### PR DESCRIPTION
Replaces links to <https://social.technet.microsoft.com/wiki/contents/articles/32711.exchange-online-how-to-enable-your-tenant-for-modern-authentication.aspx)> with <https://learn.microsoft.com/exchange/clients-and-mobile-in-exchange-online/enable-or-disable-modern-authentication-in-exchange-online>. The latter is hosted on the Learn site and is still being maintained.

Related PR: https://github.com/OfficeDev/office-js-docs-reference/pull/1657