### PR TITLE
[Outlook] (manifest) Swap order of manifest tabs in walkthroughs

### DIFF
--- a/docs/outlook/delegate-access.md
+++ b/docs/outlook/delegate-access.md
@@ -151,6 +151,24 @@ First, to support REST calls from a delegate, the add-in must request the **read
 
 Second, enable support for shared folders. The markup varies depending on the type of manifest.
 
+# [Unified manifest for Microsoft 365 (developer preview)](#tab/jsonmanifest)
+
+Add an additional object to the "authorization.permissions.resourceSpecific" array and set its "name" property to "Mailbox.SharedFolder".
+
+```json
+"authorization": {
+  "permissions": {
+    "resourceSpecific": [
+      ...
+      {
+        "name": "Mailbox.SharedFolder",
+        "type": "Delegated"
+      },
+    ]
+  }
+},
+```
+
 # [XML Manifest](#tab/xmlmanifest)
 
 Set the [SupportsSharedFolders](/javascript/api/manifest/supportssharedfolders) element to `true` in the manifest under the parent element `DesktopFormFactor`. At present, other form factors aren't supported.
@@ -178,24 +196,6 @@ Set the [SupportsSharedFolders](/javascript/api/manifest/supportssharedfolders) 
   </VersionOverrides>
 </VersionOverrides>
 ...
-```
-
-# [Unified manifest for Microsoft 365 (developer preview)](#tab/jsonmanifest)
-
-Add an additional object to the "authorization.permissions.resourceSpecific" array and set its "name" property to "Mailbox.SharedFolder".
-
-```json
-"authorization": {
-  "permissions": {
-    "resourceSpecific": [
-      ...
-      {
-        "name": "Mailbox.SharedFolder",
-        "type": "Delegated"
-      },
-    ]
-  }
-},
 ```
 
 ---

--- a/docs/outlook/on-new-compose-events-walkthrough.md
+++ b/docs/outlook/on-new-compose-events-walkthrough.md
@@ -23,6 +23,90 @@ Complete the [Outlook quick start](../quickstarts/outlook-quickstart.md?tabs=yeo
 
 To configure the manifest, select the tab for the type of manifest you're using.
 
+# [Unified manifest for Microsoft 365 (developer preview)](#tab/jsonmanifest)
+
+1. Open the **manifest.json** file.
+
+1. Add the following object to the "extensions.runtimes" array. Note the following about this markup:
+
+   - The "minVersion" of the Mailbox requirement set is configured to "1.10" as this is the lowest version of the requirement set that supports the `OnNewMessageCompose` and `OnNewAppointmentOrganizer` events.
+   - The "id" of the runtime is set to the descriptive name "autorun_runtime".
+   - The "code" property has a child "page" property that is set to an HTML file and a child "script" property that is set to a JavaScript file. You'll create or edit these files in later steps. Office uses one of these values depending on the platform.
+       - Office on Windows executes the event handlers in a JavaScript-only runtime, which loads a JavaScript file directly.
+       - Office on Mac and the web execute the handlers in a browser runtime, which loads an HTML file. That file, in turn, contains a `<script>` tag that loads the JavaScript file.
+
+     For more information, see [Runtimes in Office Add-ins](../testing/runtimes.md).
+   - The "lifetime" property is set to "short", which means that the runtime starts up when one of the events is triggered and shuts down when the handler completes. (In certain rare cases, the runtime shuts down before the handler completes. See [Runtimes in Office Add-ins](../testing/runtimes.md).)
+   - There are two types of "actions" that can run in the runtime. You'll create functions to correspond to these actions in a later step.
+
+    ```json
+     {
+        "requirements": {
+            "capabilities": [
+                {
+                    "name": "Mailbox",
+                    "minVersion": "1.10"
+                }
+            ]
+        },
+        "id": "autorun_runtime",
+        "type": "general",
+        "code": {
+            "page": "https://localhost:3000/commands.html",
+            "script": "https://localhost:3000/launchevent.js"
+        },
+        "lifetime": "short",
+        "actions": [
+            {
+                "id": "onNewMessageComposeHandler",
+                "type": "executeFunction",
+                "displayName": "onNewMessageComposeHandler"
+            },
+            {
+                "id": "onNewAppointmentComposeHandler",
+                "type": "executeFunction",
+                "displayName": "onNewAppointmentComposeHandler"
+            }
+        ]
+    }
+    ```
+
+1. Add the following "autoRunEvents" array as a property of the object in the "extensions" array.
+
+    ```json
+    "autoRunEvents": [
+    
+    ]
+    ```
+
+1. Add the following object to the "autoRunEvents" array. The "events" property maps handlers to events as described in the table earlier in this article. The handler names must match those used in the "id" properties of the objects in the "actions" array in an earlier step.
+
+    ```json
+      {
+          "requirements": {
+              "capabilities": [
+                  {
+                      "name": "Mailbox",
+                      "minVersion": "1.10"
+                  }
+              ],
+              "scopes": [
+                  "mail"
+              ]
+          },
+          "events": [
+              {
+                  "type": "newMessageComposeCreated",
+                  "actionId": "onNewMessageComposeHandler"
+              },
+              {
+                  "type": "newAppointmentOrganizerCreated",
+                  "actionId": "onNewAppointmentComposeHandler"
+              }
+          ]
+      }
+    ```
+
 # [XML Manifest](#tab/xmlmanifest)
 
 To enable event-based activation of your add-in, you must configure the [Runtimes](/javascript/api/manifest/runtimes) element and [LaunchEvent](/javascript/api/manifest/extensionpoint#launchevent) extension point in the `VersionOverridesV1_1` node of the manifest.
@@ -134,90 +218,6 @@ In event-based add-ins, Outlook on Windows uses a JavaScript file, while Outlook
   </VersionOverrides>
 </VersionOverrides>
 ```
-
-# [Unified manifest for Microsoft 365 (developer preview)](#tab/jsonmanifest)
-
-1. Open the **manifest.json** file.
-
-1. Add the following object to the "extensions.runtimes" array. Note the following about this markup:
-
-   - The "minVersion" of the Mailbox requirement set is configured to "1.10" as this is the lowest version of the requirement set that supports the `OnNewMessageCompose` and `OnNewAppointmentOrganizer` events.
-   - The "id" of the runtime is set to the descriptive name "autorun_runtime".
-   - The "code" property has a child "page" property that is set to an HTML file and a child "script" property that is set to a JavaScript file. You'll create or edit these files in later steps. Office uses one of these values depending on the platform.
-       - Office on Windows executes the event handlers in a JavaScript-only runtime, which loads a JavaScript file directly.
-       - Office on Mac and the web execute the handlers in a browser runtime, which loads an HTML file. That file, in turn, contains a `<script>` tag that loads the JavaScript file.
-
-     For more information, see [Runtimes in Office Add-ins](../testing/runtimes.md).
-   - The "lifetime" property is set to "short", which means that the runtime starts up when one of the events is triggered and shuts down when the handler completes. (In certain rare cases, the runtime shuts down before the handler completes. See [Runtimes in Office Add-ins](../testing/runtimes.md).)
-   - There are two types of "actions" that can run in the runtime. You'll create functions to correspond to these actions in a later step.
-
-    ```json
-     {
-        "requirements": {
-            "capabilities": [
-                {
-                    "name": "Mailbox",
-                    "minVersion": "1.10"
-                }
-            ]
-        },
-        "id": "autorun_runtime",
-        "type": "general",
-        "code": {
-            "page": "https://localhost:3000/commands.html",
-            "script": "https://localhost:3000/launchevent.js"
-        },
-        "lifetime": "short",
-        "actions": [
-            {
-                "id": "onNewMessageComposeHandler",
-                "type": "executeFunction",
-                "displayName": "onNewMessageComposeHandler"
-            },
-            {
-                "id": "onNewAppointmentComposeHandler",
-                "type": "executeFunction",
-                "displayName": "onNewAppointmentComposeHandler"
-            }
-        ]
-    }
-    ```
-
-1. Add the following "autoRunEvents" array as a property of the object in the "extensions" array.
-
-    ```json
-    "autoRunEvents": [
-    
-    ]
-    ```
-
-1. Add the following object to the "autoRunEvents" array. The "events" property maps handlers to events as described in the table earlier in this article. The handler names must match those used in the "id" properties of the objects in the "actions" array in an earlier step.
-
-    ```json
-      {
-          "requirements": {
-              "capabilities": [
-                  {
-                      "name": "Mailbox",
-                      "minVersion": "1.10"
-                  }
-              ],
-              "scopes": [
-                  "mail"
-              ]
-          },
-          "events": [
-              {
-                  "type": "newMessageComposeCreated",
-                  "actionId": "onNewMessageComposeHandler"
-              },
-              {
-                  "type": "newAppointmentOrganizerCreated",
-                  "actionId": "onNewAppointmentComposeHandler"
-              }
-          ]
-      }
-    ```
 
 ---
 

--- a/docs/outlook/pinnable-taskpane.md
+++ b/docs/outlook/pinnable-taskpane.md
@@ -29,6 +29,22 @@ However, by default, if a user has an add-in task pane open for a message in the
 
 The first step is to add pinning support, which is done in the add-in manifest. The markup varies depending on the type of manifest.
 
+# [Unified manifest for Microsoft 365 (developer preview)](#tab/jsonmanifest)
+
+Add a "pinnable" property, set to `true`, to the object in the "actions" array that defines the button or menu item that opens the task pane. The following is an example.
+
+```json
+"actions": [
+    {
+        "id": "OpenTaskPane",
+        "type": "openPage",
+        "view": "TaskPaneView",
+        "displayName": "OpenTaskPane",
+        "pinnable": true
+    }
+]
+```
+
 # [XML Manifest](#tab/xmlmanifest)
 
 Add the [SupportsPinning](/javascript/api/manifest/action#supportspinning) element to the **\<Action\>** element that describes the task pane button. The following is an example.
@@ -55,28 +71,12 @@ Add the [SupportsPinning](/javascript/api/manifest/action#supportspinning) eleme
 
 The **\<SupportsPinning\>** element is defined in the VersionOverrides v1.1 schema, so you will need to include a [VersionOverrides](/javascript/api/manifest/versionoverrides) element both for v1.0 and v1.1.
 
-# [Unified manifest for Microsoft 365 (developer preview)](#tab/jsonmanifest)
-
-Add a "pinnable" property, set to `true`, to the object in the "actions" array that defines the button or menu item that opens the task pane. The following is an example.
-
-```json
-"actions": [
-    {
-        "id": "OpenTaskPane",
-        "type": "openPage",
-        "view": "TaskPaneView",
-        "displayName": "OpenTaskPane",
-        "pinnable": true
-    }
-]
-```
-
 ---
 
 For a full example, see the `msgReadOpenPaneButton` control in the [command-demo sample manifest](https://github.com/OfficeDev/outlook-add-in-command-demo/blob/master/command-demo-manifest.xml).
 
 > [!NOTE]
-> A pinnable task pane can also be enabled without the **\<SupportsPinning\>** element if the **\<SupportsNoItemContext\>** element is included in the manifest. To learn more, see [Activate your Outlook add-in without the Reading Pane enabled or a message selected](contextless.md).
+> Task pane pinning is automatically supported in an add-in that activates without the Reading Pane enabled or a message first selected. To learn more, see [Activate your Outlook add-in without the Reading Pane enabled or a message selected](contextless.md).
 
 ## Handling UI updates based on currently selected message
 

--- a/docs/outlook/smart-alerts-onmessagesend-walkthrough.md
+++ b/docs/outlook/smart-alerts-onmessagesend-walkthrough.md
@@ -212,12 +212,12 @@ To configure the manifest, select the tab for the type of manifest you are using
 
 1. Save your changes.
 
+---
+
 > [!TIP]
 >
 > - For a list of send mode options available with the `OnMessageSend` and `OnAppointmentSend` events, see [Available send mode options](onmessagesend-onappointmentsend-events.md#available-send-mode-options).
 > - To learn more about manifests for Outlook add-ins, see [Office add-in manifests](../develop/add-in-manifests.md).
-
----
 
 ## Implement event handling
 

--- a/docs/outlook/smart-alerts-onmessagesend-walkthrough.md
+++ b/docs/outlook/smart-alerts-onmessagesend-walkthrough.md
@@ -25,6 +25,86 @@ Then, complete the [Outlook quick start](../quickstarts/outlook-quickstart.md?ta
 
 To configure the manifest, select the tab for the type of manifest you are using.
 
+# [Unified manifest for Microsoft 365 (developer preview)](#tab/jsonmanifest)
+
+1. Open the **manifest.json** file.
+
+1. Add the following object to the "extensions.runtimes" array. Note the following about this markup:
+
+   - The "minVersion" of the Mailbox requirement set is set to "1.12" because the [supported events table](autolaunch.md#supported-events) specifies that this is the lowest version of the requirement set that supports the `OnMessageSend` event.
+   - The "id" of the runtime is set to the descriptive name "autorun_runtime".
+   - The "code" property has a child "page" property that is set to an HTML file and a child "script" property that is set to a JavaScript file. You'll create or edit these files in later steps. Office uses one of these values or the other depending on the platform.
+       - Office on Windows executes the event handler in a JavaScript-only runtime, which loads a JavaScript file directly.
+       - Office on Mac and the web execute the handler in a browser runtime, which loads an HTML file. That file, in turn, contains a `<script>` tag that loads the JavaScript file.
+     For more information, see [Runtimes in Office Add-ins](../testing/runtimes.md).
+   - The "lifetime" property is set to "short", which means that the runtime starts up when the event is triggered and shuts down when the handler completes. (In certain rare cases, the runtime shuts down before the handler completes. See [Runtimes in Office Add-ins](../testing/runtimes.md).)
+   - There is an action to run a handler for the `OnMessageSend` event. You'll create the handler function in a later step.
+
+    ```json
+     {
+        "requirements": {
+            "capabilities": [
+                {
+                    "name": "Mailbox",
+                    "minVersion": "1.12"
+                }
+            ]
+        },
+        "id": "autorun_runtime",
+        "type": "general",
+        "code": {
+            "page": "https://localhost:3000/commands.html",
+            "script": "https://localhost:3000/launchevent.js"
+        },
+        "lifetime": "short",
+        "actions": [
+            {
+                "id": "onMessageSendHandler",
+                "type": "executeFunction",
+                "displayName": "onMessageSendHandler"
+            }
+        ]
+    }
+    ```
+
+1. Add the following "autoRunEvents" array as a property of the object in the "extensions" array.
+
+    ```json
+    "autoRunEvents": [
+    
+    ]
+    ```
+
+1. Add the following object to the "autoRunEvents" array. Note the following about this code:
+
+   - The event object assigns a handler function to the `OnMessageSend` event (using the event's unified manifest name, "messageSending", as described in the [supported events table](autolaunch.md#supported-events)). The function name provided in "actionId" must match the name used in the "id" property of the object in the "actions" array in an earlier step.
+   - The "sendMode" option is set to "softBlock". This means that if the message doesn't meet the conditions that the add-in sets for sending, the user must take action before they can send the message. However, if the add-in is unavailable at the time of sending, the item will be sent.
+
+    ```json
+      {
+          "requirements": {
+              "capabilities": [
+                  {
+                      "name": "Mailbox",
+                      "minVersion": "1.12"
+                  }
+              ],
+              "scopes": [
+                  "mail"
+              ]
+          },
+          "events": [
+            {
+                "type": "messageSending",
+                "actionId": "onMessageSendHandler",
+                "options": {
+                    "sendMode": "softBlock"
+                }
+            }
+          ]
+      }
+    ```
+
 # [XML Manifest](#tab/xmlmanifest)
 
 1. In your code editor, open the quick start project.
@@ -136,86 +216,6 @@ To configure the manifest, select the tab for the type of manifest you are using
 >
 > - For a list of send mode options available with the `OnMessageSend` and `OnAppointmentSend` events, see [Available send mode options](onmessagesend-onappointmentsend-events.md#available-send-mode-options).
 > - To learn more about manifests for Outlook add-ins, see [Office add-in manifests](../develop/add-in-manifests.md).
-
-# [Unified manifest for Microsoft 365 (developer preview)](#tab/jsonmanifest)
-
-1. Open the **manifest.json** file.
-
-1. Add the following object to the "extensions.runtimes" array. Note the following about this markup:
-
-   - The "minVersion" of the Mailbox requirement set is set to "1.12" because the [supported events table](autolaunch.md#supported-events) specifies that this is the lowest version of the requirement set that supports the `OnMessageSend` event.
-   - The "id" of the runtime is set to the descriptive name "autorun_runtime".
-   - The "code" property has a child "page" property that is set to an HTML file and a child "script" property that is set to a JavaScript file. You'll create or edit these files in later steps. Office uses one of these values or the other depending on the platform.
-       - Office on Windows executes the event handler in a JavaScript-only runtime, which loads a JavaScript file directly.
-       - Office on Mac and the web execute the handler in a browser runtime, which loads an HTML file. That file, in turn, contains a `<script>` tag that loads the JavaScript file.
-     For more information, see [Runtimes in Office Add-ins](../testing/runtimes.md).
-   - The "lifetime" property is set to "short", which means that the runtime starts up when the event is triggered and shuts down when the handler completes. (In certain rare cases, the runtime shuts down before the handler completes. See [Runtimes in Office Add-ins](../testing/runtimes.md).)
-   - There is an action to run a handler for the `OnMessageSend` event. You'll create the handler function in a later step.
-
-    ```json
-     {
-        "requirements": {
-            "capabilities": [
-                {
-                    "name": "Mailbox",
-                    "minVersion": "1.12"
-                }
-            ]
-        },
-        "id": "autorun_runtime",
-        "type": "general",
-        "code": {
-            "page": "https://localhost:3000/commands.html",
-            "script": "https://localhost:3000/launchevent.js"
-        },
-        "lifetime": "short",
-        "actions": [
-            {
-                "id": "onMessageSendHandler",
-                "type": "executeFunction",
-                "displayName": "onMessageSendHandler"
-            }
-        ]
-    }
-    ```
-
-1. Add the following "autoRunEvents" array as a property of the object in the "extensions" array.
-
-    ```json
-    "autoRunEvents": [
-    
-    ]
-    ```
-
-1. Add the following object to the "autoRunEvents" array. Note the following about this code:
-
-   - The event object assigns a handler function to the `OnMessageSend` event (using the event's unified manifest name, "messageSending", as described in the [supported events table](autolaunch.md#supported-events)). The function name provided in "actionId" must match the name used in the "id" property of the object in the "actions" array in an earlier step.
-   - The "sendMode" option is set to "softBlock". This means that if the message doesn't meet the conditions that the add-in sets for sending, the user must take action before they can send the message. However, if the add-in is unavailable at the time of sending, the item will be sent.
-
-    ```json
-      {
-          "requirements": {
-              "capabilities": [
-                  {
-                      "name": "Mailbox",
-                      "minVersion": "1.12"
-                  }
-              ],
-              "scopes": [
-                  "mail"
-              ]
-          },
-          "events": [
-            {
-                "type": "messageSending",
-                "actionId": "onMessageSendHandler",
-                "options": {
-                    "sendMode": "softBlock"
-                }
-            }
-          ]
-      }
-    ```
 
 ---
 


### PR DESCRIPTION
Swaps the order of the unified manifest and XML manifest tabs in Outlook walkthroughs. Articles not covered in this PR are being worked on in other PRs.