### PR TITLE
[admin] (Accessibility) Remove the term 'screenshot' from image alt text

### DIFF
--- a/docs/concepts/requirements-for-running-office-add-ins.md
+++ b/docs/concepts/requirements-for-running-office-add-ins.md
@@ -88,11 +88,11 @@ Specifically for Outlook running on smartphones and non-Windows tablet devices, 
 >
 > **modern**
 >
-> ![Partial screenshot of the modern Outlook toolbar.](../images/outlook-on-the-web-new-toolbar.png)
+> ![The section of the modern Outlook toolbar that says 'Outlook' in blue and white.](../images/outlook-on-the-web-new-toolbar.png)
 >
 > **classic**
 >
-> ![Partial screenshot of the classic Outlook toolbar.](../images/outlook-on-the-web-classic-toolbar.png)
+> ![The classic Outlook toolbar that says 'Office 365' and 'Outlook' in black and white.](../images/outlook-on-the-web-classic-toolbar.png)
 
 ## See also
 

--- a/docs/develop/convert-xml-to-json-manifest.md
+++ b/docs/develop/convert-xml-to-json-manifest.md
@@ -69,11 +69,11 @@ The easiest way to convert is to use Teams Toolkit.
 1. Select **Create a new app**.
 1. In the **New Project** drop down, select **Outlook Add-in**.
 
-    :::image type="content" source="../images/teams-toolkit-create-outlook-add-in.png" alt-text="Screenshot showing four options in New Project drop down. The fourth option is called 'Outlook add-in'.":::
+    :::image type="content" source="../images/teams-toolkit-create-outlook-add-in.png" alt-text="The four options in New Project drop down. The fourth option is called 'Outlook add-in'.":::
 
 1. In the **App Features Using an Outlook Add-in** drop down, select **Import an Existing Outlook Add-in**.
 
-    :::image type="content" source="../images/teams-toolkit-create-outlook-task-pane-capability.png" alt-text="Screenshot showing two options in the App Features Using an Outlook Add-in drop down. The second option is called 'Import an Existing Outlook add-in'.":::
+    :::image type="content" source="../images/teams-toolkit-create-outlook-task-pane-capability.png" alt-text="The two options in the App Features Using an Outlook Add-in drop down. The second option is called 'Import an Existing Outlook add-in'.":::
 
 1. In the **Existing add-in project folder** drop down, browse to the root folder of the add-in project.
 1. In the **Select import project manifest file** drop down, browse to the XML manifest file.

--- a/docs/develop/debug-office-add-ins-in-visual-studio.md
+++ b/docs/develop/debug-office-add-ins-in-visual-studio.md
@@ -183,13 +183,13 @@ The best method for debugging an add-in in Visual Studio 2022 depends on whether
 
 #### Use the browser developer tools in Outlook on the web
 
-1. In the Outlook page, select an email message or appointment item to open it in its own window. 
+1. In the Outlook page, select an email message or appointment item to open it in its own window.
 
 1. Press F12 to open the Edge debugging tool.
 
 1. After the tool is open, launch the add-in. For example, in the toolbar at the top of a message, select the **More apps** button, and then select your add-in from the callout that opens.
 
-   ![Screenshot showing the More apps button and the callout that it opens with the add-in's name and icon visible along with other app icons.](../images/outlook-more-apps-button.png)
+   ![The More apps button and the callout that it opens with the add-in's name and icon visible along with other app icons.](../images/outlook-more-apps-button.png)
 
 1. Use the instructions in one of the following articles to set breakpoints and step through code. They each have a link to more detailed guidance.
 

--- a/docs/develop/dialog-best-practices.md
+++ b/docs/develop/dialog-best-practices.md
@@ -39,7 +39,7 @@ For best practices in dialog box design, see [Dialog boxes in Office Add-ins](..
 
 Attempting to display a dialog box while using Office on the web may cause the browser's pop-up blocker to block the dialog box. If this happens, then Office on the web will open a prompt similar to the following:
 
-![Screenshot showing the prompt with a brief description and Allow and Ignore buttons that an add-in can generate to avoid in-browser pop-up blockers](../images/dialog-prompt-before-open.png)
+![The prompt with a brief description and Allow and Ignore buttons that an add-in can generate to avoid in-browser pop-up blockers](../images/dialog-prompt-before-open.png)
 
 If the user chooses **Allow**, the Office dialog box opens. If the user chooses **Ignore**, the prompt closes and the Office dialog box does not open. Instead, the `displayDialogAsync` method returns error 12009. Your code should catch this error and either provide an alternate experience that does not require a dialog, or display a message to the user advising that the add-in requires them to allow the dialog. (For more about 12009, see [Errors from displayDialogAsync](dialog-handle-errors-events.md#errors-from-displaydialogasync).)
 

--- a/docs/develop/dialog-best-practices.md
+++ b/docs/develop/dialog-best-practices.md
@@ -39,7 +39,7 @@ For best practices in dialog box design, see [Dialog boxes in Office Add-ins](..
 
 Attempting to display a dialog box while using Office on the web may cause the browser's pop-up blocker to block the dialog box. If this happens, then Office on the web will open a prompt similar to the following:
 
-![The prompt with a brief description and Allow and Ignore buttons that an add-in can generate to avoid in-browser pop-up blockers](../images/dialog-prompt-before-open.png)
+![The prompt with a brief description and Allow and Ignore buttons that an add-in can generate to avoid in-browser pop-up blockers.](../images/dialog-prompt-before-open.png)
 
 If the user chooses **Allow**, the Office dialog box opens. If the user chooses **Ignore**, the prompt closes and the Office dialog box does not open. Instead, the `displayDialogAsync` method returns error 12009. Your code should catch this error and either provide an alternate experience that does not require a dialog, or display a message to the user advising that the add-in requires them to allow the dialog. (For more about 12009, see [Errors from displayDialogAsync](dialog-handle-errors-events.md#errors-from-displaydialogasync).)
 

--- a/docs/develop/dialog-video.md
+++ b/docs/develop/dialog-video.md
@@ -29,4 +29,4 @@ To play a video in a dialog box with the Office dialog API, follow these steps.
 
 For a sample of a video playing in a dialog box, see the [video placemat design pattern](../design/first-run-experience-patterns.md#video-placemat).
 
-![Screenshot showing a video playing in an add-in dialog box in front of Excel.](../images/video-placemats-dialog-open.png)
+![A video playing in an add-in dialog box in front of Excel.](../images/video-placemats-dialog-open.png)

--- a/docs/develop/install-latest-office-version.md
+++ b/docs/develop/install-latest-office-version.md
@@ -65,7 +65,7 @@ New developer features, including those still in preview, are delivered first to
 
 When the installation process finishes, you will have the latest Office applications installed. To verify that you have the latest build, go to **File** > **Account** from any Office application. Under Office Updates, you'll see the (Office Insiders) label above the version number.
 
-![A screenshot that shows product information with the Office Insiders label.](../images/office-insiders-label.png)
+![Product information, including the version number, with the Office Insiders label.](../images/office-insiders-label.png)
 
 ## Minimum Office builds for Office JavaScript API requirement sets
 

--- a/docs/develop/teams-toolkit-overview.md
+++ b/docs/develop/teams-toolkit-overview.md
@@ -23,11 +23,11 @@ Install the latest version of Teams Toolkit into Visual Studio Code as described
 1. Select **Create a new app**.
 1. In the **New Project** drop down, select **Outlook add-in**.
 
-    :::image type="content" source="../images/teams-toolkit-create-outlook-add-in.png" alt-text="Screenshot showing four options in New Project drop down. The fourth option is called 'Outlook add-in'.":::
+    :::image type="content" source="../images/teams-toolkit-create-outlook-add-in.png" alt-text="The four options in New Project drop down. The fourth option is called 'Outlook add-in'.":::
 
 1. In the **App Features Using an Outlook Add-in** drop down, select **Taskpane**.
 
-    :::image type="content" source="../images/teams-toolkit-create-outlook-task-pane-capability.png" alt-text="Screenshot showing two options in the App Features Using an Outlook Add-in drop down. The first option 'Taskpane' is selected.":::
+    :::image type="content" source="../images/teams-toolkit-create-outlook-task-pane-capability.png" alt-text="The two options in the App Features Using an Outlook Add-in drop down. The first option 'Taskpane' is selected.":::
 
 1. In the **Workspace folder** dialog that opens, select the folder where you want to create the project.
 1. Give a name to the project (with no spaces) when prompted. Teams Toolkit will create the project with basic files and scaffolding. It will then open the project *in a second Visual Studio Code window*. Close the original Visual Studio Code window.

--- a/docs/develop/yeoman-generator-overview.md
+++ b/docs/develop/yeoman-generator-overview.md
@@ -63,15 +63,15 @@ The first question asks you to choose between several types of projects. The opt
 
 The next question asks you to choose between **TypeScript** and **JavaScript**. (This question is skipped if you chose the manifest-only option in the preceding question.)
 
-![The yo office interface after the user chose "Office Add-in Task Pane project" to the preceding question and shows the prompt for language, and the possible answers, TypeScript and JavaScript, in the Yeoman generator.](../images/yo-office-language-prompt.png)
+![The Yo Office interface after the user chose "Office Add-in Task Pane project" to the preceding question. It shows the prompt for language, and the possible answers, TypeScript and JavaScript, in the Yeoman generator.](../images/yo-office-language-prompt.png)
 
 You're then prompted to give the add-in a name. The name you specify will be used in the add-in's manifest, but you can change it later. This is also the folder name for the project.
 
-![The yo office interface after the user chose TypeScript to the previous question and shows the prompt for the add-in name in the Yeoman generator.](../images/yo-office-name-prompt.png)
+![The Yo Office interface after the user chose TypeScript to the previous question. It shows the prompt for the add-in name in the Yeoman generator.](../images/yo-office-name-prompt.png)
 
 You're then prompted to choose which Office application the add-in should run in. There are six possible applications to choose from: **Excel**, **OneNote**, **Outlook**, **PowerPoint**, **Project**, and **Word**. You must choose just one, but you can change the manifest later to support the additional Office applications. The exception is Outlook. A manifest that supports Outlook cannot support any other Office application.
 
-![The yo office interface after the user named the project "Contoso Add-in" and shows the prompt for Office application, and the possible answers, in the Yeoman generator.](../images/yo-office-host-prompt.png)
+![The Yo Office interface after the user named the project "Contoso Add-in". It shows the prompt for Office application, and the possible answers, in the Yeoman generator.](../images/yo-office-host-prompt.png)
 
 After you've answered this question, the generator creates the project and installs the dependencies. You may see **WARN** messages in the npm output on screen. You can ignore these. You may also see messages that vulnerabilities were found. You can ignore these for now, but you'll eventually need to fix them before your add-in is released to production. For more information about fixing vulnerabilities, open your browser and search for "npm vulnerability".
 

--- a/docs/develop/yeoman-generator-overview.md
+++ b/docs/develop/yeoman-generator-overview.md
@@ -54,24 +54,24 @@ The first question asks you to choose between several types of projects. The opt
 - **Outlook Add-in with the unified manifest for Microsoft 365 (preview)**
 - **Office Add-in project containing the manifest only**
 
-![Screenshot showing the prompt for project type, and the possible answers, in the Yeoman generator.](../images/yo-office-project-type-prompt.png)
+![The prompt for project type, and the possible answers, in the Yeoman generator.](../images/yo-office-project-type-prompt.png)
 
 > [!NOTE]
-> 
-> -  The unified manifest is in preview and is supported only on Outlook on Windows. It isn't supported yet for a production add-in.
+>
+> - The unified manifest is in preview and is supported only on Outlook on Windows. It isn't supported yet for a production add-in.
 > - The **Office Add-in project containing the manifest only** option produces a project that contains a basic add-in manifest and minimal scaffolding. For more information about the option, see [Manifest-only option](#manifest-only-option).
 
 The next question asks you to choose between **TypeScript** and **JavaScript**. (This question is skipped if you chose the manifest-only option in the preceding question.)
 
-![Screenshot showing that the user chose "Office Add-in Task Pane project" to the preceding question and shows the prompt for language, and the possible answers, TypeScript and JavaScript, in the Yeoman generator.](../images/yo-office-language-prompt.png)
+![The yo office interface after the user chose "Office Add-in Task Pane project" to the preceding question and shows the prompt for language, and the possible answers, TypeScript and JavaScript, in the Yeoman generator.](../images/yo-office-language-prompt.png)
 
 You're then prompted to give the add-in a name. The name you specify will be used in the add-in's manifest, but you can change it later. This is also the folder name for the project.
 
-![Screenshot showing that the user chose TypeScript to the previous question and shows the prompt for the add-in name in the Yeoman generator.](../images/yo-office-name-prompt.png)
+![The yo office interface after the user chose TypeScript to the previous question and shows the prompt for the add-in name in the Yeoman generator.](../images/yo-office-name-prompt.png)
 
 You're then prompted to choose which Office application the add-in should run in. There are six possible applications to choose from: **Excel**, **OneNote**, **Outlook**, **PowerPoint**, **Project**, and **Word**. You must choose just one, but you can change the manifest later to support the additional Office applications. The exception is Outlook. A manifest that supports Outlook cannot support any other Office application.
 
-![Screenshot showing that the user named the project "Contoso Add-in" and shows the prompt for Office application, and the possible answers, in the Yeoman generator.](../images/yo-office-host-prompt.png)
+![The yo office interface after the user named the project "Contoso Add-in" and shows the prompt for Office application, and the possible answers, in the Yeoman generator.](../images/yo-office-host-prompt.png)
 
 After you've answered this question, the generator creates the project and installs the dependencies. You may see **WARN** messages in the npm output on screen. You can ignore these. You may also see messages that vulnerabilities were found. You can ignore these for now, but you'll eventually need to fix them before your add-in is released to production. For more information about fixing vulnerabilities, open your browser and search for "npm vulnerability".
 

--- a/docs/excel/excel-add-ins-worksheet-functions.md
+++ b/docs/excel/excel-add-ins-worksheet-functions.md
@@ -33,7 +33,7 @@ await Excel.run(async (context) => {
 
 The following image shows a table in an Excel worksheet that contains sales data for various types of tools over a three month period. Each number in the table represents the number of units sold for a specific tool in a specific month. The examples that follow will show how to apply built-in worksheet functions to this data.
 
-![Screenshot of sales data in Excel for Hammer, Wrench, and Saw in months November, December, and January.](../images/worksheet-functions-chaining-results.jpg)
+![Sales data in Excel for Hammer, Wrench, and Saw in months November, December, and January.](../images/worksheet-functions-chaining-results.jpg)
 
 ## Example 1: Single function
 

--- a/docs/excel/excel-data-types-entity-card.md
+++ b/docs/excel/excel-data-types-entity-card.md
@@ -16,7 +16,7 @@ An entity value, or [EntityCellValue](/javascript/api/excel/excel.entitycellvalu
 
 The following screenshot shows an example of an open entity value card, in this case for the **Chef Anton's Gumbo Mix** product from a list of grocery store products.
 
-:::image type="content" source="../images/excel-data-types-entity-card-gumbo.png" alt-text="A screenshot showing an entity value data type with the card window displayed.":::
+:::image type="content" source="../images/excel-data-types-entity-card-gumbo.png" alt-text="An entity value data type with the card window displayed.":::
 
 ## Card properties
 
@@ -69,7 +69,7 @@ const entity: Excel.EntityCellValue = {
 
 The following screenshot shows an entity value card that uses the preceding code snippet. The screenshot shows the **Product ID**, **Product Name**, **Image**, **Quantity Per Unit**, and **Unit Price** information from the preceding code snippet.
 
-:::image type="content" source="../images/excel-data-types-entity-card-properties-gumbo.png" alt-text="A screenshot showing an entity value data type with the card layout window displayed. The card shows the product name, product ID, quantity per unit, and unit price information.":::
+:::image type="content" source="../images/excel-data-types-entity-card-properties-gumbo.png" alt-text="An entity value data type with the card layout window displayed. The card shows the product name, product ID, quantity per unit, and unit price information.":::
 
 ### Property metadata
 
@@ -94,7 +94,7 @@ Entity properties have an optional `propertyMetadata` field that uses the [`Cell
 
 The following screenshot shows an entity value card that uses the preceding code snippet, displaying the property metadata `sublabel` of **USD** next to the **Unit Price** property.
 
-:::image type="content" source="../images/excel-data-types-entity-card-property-metadata.png" alt-text="A screenshot showing the sublabel USD next to the Unit Price.":::
+:::image type="content" source="../images/excel-data-types-entity-card-property-metadata.png" alt-text="The sublabel USD next to the Unit Price.":::
 
 ## Card layout
 
@@ -159,7 +159,7 @@ const entity: Excel.EntityCellValue = {
 
 The following screenshot shows an entity value card that uses the preceding code snippets. In the screenshot, the `shoppingBag` icon displays alongside the product names in the spreadsheet. In the entity card, the `mainImage` object displays at the top, followed by the `title` object which uses the **Product Name** and is set to **Chef Anton's Gumbo Mix**. The screenshot also shows `sections`. The **Quantity and price** section is collapsible and contains **Quantity Per Unit** and **Unit Price**. The **Additional information** field is collapsible and is collapsed when the card is opened.
 
-:::image type="content" source="../images/excel-data-types-entity-card-sections-gumbo.png" alt-text="A screenshot showing an entity value data type with the card layout window displayed. The card shows the card title and sections.":::
+:::image type="content" source="../images/excel-data-types-entity-card-sections-gumbo.png" alt-text="An entity value data type with the card layout window displayed. The card shows the card title and sections.":::
 
 > [!NOTE]
 > In the preceding screenshot, the `branch` icon displays alongside **Condiments** in the **Category** section. See the [Data types: Create entity cards from data in a table](https://github.com/OfficeDev/office-js-snippets/blob/prod/samples/excel/20-data-types/data-types-entity-values.yaml) sample to learn how to set nested icons like the **Category** section icon.
@@ -197,7 +197,7 @@ const entity: Excel.EntityCellValue = {
 
 The following screenshot shows an entity value card that uses the preceding code snippet. The screenshot shows the data provider attribution in the lower left corner. In this instance, the data provider is Microsoft and the Microsoft logo is displayed.
 
-:::image type="content" source="../images/excel-data-types-entity-card-attribution.png" alt-text="A screenshot showing an entity value data type with the card layout window displayed. The card shows the data provider attribution in the lower left corner.":::
+:::image type="content" source="../images/excel-data-types-entity-card-attribution.png" alt-text="An entity value data type with the card layout window displayed. The card shows the data provider attribution in the lower left corner.":::
 
 ## Next steps
 

--- a/docs/excel/excel-data-types-overview.md
+++ b/docs/excel/excel-data-types-overview.md
@@ -13,7 +13,7 @@ Data types organize complex data structures as objects. This includes formatted 
 
 The following screenshot highlights one of the primary features of data types: an entity card. In this case, the entity card shows expanded information about the **Tofu** product from a list of grocery store products.
 
-:::image type="content" source="../images/excel-data-types-entity-card-tofu.png" alt-text="A screenshot showing an entity value data type with the card window displayed.":::
+:::image type="content" source="../images/excel-data-types-entity-card-tofu.png" alt-text="An entity value data type with the card window displayed.":::
 
 > [!NOTE]
 > To start experimenting with data types right away, install [Script Lab](../overview/explore-with-script-lab.md) in Excel and check out the **Data types** section in our **Samples** library. You can also explore the Script Lab samples in our [OfficeDev/office-js-snippets](https://github.com/OfficeDev/office-js-snippets/tree/prod/samples/excel/20-data-types) repository.

--- a/docs/excludes/excel-quickstart-angular.md
+++ b/docs/excludes/excel-quickstart-angular.md
@@ -23,7 +23,7 @@ In this article, you'll walk through the process of building an Excel task pane 
 - **What do you want to name your add-in?** `My Office Add-in`
 - **Which Office client application would you like to support?** `Excel`
 
-![Screenshot of the Yeoman Office Add-in generator command line interface, with project type set to the Angular framework.](../images/yo-office-excel-angular-2.png)
+![The Yeoman Office Add-in generator command line interface, with project type set to the Angular framework.](../images/yo-office-excel-angular-2.png)
 
 After you complete the wizard, the generator creates the project and installs supporting Node components.
 
@@ -50,13 +50,13 @@ The add-in project that you've created with the Yeoman generator contains sample
 
 1. In Excel, choose the **Home** tab, and then choose the **Show Taskpane** button on the ribbon to open the add-in task pane.
 
-    ![Screenshot of the Excel Home menu, with the Show Taskpane button highlighted.](../images/excel-quickstart-addin-3b.png)
+    ![The Excel Home menu, with the Show Taskpane button highlighted.](../images/excel-quickstart-addin-3b.png)
 
 1. Select any range of cells in the worksheet.
 
 1. At the bottom of the task pane, choose the **Run** link to set the color of the selected range to yellow.
 
-    ![Screenshot of Excel, with the add-in task pane open, and the Run button highlighted in the add-in task pane.](../images/excel-quickstart-addin-3c.png)
+    ![Excel with the add-in task pane open, and the Run button highlighted in the add-in task pane.](../images/excel-quickstart-addin-3c.png)
 
 ## Next steps
 

--- a/docs/includes/mac-cache-folders.md
+++ b/docs/includes/mac-cache-folders.md
@@ -8,7 +8,7 @@ You can clear the cache by using the personality menu of any task pane add-in. H
     > [!NOTE]
     > You must run macOS Version 10.13.6 or later to see the personality menu.
 
-    ![Screenshot of clear web cache option on personality menu.](../images/mac-clear-cache-menu.png)
+    ![The clear web cache option on personality menu.](../images/mac-clear-cache-menu.png)
 
 ### Clear the cache manually
 

--- a/docs/powerpoint/insert-slides-into-presentation.md
+++ b/docs/powerpoint/insert-slides-into-presentation.md
@@ -33,7 +33,7 @@ There are many ways to convert a file to base64. Which programming language and 
 
     This markup adds the UI in the following screenshot to the page.
 
-    ![Screenshot showing an HTML file type input control preceded by an instructional sentence reading "Select a PowerPoint presentation from which to insert slides". The control consists of a button labelled "Choose file" followed by the sentence "No file chosen".](../images/powerpoint-html-file-input-control.png)
+    ![An HTML file type input control preceded by an instructional sentence reading "Select a PowerPoint presentation from which to insert slides". The control consists of a button labelled "Choose file" followed by the sentence "No file chosen".](../images/powerpoint-html-file-input-control.png)
 
     > [!NOTE]
     > There are many other ways to get a PowerPoint file. For example, if the file is stored on OneDrive or SharePoint, you can use Microsoft Graph to download it. For more information, see [Working with files in Microsoft Graph](/graph/api/resources/onedrive) and [Access Files with Microsoft Graph](/training/modules/msgraph-access-file-data/).

--- a/docs/quickstarts/excel-custom-functions-quickstart.md
+++ b/docs/quickstarts/excel-custom-functions-quickstart.md
@@ -24,7 +24,7 @@ To start, you'll use the Yeoman generator to create the custom functions project
     - **Choose a script type:** `JavaScript`
     - **What do you want to name your add-in?** `My custom functions add-in`
 
-    :::image type="content" source="../images/yo-office-excel-cf-quickstart.png" alt-text="Screenshot of the Yeoman Office Add-in generator command line interface prompts for custom functions projects.":::
+    :::image type="content" source="../images/yo-office-excel-cf-quickstart.png" alt-text="The Yeoman Office Add-in generator command line interface prompts for custom functions projects.":::
 
     The Yeoman generator will create the project files and install supporting Node components.
 

--- a/docs/quickstarts/excel-quickstart-react.md
+++ b/docs/quickstarts/excel-quickstart-react.md
@@ -23,7 +23,7 @@ In this article, you'll walk through the process of building an Excel task pane 
 - **What do you want to name your add-in?** `My Office Add-in`
 - **Which Office client application would you like to support?** `Excel`
 
-![Screenshot of the Yeoman Office Add-in generator command line interface, with project type set to the React framework.](../images/yo-office-excel-react-2.png)
+![The Yeoman Office Add-in generator command line interface, with project type set to the React framework.](../images/yo-office-excel-react-2.png)
 
 After you complete the wizard, the generator creates the project and installs supporting Node components.
 
@@ -52,13 +52,13 @@ The add-in project that you've created with the Yeoman generator contains sample
 
 1. In Excel, choose the **Home** tab, and then choose the **Show Taskpane** button on the ribbon to open the add-in task pane.
 
-    ![Screenshot of the Excel Home menu, with the Show Taskpane button highlighted.](../images/excel-quickstart-addin-3b.png)
+    ![The Excel Home menu, with the Show Taskpane button highlighted.](../images/excel-quickstart-addin-3b.png)
 
 1. Select any range of cells in the worksheet.
 
 1. At the bottom of the task pane, choose the **Run** link to set the color of the selected range to yellow.
 
-    ![Screenshot of Excel, with the add-in task pane open, and the Run button highlighted in the add-in task pane.](../images/excel-quickstart-addin-3c.png)
+    ![Excel with the add-in task pane open, and the Run button highlighted in the add-in task pane.](../images/excel-quickstart-addin-3c.png)
 
 ## Next steps
 

--- a/docs/quickstarts/outlook-quickstart-json-manifest.md
+++ b/docs/quickstarts/outlook-quickstart-json-manifest.md
@@ -42,7 +42,7 @@ You can create an Office Add-in with the unified manifest by using the [Yeoman g
 
     - **What do you want to name your add-in?** - `Add-in with Unified Manifest`
 
-     ![Screenshot showing the prompts and answers for the Yeoman generator in a command line interface with unified manifest option chosen.](../images/yo-office-outlook-json-manifest.png)
+     ![The prompts and answers for the Yeoman generator in a command line interface with unified manifest option chosen.](../images/yo-office-outlook-json-manifest.png)
 
     > [!NOTE]
     > For this preview, the add-in name cannot be more than 30 characters.

--- a/docs/quickstarts/powerpoint-quickstart.md
+++ b/docs/quickstarts/powerpoint-quickstart.md
@@ -29,7 +29,7 @@ In this article, you'll walk through the process of building a PowerPoint task p
 - **What do you want to name your add-in?** `My Office Add-in`
 - **Which Office client application would you like to support?** `PowerPoint`
 
-![Screenshot showing the prompts and answers for the Yeoman generator in a command line interface.](../images/yo-office-powerpoint.png)
+![The prompts and answers for the Yeoman generator in a command line interface.](../images/yo-office-powerpoint.png)
 
 After you complete the wizard, the generator creates the project and installs supporting Node components.
 
@@ -72,11 +72,11 @@ After you complete the wizard, the generator creates the project and installs su
 
 3. In PowerPoint, insert a new blank slide, choose the **Home** tab, and then choose the **Show Taskpane** button on the ribbon to open the add-in task pane.
 
-    ![Screenshot of PowerPoint with the Show Taskpane button highlighted.](../images/powerpoint_quickstart_addin_1c.png)
+    ![PowerPoint with the Show Taskpane button highlighted.](../images/powerpoint_quickstart_addin_1c.png)
 
 4. At the bottom of the task pane, choose the **Run** link to insert the text "Hello World" into the current slide.
 
-    ![Screenshot of PowerPoint with an image of a dog and the text 'Hello World` displayed on the slide.](../images/powerpoint_quickstart_addin_3c.png)
+    ![PowerPoint with an image of a dog and the text 'Hello World` displayed on the slide.](../images/powerpoint_quickstart_addin_3c.png)
 
 ### Next steps
 
@@ -231,15 +231,15 @@ Congratulations, you've successfully created a PowerPoint task pane add-in! Next
 
 2. In PowerPoint, insert a new blank slide, choose the **Home** tab, and then choose the **Show Taskpane** button on the ribbon to open the add-in task pane.
 
-    ![Screenshot of PowerPoint with the Show Taskpane ribbon button highlighted.](../images/powerpoint_quickstart_addin_1.png)
+    ![PowerPoint with the Show Taskpane ribbon button highlighted.](../images/powerpoint_quickstart_addin_1.png)
 
 3. In the task pane, choose the **Insert Image** button to add an image to the selected slide.
 
-    ![Screenshot of PowerPoint with an image of a dog displayed on the slide.](../images/powerpoint_quickstart_addin_2.png)
+    ![PowerPoint with an image of a dog displayed on the slide.](../images/powerpoint_quickstart_addin_2.png)
 
 4. In the task pane, choose the **Insert Text** button to add text to the selected slide.
 
-    ![Screenshot of PowerPoint with an image of a dog and the text 'Hello World` on the slide.](../images/powerpoint_quickstart_addin_3.png)
+    ![PowerPoint with an image of a dog and the text 'Hello World` on the slide.](../images/powerpoint_quickstart_addin_3.png)
 
 [!include[Console tool note](../includes/console-tool-note.md)]
 

--- a/docs/quickstarts/sso-quickstart.md
+++ b/docs/quickstarts/sso-quickstart.md
@@ -105,14 +105,14 @@ Complete the following steps to test an Excel, Word, or PowerPoint add-in.
 
 5. If a dialog window appears to request permissions on behalf of the add-in, this means that SSO is not supported for your scenario and the add-in has instead fallen back to an alternate method of user authentication. This may occur when the tenant administrator hasn't granted consent for the add-in to access Microsoft Graph, or when the user isn't signed in to Office with a valid Microsoft account or Microsoft 365 Education or Work account. Choose **Accept** to continue.
 
-    ![Screenshot showing permissions requested dialog with Accept button highlighted.](../images/sso-permissions-request.png)
+    ![The permissions requested dialog with Accept button highlighted.](../images/sso-permissions-request.png)
 
     > [!NOTE]
     > After a user accepts this permissions request, they won't be prompted again in the future.
 
 6. The add-in retrieves profile information for the signed-in user and writes it to the document. The following image shows an example of profile information written to an Excel worksheet.
 
-    ![Screenshot showing user profile information in Excel worksheet.](../images/sso-user-profile-info-excel.png)
+    ![The user profile information in Excel worksheet.](../images/sso-user-profile-info-excel.png)
 
 ### Outlook
 
@@ -132,20 +132,20 @@ Complete the following steps to try out an Outlook add-in.
 
 4. In the message compose window, choose the **Show Taskpane** button to open the add-in task pane.
 
-    ![Screenshot showing highlighted add-in ribbon button in Outlook compose message window.](../images/outlook-sso-ribbon-button.png)
+    ![The highlighted add-in ribbon button in Outlook compose message window.](../images/outlook-sso-ribbon-button.png)
 
 5. At the bottom of the task pane, choose the **Get My User Profile Information** button to initiate the SSO process.
 
 6. If a dialog window appears to request permissions on behalf of the add-in, this means that SSO is not supported for your scenario and the add-in has instead fallen back to an alternate method of user authentication. This may occur when the tenant administrator hasn't granted consent for the add-in to access Microsoft Graph, or when the user isn't signed in to Office with a valid Microsoft account or Microsoft 365 Education or Work account. Choose **Accept** to continue.
 
-    ![Screenshot of permissions requested dialog with Accept button highlighted.](../images/sso-permissions-request.png)
+    ![The permissions requested dialog with Accept button highlighted.](../images/sso-permissions-request.png)
 
     > [!NOTE]
     > After a user accepts this permissions request, they won't be prompted again in the future.
 
 7. The add-in retrieves profile information for the signed-in user and writes it to the body of the email message.
 
-    ![Screenshot showing user profile information in Outlook compose message window.](../images/sso-user-profile-info-outlook.png)
+    ![The user profile information in Outlook compose message window.](../images/sso-user-profile-info-outlook.png)
 
 ## Next steps
 

--- a/docs/testing/attach-debugger-from-task-pane.md
+++ b/docs/testing/attach-debugger-from-task-pane.md
@@ -19,7 +19,7 @@ The technique described in this article can be used only when the following cond
 
 To launch the debugger, choose the top right corner of the task pane to activate the **Personality** menu (as shown in the red circle in the following image).
 
-![Screenshot of Attach Debugger menu.](../images/attach-debugger.png)
+![The Attach Debugger menu in the add-in task pane.](../images/attach-debugger.png)
 
 Select **Attach Debugger**. This launches the Microsoft Edge (Chromium-based) developer tools. Use the tools as described in [Debug add-ins using developer tools in Microsoft Edge (Chromium-based)](debug-add-ins-using-devtools-edge-chromium.md).
 

--- a/docs/testing/clear-cache.md
+++ b/docs/testing/clear-cache.md
@@ -80,11 +80,11 @@ To clear the Office cache on Windows 10 when the add-in is running in Microsoft 
 
 6. On the **Network** tab of the new window, select **Clear cache**.
 
-    ![Microsoft Edge DevTools screenshot with the Clear cache button highlighted.](../images/edge-devtools-clear-cache.png)
+    ![Microsoft Edge DevTools with the Clear cache button highlighted.](../images/edge-devtools-clear-cache.png)
 
 7. If completing these steps doesn't produce the desired result, try selecting **Always refresh from server**.
 
-    ![Microsoft Edge DevTools screenshot with the Always refresh from server button highlighted.](../images/edge-devtools-refresh-from-server.png)
+    ![Microsoft Edge DevTools with the Always refresh from server button highlighted.](../images/edge-devtools-refresh-from-server.png)
 
 ## Clear the Office cache on Mac
 

--- a/docs/testing/debug-add-ins-using-devtools-edge-chromium.md
+++ b/docs/testing/debug-add-ins-using-devtools-edge-chromium.md
@@ -46,7 +46,7 @@ To determine which webview you're using, see [Browsers and webview controls used
    1. Select the refresh button.
    1. In the search results, select the line to open the code file in the pane above the search results.
 
-   :::image type="content" source="../images/open-file-in-edge-chromium-devtools.png" alt-text="Screenshot of Edge Chromium developer tools source tab with 4 parts labelled A through D.":::
+   :::image type="content" source="../images/open-file-in-edge-chromium-devtools.png" alt-text="Edge Chromium developer tools source tab with 4 parts labelled A through D.":::
 
 1. To set a breakpoint, select the line number of the line in the code file. A red dot appears by the line in the code file. In the debugger window to the right, the breakpoint is registered in the **Breakpoints** drop down.
 1. Execute functions in the add-in as needed to trigger the breakpoint.

--- a/docs/testing/debug-add-ins-using-f12-tools-ie.md
+++ b/docs/testing/debug-add-ins-using-f12-tools-ie.md
@@ -43,7 +43,7 @@ The following steps are the instructions for debugging your add-in. If you just 
 1. Open the **Debugger** tab.
 1. In the upper left of the tab, just below the debugger tool ribbon, there is a small folder icon. Select this to open a drop down list of the files in the add-in. The following is an example.
 
-    :::image type="content" source="../images/f12-file-dropdown.png" alt-text="Screenshot of upper left corner of debugger tab with a folder drop down open and a list of files.":::
+    :::image type="content" source="../images/f12-file-dropdown.png" alt-text="The upper left corner of debugger tab with a folder drop down open and a list of files.":::
 
 1. Select the file that you want to debug and it opens in the the **script** (left) pane of the **Debugger** tab. If you're using a transpiler, bundler, or minifier, that changes the name of the file, it will have the final name that is actually loaded, not the original source file name.
 

--- a/docs/testing/runtime-logging.md
+++ b/docs/testing/runtime-logging.md
@@ -71,7 +71,7 @@ Enabling runtime logging from the command line is the fastest way to use this lo
 
 The following image shows what the registry should look like. To turn the feature off, remove the `RuntimeLogging` key from the registry.
 
-![Screenshot of the registry editor with a RuntimeLogging registry key.](../images/runtime-logging-registry.png)
+![The registry editor with a RuntimeLogging registry key.](../images/runtime-logging-registry.png)
 
 ## Runtime logging on Mac
 

--- a/docs/testing/testing-and-troubleshooting.md
+++ b/docs/testing/testing-and-troubleshooting.md
@@ -59,7 +59,7 @@ When using an Office Add-in, the user is asked to allow a dialog box to be displ
 
 "The security settings in your browser prevent us from creating a dialog box. Try a different browser, or configure your browser so that [URL] and the domain shown in your address bar are in the same security zone."
 
-![Screenshot of the dialog box error message.](../images/dialog-prevented.png)
+![The dialog box error message showing the previously stated text.](../images/dialog-prevented.png)
 
 |Affected browsers|Affected platforms|
 |:--------------------|:---------------------|

--- a/docs/tutorials/excel-tutorial-create-custom-functions.md
+++ b/docs/tutorials/excel-tutorial-create-custom-functions.md
@@ -40,7 +40,7 @@ In this tutorial, you will:
     - **Choose a script type:** `JavaScript`
     - **What do you want to name your add-in?** `My custom functions add-in`
 
-    :::image type="content" source="../images/yo-office-excel-cf-quickstart.png" alt-text="Screenshot of the Yeoman Office Add-in generator command line interface prompts for custom functions projects.":::
+    :::image type="content" source="../images/yo-office-excel-cf-quickstart.png" alt-text="The Yeoman Office Add-in generator command line interface prompts for custom functions projects.":::
 
     The Yeoman generator will create the project files and install supporting Node components.
 

--- a/docs/tutorials/excel-tutorial.md
+++ b/docs/tutorials/excel-tutorial.md
@@ -43,7 +43,7 @@ In this tutorial, you'll create an Excel task pane add-in that:
 - **What do you want to name your add-in?** `My Office Add-in`
 - **Which Office client application would you like to support?** `Excel`
 
-![Screenshot of the Yeoman Office Add-in generator command line interface.](../images/yo-office-excel.png)
+![The Yeoman Office Add-in generator command line interface.](../images/yo-office-excel.png)
 
 After you complete the wizard, the generator creates the project and installs supporting Node components. You may need to manually run `npm install` in the root folder of your project if something fails during the initial setup.
 
@@ -202,11 +202,11 @@ In this step of the tutorial, you'll programmatically test that your add-in supp
 
 1. In Excel, choose the **Home** tab, and then choose the **Show Taskpane** button on the ribbon to open the add-in task pane.
 
-    ![Screenshot of the Excel Home menu, with the Show Taskpane button highlighted.](../images/excel-quickstart-addin-3b.png)
+    ![The Excel Home menu, with the Show Taskpane button highlighted.](../images/excel-quickstart-addin-3b.png)
 
 1. In the task pane, choose the **Create Table** button.
 
-    ![Screenshot of Excel, displaying an add-in task pane with a Create Table button, and a table in the worksheet populated with Date, Merchant, Category, and Amount data.](../images/excel-tutorial-create-table-2.png)
+    ![Excel displaying an add-in task pane with a Create Table button, and a table in the worksheet populated with Date, Merchant, Category, and Amount data.](../images/excel-tutorial-create-table-2.png)
 
 ## Filter and sort a table
 
@@ -321,7 +321,7 @@ In this step of the tutorial, you'll filter and sort the table that you created 
 
 1. Choose the **Filter Table** button and the **Sort Table** button, in either order.
 
-    ![Screenshot of Excel, with Filter Table and Sort Table buttons visible in the add-in task pane.](../images/excel-tutorial-filter-and-sort-table-2.png)
+    ![Excel with Filter Table and Sort Table buttons visible in the add-in task pane.](../images/excel-tutorial-filter-and-sort-table-2.png)
 
 ## Create a chart
 
@@ -410,7 +410,7 @@ In this step of the tutorial, you'll create a chart using data from the table th
 
 1. Choose the **Create Chart** button. A chart is created and only the data from the rows that have been filtered are included. The labels on the data points across the bottom are in the sort order of the chart; that is, merchant names in reverse alphabetical order.
 
-    ![Screenshot of Excel, with a Create Chart button visible in the add-in task pane, and a chart in the worksheet displaying grocery and education expense data.](../images/excel-tutorial-create-chart-2.png)
+    ![Excel with a Create Chart button visible in the add-in task pane, and a chart in the worksheet displaying grocery and education expense data.](../images/excel-tutorial-create-chart-2.png)
 
 ## Freeze a table header
 
@@ -474,7 +474,7 @@ When a table is long enough that a user must scroll to see some rows, the header
 
 1. Scroll down the worksheet far enough to see that the table header remains visible at the top even when the higher rows scroll out of sight.
 
-    ![Screenshot displaying an Excel worksheet with a frozen table header.](../images/excel-tutorial-freeze-header-2.png)
+    ![An Excel worksheet with a frozen table header.](../images/excel-tutorial-freeze-header-2.png)
 
 ## Protect a worksheet
 
@@ -700,7 +700,7 @@ These steps must be completed whenever your code needs to *read* information fro
 
 1. On the **Home** tab in Excel, choose the **Toggle Worksheet Protection** button. Note that most of the controls on the ribbon are disabled (and visually grayed-out) as seen in the following screenshot.
 
-    ![Screenshot of the Excel ribbon with the Toggle Worksheet Protection button highlighted and enabled. Most other buttons appear gray and disabled.](../images/excel-tutorial-ribbon-with-protection-on-2.png)
+    ![The Excel ribbon with the Toggle Worksheet Protection button highlighted and enabled. Most other buttons appear gray and disabled.](../images/excel-tutorial-ribbon-with-protection-on-2.png)
 
 1. Select a cell and try to edit its content. Excel displays an error message indicating that the worksheet is protected.
 
@@ -958,7 +958,7 @@ Open the file **webpack.config.js** in the root directory of the project and com
 
 1. Optionally, in the **./src/taskpane/taskpane.js** file, comment out the line `dialog.close();` in the `processMessage` function. Then repeat the steps of this section. The dialog stays open and you can change the name. You can close it manually by pressing the **X** button in the upper right corner.
 
-    ![Screenshot of Excel, with an Open Dialog button visible in the add-in task pane and a dialog box displayed over the worksheet.](../images/excel-tutorial-dialog-open-2.png)
+    ![Excel with an Open Dialog button visible in the add-in task pane and a dialog box displayed over the worksheet.](../images/excel-tutorial-dialog-open-2.png)
 
 ## Next steps
 

--- a/docs/tutorials/migrate-vsto-to-office-add-in-shared-code-library-tutorial.md
+++ b/docs/tutorials/migrate-vsto-to-office-add-in-shared-code-library-tutorial.md
@@ -63,7 +63,7 @@ This tutorial uses the [VSTO Add-in shared library for Office Add-in](https://gi
 
 The add-in is a custom task pane for Excel. You can select any cell with text, and then choose the **Show unicode** button. In the **Result** section, the add-in will display a list of each character in the text along with its corresponding Unicode number.
 
-![Screenshot of the Cell Analyzer VSTO add-in running in Excel with the "Show unicode" button and empty Result section.](../images/pnp-cell-analyzer-vsto-add-in.png)
+![The Cell Analyzer VSTO add-in running in Excel with the "Show unicode" button and empty Result section.](../images/pnp-cell-analyzer-vsto-add-in.png)
 
 ## Analyze types of code in the VSTO Add-in
 

--- a/docs/tutorials/word-tutorial.md
+++ b/docs/tutorials/word-tutorial.md
@@ -42,7 +42,7 @@ In this tutorial, you'll create a Word task pane add-in that:
 - **What do you want to name your add-in?** `My Office Add-in`
 - **Which Office client application would you like to support?** `Word`
 
-![Screenshot showing the prompts and answers for the Yeoman generator in a command line interface.](../images/yo-office-word.png)
+![The previous prompts and answers given to the Yeoman generator in a command line interface.](../images/yo-office-word.png)
 
 After you complete the wizard, the generator creates the project and installs supporting Node components.
 
@@ -154,7 +154,7 @@ In this step of the tutorial, you'll programmatically test that your add-in supp
 
 1. In Word, if the "My Office Add-in" task pane isn't already open, choose the **Home** tab, and then choose the **Show Taskpane** button on the ribbon to open the add-in task pane.
 
-    ![Screenshot displaying the Show Taskpane button highlighted in Word.](../images/word-quickstart-addin-2b.png)
+    ![The Show Taskpane button highlighted in Word.](../images/word-quickstart-addin-2b.png)
 
 1. In the task pane, choose the **Insert Paragraph** button.
 
@@ -162,7 +162,7 @@ In this step of the tutorial, you'll programmatically test that your add-in supp
 
 1. Choose the **Insert Paragraph** button again. Note that the new paragraph appears above the previous one because the `insertParagraph` method is inserting at the start of the document's body.
 
-    ![Screenshot showing the Insert Paragraph button in the add-in.](../images/word-tutorial-insert-paragraph-2.png)
+    ![The Insert Paragraph button in the add-in.](../images/word-tutorial-insert-paragraph-2.png)
 
 ## Format text
 
@@ -306,7 +306,7 @@ In this step of the tutorial, you'll apply a built-in style to text, apply a cus
 
 1. Choose the **Change Font** button. The font of the second paragraph changes to 18 pt., bold, Courier New.
 
-    ![Screenshot showing the results of applying the styles and fonts defined for the add-in buttons Apply Style, Apply Custom Style, and Change font.](../images/word-tutorial-apply-styles-and-font-2.png)
+    ![The results of applying the styles and fonts defined for the add-in buttons Apply Style, Apply Custom Style, and Change font.](../images/word-tutorial-apply-styles-and-font-2.png)
 
 ## Replace text and insert text
 
@@ -546,7 +546,7 @@ async function insertTextIntoRange() {
 
 1. Choose the **Change Quantity Term** button. Note that "many" replaces the selected text.
 
-    ![Screenshot showing the results of choosing the add-in buttons Insert Abbreviation, Add Version Info, and Change Quantity Term.](../images/word-tutorial-text-replace-2.png)
+    ![The results of choosing the add-in buttons Insert Abbreviation, Add Version Info, and Change Quantity Term.](../images/word-tutorial-text-replace-2.png)
 
 ## Insert images, HTML, and tables
 
@@ -725,7 +725,7 @@ Complete the following steps to define the image that you'll insert into the doc
 
 1. Choose the **Insert Table** button and note that a table is inserted after the second paragraph.
 
-    ![Screenshot showing the results of choosing the add-in buttons Insert Image, Insert HTML, and Insert Table.](../images/word-tutorial-insert-image-html-table-2.png)
+    ![The results of choosing the add-in buttons Insert Image, Insert HTML, and Insert Table.](../images/word-tutorial-insert-image-html-table-2.png)
 
 ## Create and update content controls
 
@@ -841,7 +841,7 @@ In this step of the tutorial, you'll learn how to create Rich Text content contr
 
 1. Choose the **Rename Service** button and note that the text of the content control changes to "Fabrikam Online Productivity Suite".
 
-    ![Screenshot showing the results of choosing the add-in buttons Create Content Control and Rename Service.](../images/word-tutorial-content-control-2.png)
+    ![The results of choosing the add-in buttons Create Content Control and Rename Service.](../images/word-tutorial-content-control-2.png)
 
 ## Next steps
 


### PR DESCRIPTION
Based on @samantharamon's feedback in https://github.com/OfficeDev/office-js-docs-pr/pull/4400, current guidance is to refrain from stating an image is a screenshot in the alt text. This PR addresses that.