### PR TITLE
[OneNote] Refresh OneNote landing page

### DIFF
--- a/docs/onenote/index.yml
+++ b/docs/onenote/index.yml
@@ -16,6 +16,15 @@ metadata:
 landingContent:
 # Cards and links should be based on top customer tasks or top subjects
 # Start card title with a verb
+
+  # Card (optional)
+  - title: Quickstarts
+    linkLists:
+      - linkListType: quickstart
+        links:
+          - text: Build your first OneNote add-in
+            url: ../quickstarts/onenote-quickstart.md
+            
   # Card (optional)
   - title: About OneNote add-ins
     linkLists:
@@ -37,14 +46,6 @@ landingContent:
             url: ../publish/publish.md
 
   # Card (optional)
-  - title: Quickstarts
-    linkLists:
-      - linkListType: quickstart
-        links:
-          - text: Build your first OneNote add-in
-            url: ../quickstarts/onenote-quickstart.md
-
-  # Card (optional)
   - title: Key Office Add-ins concepts
     linkLists:
       - linkListType: overview
@@ -59,17 +60,7 @@ landingContent:
             url: ../design/add-in-design.md
           - text: Develop Office Add-ins
             url: ../develop/develop-overview.md
-
-  # Card (optional)
-  - title: Resources
-    linkLists:
       - linkListType: reference
         links:
-          - text: Ask questions
-            url: /answers/topics/office-addins-dev.html
-          - text: Request features
-            url: https://techcommunity.microsoft.com/t5/microsoft-365-developer-platform/idb-p/Microsoft365DeveloperPlatform
-          - text: Report issues
-            url: https://github.com/officedev/office-js/issues
           - text: Office Add-ins additional resources
             url: ../resources/resources-links-help.md

--- a/docs/onenote/index.yml
+++ b/docs/onenote/index.yml
@@ -24,7 +24,7 @@ landingContent:
         links:
           - text: Build your first OneNote add-in
             url: ../quickstarts/onenote-quickstart.md
-          - text: Rubric Grader Task Pane Add-in for OneNote Online
+          - text: "Sample: Rubric Grader Task Pane Add-in"
             url: https://github.com/OfficeDev/OneNote-Add-in-Rubric-Grader
 
   # Card (optional)

--- a/docs/onenote/index.yml
+++ b/docs/onenote/index.yml
@@ -8,7 +8,7 @@ metadata:
   description: Resources for learning about OneNote add-ins. # Required; article description that is displayed in search results. < 160 chars.
   ms.service: onenote #Required
   ms.topic: landing-page # Required
-  ms.date: 03/29/2021 #Required; mm/dd/yyyy format.
+  ms.date: 09/29/2023 #Required; mm/dd/yyyy format.
   ms.localizationpriority: high
 
 # linkListType: architecture | concept | deploy | download | get-started | how-to-guide | learn | overview | quickstart | reference | sample | tutorial | video | whats-new
@@ -27,10 +27,6 @@ landingContent:
             url: ../reference/overview/onenote-add-ins-javascript-reference.md         
           - text: Microsoft Graph OneNote REST API Overview
             url: /graph/integrate-with-onenote
-      - linkListType: quickstart
-        links:
-          - text: Build your first OneNote add-in
-            url: ../quickstarts/onenote-quickstart.md
       - linkListType: how-to-guide
         links:
           - text: Use the OneNote JavaScript API to interact with objects and notebook content
@@ -39,6 +35,14 @@ landingContent:
             url: ../testing/test-debug-office-add-ins.md
           - text: Deploy and publish a OneNote add-in
             url: ../publish/publish.md
+
+  # Card (optional)
+  - title: Quickstarts
+    linkLists:
+      - linkListType: quickstart
+        links:
+          - text: Build your first OneNote add-in
+            url: ../quickstarts/onenote-quickstart.md
 
   # Card (optional)
   - title: Key Office Add-ins concepts
@@ -56,7 +60,7 @@ landingContent:
           - text: Develop Office Add-ins
             url: ../develop/develop-overview.md
 
-  # Card
+  # Card (optional)
   - title: Resources
     linkLists:
       - linkListType: reference

--- a/docs/onenote/index.yml
+++ b/docs/onenote/index.yml
@@ -18,13 +18,17 @@ landingContent:
 # Start card title with a verb
 
   # Card (optional)
-  - title: Quickstarts
+  - title: get-started
     linkLists:
       - linkListType: quickstart
         links:
           - text: Build your first OneNote add-in
             url: ../quickstarts/onenote-quickstart.md
-            
+      - linkListType: sample
+        links:
+          - text: Rubric Grader Task Pane Add-in for OneNote Online
+            url: https://github.com/OfficeDev/OneNote-Add-in-Rubric-Grader
+
   # Card (optional)
   - title: About OneNote add-ins
     linkLists:
@@ -36,14 +40,12 @@ landingContent:
             url: ../reference/overview/onenote-add-ins-javascript-reference.md         
           - text: Microsoft Graph OneNote REST API Overview
             url: /graph/integrate-with-onenote
-      - linkListType: how-to-guide
+      - linkListType: concept
         links:
+          - text: Work with OneNote page content
+            url: onenote-add-ins-page-content.md
           - text: Use the OneNote JavaScript API to interact with objects and notebook content
             url: ../reference/overview/onenote-add-ins-javascript-reference.md
-          - text: Test and debug a OneNote add-in
-            url: ../testing/test-debug-office-add-ins.md
-          - text: Deploy and publish a OneNote add-in
-            url: ../publish/publish.md
 
   # Card (optional)
   - title: Key Office Add-ins concepts
@@ -60,6 +62,10 @@ landingContent:
             url: ../design/add-in-design.md
           - text: Develop Office Add-ins
             url: ../develop/develop-overview.md
+          - text: Test and debug a OneNote add-in
+            url: ../testing/test-debug-office-add-ins.md
+          - text: Deploy and publish a OneNote add-in
+            url: ../publish/publish.md
       - linkListType: reference
         links:
           - text: Office Add-ins additional resources

--- a/docs/onenote/index.yml
+++ b/docs/onenote/index.yml
@@ -18,14 +18,12 @@ landingContent:
 # Start card title with a verb
 
   # Card (optional)
-  - title: get-started
+  - title: Get started
     linkLists:
-      - linkListType: quickstart
+      - linkListType: get-started
         links:
           - text: Build your first OneNote add-in
             url: ../quickstarts/onenote-quickstart.md
-      - linkListType: sample
-        links:
           - text: Rubric Grader Task Pane Add-in for OneNote Online
             url: https://github.com/OfficeDev/OneNote-Add-in-Rubric-Grader
 


### PR DESCRIPTION
This page has low click-through rate and high exit rate. People weren't clicking where we would expect them to. This change restructures the page to guide them to the quick start and a sample.