### PR TITLE
[all hosts] (TOC) Remove Samples node from TOC

### DIFF
--- a/docs/overview/create-an-office-add-in-from-script-lab.md
+++ b/docs/overview/create-an-office-add-in-from-script-lab.md
@@ -2,7 +2,7 @@
 title: Create a standalone Office Add-in from your Script Lab code
 description: Learn how to move your snippet from Script Lab into a Yo Office project
 ms.topic: how-to
-ms.date: 06/23/2023
+ms.date: 11/10/2023
 ms.localizationpriority: high
 ---
 
@@ -16,7 +16,7 @@ The steps in this article refer to [Visual Studio Code](https://code.visualstudi
 
 You need to create the standalone add-in project which will be the new development location for your snippet code.
 
-Run the command `yo office --projectType taskpane --ts true --host <host> --name "basic-sample"`, where `<host>` is one of the following values.
+Run the command `yo office --projectType taskpane --ts true --host <host> --name "my-add-in"`, where `<host>` is one of the following values.
 
 - excel
 - outlook
@@ -26,7 +26,7 @@ Run the command `yo office --projectType taskpane --ts true --host <host> --name
 > [!IMPORTANT]
 > The `--name` argument value must be in double quotation marks, even if it has no spaces.
 
-The previous command creates a new project folder named **basic-sample**. It's configured to run in the host you specified, and uses TypeScript. Script Lab uses TypeScript by default, but most of the snippets are JavaScript. You can build a Yo Office JavaScript project if you prefer, but just be sure any code you copy over is JavaScript.
+The previous command creates a new project folder named **my-add-in**. It's configured to run in the host you specified, and uses TypeScript. Script Lab uses TypeScript by default, but most of the snippets are JavaScript. You can build a Yo Office JavaScript project if you prefer, but just be sure any code you copy over is JavaScript.
 
 ## Open the snippet in Script Lab
 
@@ -34,15 +34,13 @@ Use an existing snippet in Script Lab to learn how to copy a snippet to a Yo Off
 
 1. Open Office (Word, Excel, PowerPoint, or Outlook) and then open Script Lab.
 1. Select **Script Lab** > **Code**. If you're working in Outlook, open an email message to see Script Lab on the ribbon.
-1. In the Script Lab task pane, choose **Samples**. Then select a basic sample based on which Office host you are working in.
-    - For Excel, PowerPoint, or Word, choose the **Basic API Call (TypeScript)** sample.
-    - For Outlook, choose the **Use add-in settings** sample.
+1. Open your snippet in Script Lab. If you want to start with an existing sample, go to the Script Lab task pane and choose **Samples**.
 
 ## Copy snippet code to Visual Studio code
 
 Now you can copy the code from the snippet to the Yo Office project in VS Code.
 
-- In VS Code, open the **basic-sample** project.
+- In VS Code, open the **my-add-in** project.
 
 In the next steps, you'll copy code from several tabs in Script Lab.
 
@@ -140,14 +138,14 @@ Script Lab handles the `Office.onReady` initialization automatically. You'll nee
 
 If your snippet uses custom functions, you need to use the Yo Office custom functions template. To turn custom functions into a standalone add-in, follow these steps.
 
-1. Run the command `yo office --projectType excel-functions --ts true --name "functions-sample"`.
+1. Run the command `yo office --projectType excel-functions --ts true --name "my-functions"`.
 
     > [!IMPORTANT]
     > The `--name` argument value must be in double quotation marks, even if it has no spaces.
 
 1. Open Excel, and then open Script Lab.
 1. Select **Script Lab** > **Code**.
-1. In the Script Lab task pane, choose **Samples**, and then choose the **Basic custom function** sample.
+1. Open your snippet in Script Lab. If you want to start with an existing sample, go to the Script Lab task pane, choose **Samples**, and search under the **Custom Functions** section.
 1. Open the **/src/functions/functions.ts** file. If you're using a JavaScript project, the filename is **functions.js**.
 1. In Script Lab, select the **Script** tab.
 1. Copy all of the code in the **Script** tab to the clipboard. Paste the code at the top of the **functions.ts** (or **functions.js** for JavaScript) with the code you copied.

--- a/docs/overview/explore-with-script-lab.md
+++ b/docs/overview/explore-with-script-lab.md
@@ -1,7 +1,7 @@
 ---
 title: Explore Office JavaScript API using Script Lab
 description: Use Script Lab to explore the Office JS API and to prototype functionality.
-ms.date: 05/20/2023
+ms.date: 11/10/2023
 ms.topic: concept-article
 ms.custom: scenarios:getting-started
 ms.localizationpriority: high
@@ -74,17 +74,15 @@ For more details on Script Lab for Outlook, see the related [blog post](https://
 
 ## Next steps
 
-To use Script Lab in Excel, Word, or PowerPoint, install the [Script Lab add-in](https://appsource.microsoft.com/product/office/WA104380862) from AppSource.
+> [!div class="nextstepaction"]
+> [Get Script Lab for Excel, PowerPoint, and Word](https://appsource.microsoft.com/product/office/WA104380862)
 
-To use Script Lab for Outlook, install the [Script Lab for Outlook add-in](https://appsource.microsoft.com/product/office/wa200001603) from AppSource.
+> [!div class="nextstepaction"]
+> [Get Script Lab for Outlook](https://appsource.microsoft.com/product/office/WA200001603)
 
-You're welcome to expand the sample library in Script Lab by contributing new snippets to the [office-js-snippets](https://github.com/OfficeDev/office-js-snippets#office-js-snippets) GitHub repository.
-
-When you're ready to create your first Office Add-in, try out the quick start for [Excel](../quickstarts/excel-quickstart-jquery.md), [Outlook](../quickstarts/outlook-quickstart.md), [Word](../quickstarts/word-quickstart.md), [OneNote](../quickstarts/onenote-quickstart.md), [PowerPoint](../quickstarts/powerpoint-quickstart.md), or [Project](../quickstarts/project-quickstart.md).
+Once you've prototyped your code in Script Lab, turn it into a real add-in with the steps in [Create a standalone Office Add-in from your Script Lab code](./create-an-office-add-in-from-script-lab.md).
 
 ## See also
 
-- [Get Script Lab for Excel, Word, or Powerpoint](https://appsource.microsoft.com/product/office/WA104380862)
-- [Get Script Lab for Outlook](https://appsource.microsoft.com/product/office/wa200001603)
-- [Script Lab on GitHub](https://github.com/OfficeDev/script-lab)
+- [Script Lab sample GitHub repository](https://github.com/OfficeDev/office-js-snippets#office-js-snippets)
 - [Developing Office Add-ins](../develop/develop-overview.md)

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -32,6 +32,9 @@ items:
   - name: Explore Office JS APIs using Script Lab
     href: overview/explore-with-script-lab.md
     displayName: Excel, Word, PowerPoint
+  - name: Samples
+    href: overview/office-add-in-code-samples.md
+    displayName: PnP
   - name: Set up your development environment 
     href: overview/set-up-your-dev-environment.md
     displayName: Excel, Word, OneNote, Project, PowerPoint, Outlook
@@ -286,6 +289,8 @@ items:
           href: develop/get-javascript-intellisense-in-visual-studio.md
         - name: Convert JavaScript projects to TypeScript
           href: develop/convert-javascript-to-typescript.md
+      - name: Copy Script Lab snippet to Yo Office
+        href: overview/create-an-office-add-in-from-script-lab.md
     - name: Special requirements for add-ins on the iPad
       href: develop/develop-office-add-ins-for-the-ipad.md
   - name: Test and debug
@@ -412,6 +417,9 @@ items:
       displayName: Excel
   - name: Excel add-in tutorial
     href: tutorials/excel-tutorial.md
+    displayName: Excel
+  - name: Open in Excel sample
+    href: excel/pnp-open-in-excel.md
     displayName: Excel
   - name: Excel JavaScript API
     items:
@@ -567,6 +575,9 @@ items:
       displayName: Excel, Custom Functions
     - name: Autogenerate JSON metadata
       href: excel/custom-functions-json-autogeneration.md
+      displayName: Excel, Custom Functions
+    - name: Batching custom function remote calls
+      href: excel/custom-functions-batching.md
       displayName: Excel, Custom Functions
     - name: Data types
       href: excel/custom-functions-data-types-concepts.md
@@ -940,19 +951,6 @@ items:
     - name: Troubleshoot Word add-ins
       href: word/word-add-ins-troubleshooting.md
       displayName: Word
-- name: Samples
-  items:
-  - name: Samples list
-    href: overview/office-add-in-code-samples.md
-    displayName: PnP
-  - name: Open in Excel
-    href: excel/pnp-open-in-excel.md
-    displayName: Excel
-  - name: Copy Script Lab snippet to Yo Office
-    href: overview/create-an-office-add-in-from-script-lab.md
-  - name: Batching custom function remote calls
-    href: excel/custom-functions-batching.md
-    displayName: Excel, Custom Functions
 - name: Resources
   items:
   - name: Glossary

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -418,7 +418,7 @@ items:
   - name: Excel add-in tutorial
     href: tutorials/excel-tutorial.md
     displayName: Excel
-  - name: Open in Excel sample
+  - name: 'Sample: Open in Excel'
     href: excel/pnp-open-in-excel.md
     displayName: Excel
   - name: Excel JavaScript API

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -34,7 +34,7 @@ items:
     displayName: Excel, Word, PowerPoint
   - name: Samples
     href: overview/office-add-in-code-samples.md
-    displayName: PnP, code samples
+    displayName: PnP, 'code samples'
   - name: Set up your development environment 
     href: overview/set-up-your-dev-environment.md
     displayName: Excel, Word, OneNote, Project, PowerPoint, Outlook
@@ -291,7 +291,7 @@ items:
           href: develop/convert-javascript-to-typescript.md
       - name: Copy Script Lab snippet to Yo Office
         href: overview/create-an-office-add-in-from-script-lab.md
-        displayName: code samples
+        displayName: 'code samples'
     - name: Special requirements for add-ins on the iPad
       href: develop/develop-office-add-ins-for-the-ipad.md
   - name: Test and debug
@@ -421,7 +421,7 @@ items:
     displayName: Excel
   - name: 'Sample: Open in Excel'
     href: excel/pnp-open-in-excel.md
-    displayName: Excel, code samples
+    displayName: Excel, 'code samples'
   - name: Excel JavaScript API
     items:
     - name: Overview

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -34,7 +34,7 @@ items:
     displayName: Excel, Word, PowerPoint
   - name: Samples
     href: overview/office-add-in-code-samples.md
-    displayName: PnP
+    displayName: PnP, code samples
   - name: Set up your development environment 
     href: overview/set-up-your-dev-environment.md
     displayName: Excel, Word, OneNote, Project, PowerPoint, Outlook
@@ -291,6 +291,7 @@ items:
           href: develop/convert-javascript-to-typescript.md
       - name: Copy Script Lab snippet to Yo Office
         href: overview/create-an-office-add-in-from-script-lab.md
+        displayName: code samples
     - name: Special requirements for add-ins on the iPad
       href: develop/develop-office-add-ins-for-the-ipad.md
   - name: Test and debug
@@ -420,7 +421,7 @@ items:
     displayName: Excel
   - name: 'Sample: Open in Excel'
     href: excel/pnp-open-in-excel.md
-    displayName: Excel
+    displayName: Excel, code samples
   - name: Excel JavaScript API
     items:
     - name: Overview


### PR DESCRIPTION
This PR adjusts the Samples node in the TOC. Previously, a few samples existed there, but it didn't represent the full breadth of our sample library and may have given false impressions. The existing sample pages have been moved elsewhere in the TOC.

This PR also makes a tighter connection between the Script Lab article and the sample to convert a Script Lab snippet into an add-in.