### PR TITLE
[all hosts] Rework hub page to be more scenario/intent focused 

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -32,18 +32,19 @@ highlightedContent:
       url: overview/office-add-in-code-samples.md
 
 productDirectory:
+  title: Get started with Office Add-ins # < 60 chars (optional)
   items:
-  - title: Get started in 5 minutes
+  - title: 5-minute quick starts
     imageSrc: images/index-landing-page/i_quick-start.svg
     links:
       - url: quickstarts/excel-quickstart-jquery.md
-        text: Excel add-in
+        text: Build an Excel task pane add-in
       - url: quickstarts/outlook-quickstart.md
-        text: Outlook add-in
+        text: Build your first Outlook add-in
       - url: quickstarts/powerpoint-quickstart.md
-        text: PowerPoint add-in
+        text: Build your first PowerPoint task pane add-in
       - url: quickstarts/word-quickstart.md
-        text: Word add-in
+        text: Build your first PowerPoint task pane add-in
   
   - title: Add-in scenarios
     imageSrc: images/index-landing-page/i_code-blocks.svg

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -12,7 +12,7 @@ metadata:
   ms.topic: hub-page # Required
   author: o365devx #Required; your GitHub user alias, with correct capitalization.
   ms.author: o365devx #Required; microsoft alias of author; optional team alias.
-  ms.date: 12/16/2022 #Required; mm/dd/yyyy format.
+  ms.date: 10/26/2023 #Required; mm/dd/yyyy format.
 
 # highlightedContent section
 # Maximum of 8 items
@@ -23,26 +23,18 @@ highlightedContent:
       title: Office Add-ins platform overview
       url: overview/office-add-ins.md
     # Card 2
-    - itemType: sample
-      title: Samples for Office Add-ins
-      url: overview/office-add-in-code-samples.md
-    # Card 3
     - itemType: how-to-guide
       title: Office Add-ins Beginner's guide
       url: overview/learning-path-beginner.md
-    # Card 4
+    # Card 3
     - itemType: sample
-      title: Test and experiment with APIs using Script Lab
-      url: overview/explore-with-script-lab.md
-    # Card 5
-    - itemType: reference
-      title: Office JavaScript API reference documentation
-      url: /javascript/api/overview
+      title: Samples for Office Add-ins
+      url: overview/office-add-in-code-samples.md
 
 productDirectory:
   items:
   - title: Get started in 5 minutes
-    imageSrc: media/index/windows.svg
+    imageSrc: images/index-landing=page/i_quick-start.svg
     links:
       - url: quickstarts/excel-quickstart-jquery.md
         text: Excel add-in
@@ -54,7 +46,7 @@ productDirectory:
         text: Word add-in
   
   - title: Add-in scenarios
-    imageSrc: media/index/windows.svg
+    imageSrc: images/index-landing=page/i_design.svg
     links:
       - url: excel/pnp-open-in-excel.md
         text: Create an Excel spreadsheet with your add-in from a web page
@@ -64,6 +56,16 @@ productDirectory:
         text: Implement an integrated spam-reporting add-in
       - url: develop/create-sso-office-add-ins-nodejs.md
         text: Use single sign-on authentication in an Office Add-in 
+  
+  - title: Explore the code
+    imageSrc: images/index-landing=page/i_reference.svg
+    links:
+      - url: overview/explore-with-script-lab.md
+        text: Test and experiment with APIs using Script Lab
+      - url: /javascript/api/overview
+        text: Office JavaScript API reference documentation
+      - url: overview/office-add-in-code-samples.md#getting-started
+        text: "Hello world" samples
 
 
 # conceptualContent section (optional)

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -46,7 +46,7 @@ productDirectory:
         text: Word add-in
   
   - title: Add-in scenarios
-    imageSrc: images/index-landing-page/i_design.svg
+    imageSrc: images/index-landing-page/i_code_started.svg
     links:
       - url: excel/pnp-open-in-excel.md
         text: Create an Excel spreadsheet with your add-in from a web page

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -46,7 +46,7 @@ productDirectory:
         text: Word add-in
   
   - title: Add-in scenarios
-    imageSrc: images/index-landing-page/i_code_started.svg
+    imageSrc: images/index-landing-page/i_code-blocks.svg
     links:
       - url: excel/pnp-open-in-excel.md
         text: Create an Excel spreadsheet with your add-in from a web page

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -65,8 +65,7 @@ productDirectory:
       - url: /javascript/api/overview
         text: Office JavaScript API reference documentation
       - url: overview/office-add-in-code-samples.md#getting-started
-        text: "Hello world" samples
-
+        text: Hello world samples
 
 # conceptualContent section (optional)
 conceptualContent:

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -23,33 +23,47 @@ highlightedContent:
       title: Office Add-ins platform overview
       url: overview/office-add-ins.md
     # Card 2
-    - itemType: quickstart
-      title: Set up an Excel add-in in 5 minutes
-      url: quickstarts/excel-quickstart-jquery.md
-    # Card 3
-    - itemType: quickstart
-      title: Set up an Outlook add-in in 5 minutes
-      url: quickstarts/outlook-quickstart.md
-    # Card 4
-    - itemType: quickstart
-      title: Set up a Word add-in in 5 minutes
-      url: quickstarts/word-quickstart.md
-    # Card 5
     - itemType: sample
       title: Samples for Office Add-ins
       url: overview/office-add-in-code-samples.md
-    # Card 6
+    # Card 3
     - itemType: how-to-guide
       title: Office Add-ins Beginner's guide
       url: overview/learning-path-beginner.md
-    # Card 7
+    # Card 4
     - itemType: sample
       title: Test and experiment with APIs using Script Lab
       url: overview/explore-with-script-lab.md
-    # Card 8
+    # Card 5
     - itemType: reference
       title: Office JavaScript API reference documentation
       url: /javascript/api/overview
+
+productDirectory:
+  items:
+  - title: Get started in 5 minutes
+    imageSrc: media/index/windows.svg
+    links:
+      - url: quickstarts/excel-quickstart-jquery.md
+        text: Excel add-in
+      - url: quickstarts/outlook-quickstart.md
+        text: Outlook add-in
+      - url: quickstarts/powerpoint-quickstart.md
+        text: PowerPoint add-in
+      - url: quickstarts/word-quickstart.md
+        text: Word add-in
+  
+  - title: Add-in scenarios
+    imageSrc: media/index/windows.svg
+    links:
+      - url: excel/pnp-open-in-excel.md
+        text: Create an Excel spreadsheet with your add-in from a web page
+      - url: outlook/smart-alerts-onmessagesend-walkthrough.md
+        text: Automatically check for an attachment before a message is sent
+      - url: outlook/spam-reporting.md
+        text: Implement an integrated spam-reporting add-in
+      - url: develop/create-sso-office-add-ins-nodejs.md
+        text: Use single sign-on authentication in an Office Add-in 
 
 
 # conceptualContent section (optional)
@@ -64,15 +78,6 @@ conceptualContent:
         - url: overview/learning-path-beginner.md
           itemType: get-started
           text: Get started with Office Add-ins
-        - url: quickstarts/powerpoint-quickstart.md
-          itemType: quickstart
-          text: Set up a PowerPoint add-in in 5 minutes
-        - url: /training/modules/intro-office-add-ins
-          itemType: learn
-          text: Introduction to Office client customization with add-ins
-        - url: /training/paths/m365-office-add-in-associate
-          itemType: learn
-          text: Extend Office clients with Office Add-ins
         - url: https://devblogs.microsoft.com/microsoft365dev/category/office-add-ins/
           itemType: whats-new
           text: Microsoft 365 Developer Blog
@@ -95,12 +100,12 @@ conceptualContent:
     # Card 3
     - title: Test and debug
       links:
-        - url: testing/clear-cache.md
-          itemType: how-to-guide
-          text: Clear the Office cache
         - url: testing/test-debug-office-add-ins.md
           itemType: overview
           text: Check out the debugging overview
+        - url: testing/clear-cache.md
+          itemType: how-to-guide
+          text: Clear the Office cache
         - url: testing/testing-and-troubleshooting.md
           itemType: concept
           text: Troubleshoot user errors

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -34,7 +34,7 @@ highlightedContent:
 productDirectory:
   items:
   - title: Get started in 5 minutes
-    imageSrc: images/index-landing=page/i_quick-start.svg
+    imageSrc: images/index-landing-page/i_quick-start.svg
     links:
       - url: quickstarts/excel-quickstart-jquery.md
         text: Excel add-in
@@ -46,7 +46,7 @@ productDirectory:
         text: Word add-in
   
   - title: Add-in scenarios
-    imageSrc: images/index-landing=page/i_design.svg
+    imageSrc: images/index-landing-page/i_design.svg
     links:
       - url: excel/pnp-open-in-excel.md
         text: Create an Excel spreadsheet with your add-in from a web page
@@ -58,7 +58,7 @@ productDirectory:
         text: Use single sign-on authentication in an Office Add-in 
   
   - title: Explore the code
-    imageSrc: images/index-landing=page/i_reference.svg
+    imageSrc: images/index-landing-page/i_reference.svg
     links:
       - url: overview/explore-with-script-lab.md
         text: Test and experiment with APIs using Script Lab


### PR DESCRIPTION
Our hub page has higher-than-expected bounce rates and exit rates. This PR removes some of the links to pages with lower clicks. and promotes some scenarios, with the intention to substitute newer scenarios as they come online. 