### PR TITLE
[Outlook] (IRM) Update guidance

### DIFF
--- a/docs/includes/outlook-irm-add-in-activation.md
+++ b/docs/includes/outlook-irm-add-in-activation.md
@@ -1,4 +1,0 @@
-  > [!IMPORTANT]
-  >
-  > - Add-ins now activate on IRM-protected items in Outlook on Windows (starting in Version 2009 (Build 13229.10000)), on Mac (starting in Version 16.77.827.0), and on the web. To turn on this capability, a tenant administrator must enable the `OBJMODEL` usage right by setting the **Allow programmatic access** custom policy option in Office. For further guidance, see [Usage rights and descriptions](/azure/information-protection/configure-usage-rights).
-  > - Starting in Outlook on Windows Version 1711 (Build 8711.1000) associated with a Microsoft 365 subscription, add-ins activate on digitally-signed messages.

--- a/docs/outlook/outlook-add-ins-overview.md
+++ b/docs/outlook/outlook-add-ins-overview.md
@@ -1,7 +1,7 @@
 ---
 title: Outlook add-ins overview
 description: Outlook add-ins extend or customize the Outlook UI and are developed by Microsoft and partners using our web-based platform.
-ms.date: 01/16/2024
+ms.date: 02/20/2024
 ms.topic: overview
 ms.custom: scenarios:getting-started
 ms.localizationpriority: high
@@ -41,9 +41,9 @@ Extension points are the ways that add-ins integrate with Outlook. The following
 
 Outlook add-ins activate when the user is composing or reading a message or appointment, but not other item types. However, add-ins are *not* activated if the current message item, in a compose or read form, is one of the following:
 
-- Protected by Information Rights Management (IRM) or encrypted in other ways for protection and accessed from Outlook on mobile devices. A digitally-signed message is an example since digital signing relies on one of these mechanisms.
+- Protected by Information Rights Management (IRM) or encrypted in other ways for protection and accessed from Outlook on mobile devices. A digitally-signed message is an example since digital signing relies on one of these mechanisms. To learn more about IRM support in Outlook add-ins, see [Mail items protected by IRM](#mail-items-protected-by-irm).
 
-[!INCLUDE [outlook-irm-add-in-activation](../includes/outlook-irm-add-in-activation.md)]
+- An IRM-protected mail item with a sensitivity label that has the **Allow programmatic access** custom policy option set to `false`. To learn more about IRM support in Outlook add-ins, see [Mail items protected by IRM](#mail-items-protected-by-irm).
 
 - A delivery report or notification that has the message class IPM.Report.*, including delivery and Non-Delivery Report (NDR) reports, and read, non-read, and delay notifications.
 
@@ -63,6 +63,24 @@ Outlook add-ins activate when the user is composing or reading a message or appo
 In general, Outlook can activate add-ins in read form for items in the Sent Items folder, with the exception of add-ins that activate based on string matches of well-known entities. For more information about the reasons behind this, see [Support for well-known entities](match-strings-in-an-item-as-well-known-entities.md#support-for-well-known-entities).
 
 Currently, there are additional considerations when designing and implementing add-ins for mobile clients. To learn more, see [Add support for add-in commands in Outlook on mobile devices](add-mobile-support.md).
+
+### Mail items protected by IRM
+
+Outlook add-ins activate on IRM-protected mail items when the item is accessed from the following supported clients.
+
+- Outlook on Windows starting in Version 2009 (Build 13229.10000)
+
+    >[!NOTE]
+    > Digital signing relies on protection mechanisms, such as IRM. Starting in Outlook on Windows Version 1711 (Build 8711.1000) associated with a Microsoft 365 subscription, add-ins activate on digitally-signed messages.
+
+- Outlook on Mac starting in Version 16.77.827.0
+- Outlook on the web
+- [new Outlook on Windows (preview)](https://support.microsoft.com/office/656bb8d9-5a60-49b2-a98b-ba7822bc7627)
+
+However, add-ins won't activate on IRM-protected items when:
+
+- The IRM-protected item is accessed from Outlook on mobile devices.
+- The IRM-protected item has a sensitivity label with the **Allow programmatic access** custom policy option set to `false`. For more information on custom policy options, see [Usage rights and descriptions](/azure/information-protection/configure-usage-rights).
 
 ## Supported clients
 

--- a/docs/outlook/privacy-and-security.md
+++ b/docs/outlook/privacy-and-security.md
@@ -1,7 +1,7 @@
 ---
 title: Privacy, permissions, and security for Outlook add-ins
 description: Learn how to manage privacy, permissions, and security in an Outlook add-in.
-ms.date: 01/16/2024
+ms.date: 02/20/2024
 ms.localizationpriority: high
 ---
 
@@ -66,9 +66,13 @@ For general add-in behavior, see [Privacy and security for Office Add-ins](../co
 
 The security model addresses security, privacy, and performance concerns of end users in the following ways.
 
-- End user's messages that are protected by Outlook's Information Rights Management (IRM) don't interact with add-ins in Outlook on mobile devices.
+- End user's messages that are protected by Outlook's Information Rights Management (IRM) won't interact with add-ins in the following instances.
 
-[!INCLUDE [outlook-irm-add-in-activation](../includes/outlook-irm-add-in-activation.md)]
+  - When the IRM-protected message is accessed from Outlook on mobile devices.
+
+  - When the IRM-protected message contains a sensitivity label with the **Allow programmatic access** custom policy option set to `false`.
+
+  For more information on IRM support in add-ins, see [Mail items protected by IRM](outlook-add-ins-overview.md#mail-items-protected-by-irm).
 
 - Before installing an add-in from AppSource, end users can see the access and actions that the add-in can make on their data and must explicitly confirm to proceed. No Outlook add-in is automatically pushed onto a client computer without manual validation by the user or administrator.
 

--- a/docs/outlook/troubleshoot-outlook-add-in-activation.md
+++ b/docs/outlook/troubleshoot-outlook-add-in-activation.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshoot Outlook contextual add-in activation
 description: Possible reasons your contextual Outlook add-in doesn't activate as you expect.
-ms.date: 01/16/2024
+ms.date: 02/20/2024
 ms.topic: troubleshooting
 ms.localizationpriority: medium
 ---
@@ -69,10 +69,6 @@ If your Outlook add-in is a read add-in and is supposed to be activated when the
 Also, because appointments are always saved in Rich Text Format, an [ItemHasRegularExpressionMatch](/javascript/api/manifest/rule#itemhasregularexpressionmatch-rule) rule that specifies a **PropertyName** value of **BodyAsHTML** wouldn't activate an add-in on an appointment or message that's saved in plain text or Rich Text Format.
 
 Even if a mail item is not one of the above types, if the item wasn't delivered by a version of Exchange Server that's at least Exchange 2013, known entities and properties, such as sender's SMTP address, wouldn't be identified on the item. Any activation rules that rely on these entities or properties wouldn't be satisfied, and the add-in wouldn't be activated.
-
-In Outlook on mobile devices, if your add-in activates when the user is composing a message or meeting request, make sure the item isn't protected by Outlook's Information Rights Management (IRM).
-
-[!INCLUDE [outlook-irm-add-in-activation](../includes/outlook-irm-add-in-activation.md)]
 
 ## Is the add-in manifest installed properly, and does Outlook have a cached copy?
 


### PR DESCRIPTION
- Clarifies when Outlook add-ins activate on mail items protected by Information Rights Management (IRM).
- Moves guidance to its own section.
- Removes redundant information from "Troubleshoot Outlook contextual add-in activation" already covered by the link to the "Outlook add-ins overview" page.