### PR TITLE
Update outlook-quickstart.md

### DIFF
--- a/docs/quickstarts/outlook-quickstart.md
+++ b/docs/quickstarts/outlook-quickstart.md
@@ -74,17 +74,7 @@ The add-in project that you've created with the Yeoman generator contains sample
     </main>
     ```
 
-1. In your code editor, open the file **./src/taskpane/taskpane.js**, then add the following code to the **run** function. This code uses the Office JavaScript API to get a reference to the current message and write its **subject** property value to the task pane.
-
-    ```js
-    // Get a reference to the current message
-    const item = Office.context.mailbox.item;
-
-    // Write message property value to the task pane
-    document.getElementById("item-subject").innerHTML = "<b>Subject:</b> <br/>" + item.subject;
-    ```
-
-    Your **taskpane.js** file should now contain the following code.
+1. In your code editor, open the file **./src/taskpane/taskpane.js**, and replace the contents with the following code. This code uses the Office JavaScript API to get a reference to the current message and write its **subject** property value to the task pane.
 
     ```js
     /*


### PR DESCRIPTION
There is no existing run() function that the current documentation references with the line 'add the following code to the run function'.

The default code in taskpane.js that is created when running yo-office only contains the following import statements:

import "./excel";
import "./onenote";
import "./outlook";
import "./powerpoint";
import "./project";
import "./word";

This correction should remove any confusion.