### PR TITLE
Fix breadcrumbs

### DIFF
--- a/docs/breadcrumb/toc.yml
+++ b/docs/breadcrumb/toc.yml
@@ -1,7 +1,7 @@
-- name: Office
+- name: Microsoft 365
   tocHref: /office/
-  topicHref: /office/index
+  topicHref: /microsoft-365/index
   items:
-  - name: Add-ins
+  - name: Office Add-ins
     tocHref: /office/dev/add-ins/
-    topicHref: /office/dev/add-ins
+    topicHref: /office/dev/add-ins/index

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -41,7 +41,6 @@
       "feedback_system": "GitHub",
       "feedback_github_repo": "OfficeDev/office-js-docs-pr",
       "feedback_product_url": "https://aka.ms/office-addins-dev-questions",
-      "extendBreadcrumb": true,
       "ms.suite": "office",
       "ms.author": "o365devx",
       "author": "o365devx",


### PR DESCRIPTION
This PR brings breadcrumb implementation into alignment with [platform architecture requirements](https://review.learn.microsoft.com/en-us/help/platform/navigation-overview?branch=main#requirements-for-content-ecosystems). This PR is part of a previously announced batch of breadcrumb fixes across the Learn platform and will be auto-merged if there are no build warnings. This PR may include removing the “extend breadcrumb” feature from any docfx files that are still using it, fixing breadcrumb file references in the docfx file, and rewriting breadcrumb files to match the [approved breadcrumb pattern](https://review.learn.microsoft.com/en-us/help/platform/navigation-breadcrumbs-overview?branch=main#breadcrumbs-in-documentation) for a given product’s documentation. 