### PR TITLE
[project] Remove specific references to Project 2013

### DIFF
--- a/docs/project/create-a-project-add-in-that-uses-rest-with-an-on-premises-odata-service.md
+++ b/docs/project/create-a-project-add-in-that-uses-rest-with-an-on-premises-odata-service.md
@@ -1,28 +1,28 @@
 ---
 title: Create a Project add-in that uses REST with an on-premises Project Server OData service
-description: Learn how to build a task pane add-in for Project Professional 2013 that compares cost and work data in the active project with the averages for all projects in the current Project Web App instance.
-ms.date: 07/08/2021
+description: Learn how to build a task pane add-in for Project Professional that compares cost and work data in the active project with the averages for all projects in the current Project Web App instance.
+ms.date: 02/21/2024
 ms.localizationpriority: medium
 ---
 
 # Create a Project add-in that uses REST with an on-premises Project Server OData service
 
-This article describes how to build a task pane add-in for Project Professional 2013 that compares cost and work data in the active project with the averages for all projects in the current Project Web App instance. The add-in uses REST with the jQuery library to access the **ProjectData** OData reporting service in Project Server 2013.
+This article describes how to build a task pane add-in for Project Professional that compares cost and work data in the active project with the averages for all projects in the current Project Web App instance. The add-in uses REST with the jQuery library to access the **ProjectData** OData reporting service in Project Server.
 
 The code in this article is based on a sample developed by Saurabh Sanghvi and Arvind Iyer, Microsoft Corporation.
 
 ## Prerequisites
 
-The following are the prerequisites for creating a Project task pane add-in that reads the **ProjectData** service of a Project Web App instance in an on-premises installation of Project Server 2013.
+The following are the prerequisites for creating a Project task pane add-in that reads the **ProjectData** service of a Project Web App instance in an on-premises installation of Project Server.
 
-- Project Professional 2013 is required to connect with Project Web App. The development computer must have Project Professional 2013 installed to enable **F5** debugging with Visual Studio.
+- Project Professional is required to connect with Project Web App. The development computer must have Project Professional installed to enable **F5** debugging with Visual Studio.
 
     > [!NOTE]
-    > Project Standard 2013 can also host task pane add-ins, but cannot sign in to Project Web App.
+    > Project Standard can also host task pane add-ins, but cannot sign in to Project Web App.
 
 - Visual Studio 2015 with Office Developer Tools for Visual Studio includes templates for creating Office and SharePoint Add-ins. Ensure that you have installed the most recent version of Office Developer Tools; see the  *Tools* section of the [Office Add-ins and SharePoint downloads](https://developer.microsoft.com/office/docs).
 
-- The procedures and code examples in this article access the **ProjectData** service of Project Server 2013 in a local domain. The jQuery methods in this article do not work with Project on the web.
+- The procedures and code examples in this article access the **ProjectData** service of Project Server in a local domain. The jQuery methods in this article do not work with Project on the web.
 
     Verify that the **ProjectData** service is accessible from your development computer.
 
@@ -54,7 +54,7 @@ The following are the prerequisites for creating a Project task pane add-in that
 
 ## Use Visual Studio to create a task pane add-in for Project
 
-Office Developer Tools for Visual Studio includes a template for task pane add-ins for Project 2013. If you create a solution named **HelloProjectOData**, the solution contains the following two Visual Studio projects:
+Office Developer Tools for Visual Studio includes a template for task pane add-ins for Project. If you create a solution named **HelloProjectOData**, the solution contains the following two Visual Studio projects:
 
 - The add-in project takes the name of the solution. It includes the XML manifest file for the add-in and targets the .NET Framework 4.5. Procedure 3 shows the steps to modify the manifest for the **HelloProjectOData** add-in.
 
@@ -267,7 +267,7 @@ The task pane shows the add-in display name at the top, which is the value of th
 
 ## Create the JavaScript code for the add-in
 
-The template for a Project task pane add-in includes default initialization code that is designed to demonstrate basic get and set actions for data in a document for a typical Office 2013 add-in. Because Project 2013 does not support actions that write to the active project, and the **HelloProjectOData** add-in does not use the `getSelectedDataAsync` method, you can delete the script within the `Office.initialize` function, and delete the `setData` function and `getData` function in the default HelloProjectOData.js file.
+The template for a Project task pane add-in includes default initialization code that is designed to demonstrate basic get and set actions for data in a document for an Office add-in that uses the [Common APIs](../develop/office-javascript-api-object-model.md). Because Project does not support actions that write to the active project, and the **HelloProjectOData** add-in does not use the `getSelectedDataAsync` method, you can delete the script within the `Office.initialize` function, and delete the `setData` function and `getData` function in the default HelloProjectOData.js file.
 
 The JavaScript includes global constants for the REST query and global variables that are used in several functions. The **Get ProjectData Endpoint** button calls the `setOdataUrl` function, which initializes the global variables and determines whether Project is connected with Project Web App.
 
@@ -361,7 +361,7 @@ The remainder of the HelloProjectOData.js file includes two functions: the `retr
 1. Add the `retrieveOData` function, which concatenates values for the REST query and then calls the `ajax` function in jQuery to get the requested data from the **ProjectData** service. The `support.cors` variable enables cross-origin resource sharing (CORS) with the `ajax` function. If the `support.cors` statement is missing or is set to `false`, the `ajax` function returns a **No transport** error.
 
    > [!NOTE]
-   > The following code works with an on-premises installation of Project Server 2013. For Project on the web, you can use OAuth for token-based authentication. For more information, see [Addressing same-origin policy limitations in Office Add-ins](../develop/addressing-same-origin-policy-limitations.md).
+   > The following code works with an on-premises installation of Project Server. For Project on the web, you can use OAuth for token-based authentication. For more information, see [Addressing same-origin policy limitations in Office Add-ins](../develop/addressing-same-origin-policy-limitations.md).
 
    In the `ajax` call, you can use either the *headers* parameter or the *beforeSend* parameter. The *complete* parameter is an anonymous function so that it is in the same scope as the variables in `retrieveOData`. The function for the  *complete* parameter displays results in the `odataText` control and also calls the `parseODataResult` method to parse and display the JSON response. The *error* parameter specifies the named `getProjectDataErrorHandler` function, which writes an error message to the `odataText` control and also uses the `throwError` function to display a pop-up message.
 
@@ -534,7 +534,7 @@ The remainder of the HelloProjectOData.js file includes two functions: the `retr
 
 ## Test the HelloProjectOData add-in
 
-To test and debug the **HelloProjectOData** add-in with Visual Studio 2015, Project Professional 2013 must be installed on the development computer. To enable different test scenarios, ensure that you can choose whether Project opens for files on the local computer or connects with Project Web App. For example, do the following steps.
+To test and debug the **HelloProjectOData** add-in with Visual Studio 2015, Project Professional must be installed on the development computer. To enable different test scenarios, ensure that you can choose whether Project opens for files on the local computer or connects with Project Web App. For example, do the following steps.
 
 1. On the **File** tab, choose the **Info** tab in the Backstage view, and then choose **Manage Accounts**.
 
@@ -552,7 +552,7 @@ Basic tests should include the following:
 
 ### Procedure 6. Test the add-in
 
-1. Run Project Professional 2013, connect with Project Web App, and then create a test project. Assign tasks to local resources or to enterprise resources, set various values of percent complete on some tasks, and then publish the project. Quit Project, which enables Visual Studio to start Project for debugging the add-in.
+1. Run Project Professional, connect with Project Web App, and then create a test project. Assign tasks to local resources or to enterprise resources, set various values of percent complete on some tasks, and then publish the project. Quit Project, which enables Visual Studio to start Project for debugging the add-in.
 
 1. In Visual Studio, press **F5**. Log on to Project Web App, and then open the project that you created in the previous step. You can open the project in read-only mode or in edit mode.
 

--- a/docs/project/create-a-project-add-in-that-uses-rest-with-an-on-premises-odata-service.md
+++ b/docs/project/create-a-project-add-in-that-uses-rest-with-an-on-premises-odata-service.md
@@ -267,7 +267,7 @@ The task pane shows the add-in display name at the top, which is the value of th
 
 ## Create the JavaScript code for the add-in
 
-The template for a Project task pane add-in includes default initialization code that is designed to demonstrate basic get and set actions for data in a document for an Office add-in that uses the [Common APIs](../develop/office-javascript-api-object-model.md). Because Project does not support actions that write to the active project, and the **HelloProjectOData** add-in does not use the `getSelectedDataAsync` method, you can delete the script within the `Office.initialize` function, and delete the `setData` function and `getData` function in the default HelloProjectOData.js file.
+The template for a Project task pane add-in includes default initialization code that's designed to demonstrate basic get and set actions for data in a document for an Office add-in that uses the [Common APIs](../develop/office-javascript-api-object-model.md). Because Project doesn't support actions that write to the active project, and the **HelloProjectOData** add-in doesn't use the `getSelectedDataAsync` method, you can delete the script within the `Office.initialize` function, and delete the `setData` function and `getData` function in the default HelloProjectOData.js file.
 
 The JavaScript includes global constants for the REST query and global variables that are used in several functions. The **Get ProjectData Endpoint** button calls the `setOdataUrl` function, which initializes the global variables and determines whether Project is connected with Project Web App.
 
@@ -534,7 +534,7 @@ The remainder of the HelloProjectOData.js file includes two functions: the `retr
 
 ## Test the HelloProjectOData add-in
 
-To test and debug the **HelloProjectOData** add-in with Visual Studio 2015, Project Professional must be installed on the development computer. To enable different test scenarios, ensure that you can choose whether Project opens for files on the local computer or connects with Project Web App. For example, do the following steps.
+To test and debug the **HelloProjectOData** add-in with Visual Studio, Project Professional must be installed on the development computer. To enable different test scenarios, ensure that you can choose whether Project opens for files on the local computer or connects with Project Web App. The following are example steps.
 
 1. On the **File** tab, choose the **Info** tab in the Backstage view, and then choose **Manage Accounts**.
 

--- a/docs/project/project-add-ins.md
+++ b/docs/project/project-add-ins.md
@@ -22,21 +22,21 @@ Project managers can use Project task pane add-ins to help with project manageme
 
 Add-in scenarios for Project include the following:
 
-- **Project scheduling** View data from related projects that can affect scheduling. A task pane add-in can integrate relevant data from other projects in Project Server. For example, you can view the departmental collection of projects and milestone dates, or view specified data from other projects that are based on a selected custom field.
+- **Project scheduling**: View data from related projects that can affect scheduling. A task pane add-in can integrate relevant data from other projects in Project Server. For example, you can view the departmental collection of projects and milestone dates, or view specified data from other projects that are based on a selected custom field.
 
-- **Resource management** View the complete resource pool in Project Server or a subset based on specified skills, including cost data and resource availability, to help select appropriate resources.
+- **Resource management**: View the complete resource pool in Project Server or a subset based on specified skills, including cost data and resource availability, to help select appropriate resources.
 
-- **Statusing and approvals** Use a web application in a task pane add-in to update or view data from an external enterprise resource planning (ERP) application, timesheet system, or accounting application. Or, create a custom status approval Web Part that can be used within both Project Web App and Project Professional.
+- **Statusing and approvals**: Use a web application in a task pane add-in to update or view data from an external enterprise resource planning (ERP) application, timesheet system, or accounting application. Or, create a custom status approval Web Part that can be used within both Project Web App and Project Professional.
 
-- **Team communication** Communicate with team members and resources directly from a task pane add-in, within the context of a project. Or, easily maintain a set of context-sensitive notes for yourself as you work in a project.
+- **Team communication**: Communicate with team members and resources directly from a task pane add-in, within the context of a project. Or, easily maintain a set of context-sensitive notes for yourself as you work in a project.
 
-- **Work packages** Search for specified kinds of project templates within SharePoint libraries and online template collections. For example, find templates for construction projects and add them to your Project template collection.
+- **Work packages**: Search for specified kinds of project templates within SharePoint libraries and online template collections. For example, find templates for construction projects and add them to your Project template collection.
 
 - **Related items**: View metadata, documents, and messages that are related to specific tasks in a project plan. For example, you can use Project Professional to manage a project that was imported from a SharePoint task list, and still synchronize the task list with changes in the project. A task pane add-in can show additional fields or metadata that Project didn't import for tasks in the SharePoint list.
 
-- **Use the Project Server object models** Use the GUID of a selected task with methods in the Project Server Interface (PSI) or the client-side object model (CSOM) of Project Server. For example, the web application for an add-in can read and update the statusing data of a selected task and resource, or integrate with an external timesheet application.
+- **Use the Project Server object models**: Use the GUID of a selected task with methods in the Project Server Interface (PSI) or the client-side object model (CSOM) of Project Server. For example, the web application for an add-in can read and update the statusing data of a selected task and resource, or integrate with an external timesheet application.
 
-- **Get reporting data** Use Representational State Transfer (REST), JavaScript, or LINQ queries to find related information for a selected task or resource in the OData service for reporting tables in Project Web App. Queries that use the OData service can be done with an online or an on-premises installation of Project Server.
+- **Get reporting data**: Use Representational State Transfer (REST), JavaScript, or LINQ queries to find related information for a selected task or resource in the OData service for reporting tables in Project Web App. Queries that use the OData service can be done with an online or an on-premises installation of Project Server.
 
     For example, see [Create a Project add-in that uses REST with an on-premises Project Server OData service](../project/create-a-project-add-in-that-uses-rest-with-an-on-premises-odata-service.md).
 

--- a/docs/project/project-add-ins.md
+++ b/docs/project/project-add-ins.md
@@ -1,7 +1,7 @@
 ---
 title: Task pane add-ins for Project
 description: Learn about task pane add-ins for Project.
-ms.date: 01/23/2024
+ms.date: 02/21/2024
 ms.topic: overview
 ms.custom: scenarios:getting-started
 ms.localizationpriority: medium
@@ -9,7 +9,7 @@ ms.localizationpriority: medium
 
 # Task pane add-ins for Project
 
-Project Standard 2013 and Project Professional 2013 (version 15.1 or higher) both include support for task pane add-ins. You can run general task pane add-ins that are developed for Word or Excel. You can also develop custom add-ins that handle selection events in Project and integrate task, resource, view, and other cell-level data in a project with SharePoint lists, SharePoint Add-ins, Web Parts, web services, and enterprise applications.
+Project on Windows supports custom task pane add-ins. Use these to handle selection events in Project and integrate task, resource, view, and other cell-level data in a project with SharePoint lists, SharePoint Add-ins, Web Parts, web services, and enterprise applications.
 
 For an introduction to Office Add-ins, see [Office Add-ins platform overview](../overview/office-add-ins.md).
 
@@ -18,25 +18,25 @@ For an introduction to Office Add-ins, see [Office Add-ins platform overview](..
 Project managers can use Project task pane add-ins to help with project management activities. Instead of leaving Project and opening another application to search for frequently used information, project managers can directly access the information within Project. The content in a task pane add-in can be context-sensitive, based on the selected task, resource, view, or other data in a cell in a Gantt chart, task usage view, or resource usage view.
 
 > [!NOTE]
-> With Project Professional 2013, you can develop task pane add-ins that access Project on the web, on-premises installations of Project Server 2013, and on-premises or online SharePoint 2013. Project Standard 2013 does not support direct integration with Project Server data or SharePoint task lists that are synchronized with Project Server.
+> With Project Professional, you can develop task pane add-ins that access Project on the web, on-premises installations of Project Server, and on-premises or online SharePoint. Project Standard does not support direct integration with Project Server data or SharePoint task lists that are synchronized with Project Server.
 
 Add-in scenarios for Project include the following:
 
-- **Project scheduling** View data from related projects that can affect scheduling. A task pane add-in can integrate relevant data from other projects in Project Server 2013. For example, you can view the departmental collection of projects and milestone dates, or view specified data from other projects that are based on a selected custom field.
+- **Project scheduling** View data from related projects that can affect scheduling. A task pane add-in can integrate relevant data from other projects in Project Server. For example, you can view the departmental collection of projects and milestone dates, or view specified data from other projects that are based on a selected custom field.
 
-- **Resource management** View the complete resource pool in Project Server 2013 or a subset based on specified skills, including cost data and resource availability, to help select appropriate resources.
+- **Resource management** View the complete resource pool in Project Server or a subset based on specified skills, including cost data and resource availability, to help select appropriate resources.
 
-- **Statusing and approvals** Use a web application in a task pane add-in to update or view data from an external enterprise resource planning (ERP) application, timesheet system, or accounting application. Or, create a custom status approval Web Part that can be used within both Project Web App and Project Professional 2013.
+- **Statusing and approvals** Use a web application in a task pane add-in to update or view data from an external enterprise resource planning (ERP) application, timesheet system, or accounting application. Or, create a custom status approval Web Part that can be used within both Project Web App and Project Professional.
 
 - **Team communication** Communicate with team members and resources directly from a task pane add-in, within the context of a project. Or, easily maintain a set of context-sensitive notes for yourself as you work in a project.
 
 - **Work packages** Search for specified kinds of project templates within SharePoint libraries and online template collections. For example, find templates for construction projects and add them to your Project template collection.
 
-- **Related items** View metadata, documents, and messages that are related to specific tasks in a project plan. For example, you can use Project Professional 2013 to manage a project that was imported from a SharePoint task list, and still synchronize the task list with changes in the project. A task pane add-in can show additional fields or metadata that Project did not import for tasks in the SharePoint list.
+- **Related items** View metadata, documents, and messages that are related to specific tasks in a project plan. For example, you can use Project Professional to manage a project that was imported from a SharePoint task list, and still synchronize the task list with changes in the project. A task pane add-in can show additional fields or metadata that Project did not import for tasks in the SharePoint list.
 
 - **Use the Project Server object models** Use the GUID of a selected task with methods in the Project Server Interface (PSI) or the client-side object model (CSOM) of Project Server. For example, the web application for an add-in can read and update the statusing data of a selected task and resource, or integrate with an external timesheet application.
 
-- **Get reporting data** Use Representational State Transfer (REST), JavaScript, or LINQ queries to find related information for a selected task or resource in the OData service for reporting tables in Project Web App. Queries that use the OData service can be done with an online or an on-premises installation of Project Server 2013.
+- **Get reporting data** Use Representational State Transfer (REST), JavaScript, or LINQ queries to find related information for a selected task or resource in the OData service for reporting tables in Project Web App. Queries that use the OData service can be done with an online or an on-premises installation of Project Server.
 
     For example, see [Create a Project add-in that uses REST with an on-premises Project Server OData service](../project/create-a-project-add-in-that-uses-rest-with-an-on-premises-odata-service.md).
 
@@ -44,7 +44,7 @@ Add-in scenarios for Project include the following:
 
 Project supports add-ins made with the JavaScript API, but there's currently no JavaScript API designed specifically for interacting with Project. You can use the [Common API](/javascript/api/office) to create Project add-ins. For information about the Common API, see [Office JavaScript API object model](../develop/office-javascript-api-object-model.md).
 
-To create an add-in, you can use a simple text editor to create an HTML webpage and related JavaScript files, CSS files, and REST queries. In addition to an HTML page or a web application, an add-in requires an XML manifest file for configuration. Project can use a manifest file that includes a **type** attribute that is specified as **TaskPaneExtension**. The manifest file can be used by multiple Office 2013 client applications, or you can create a manifest file that is specific for Project 2013. For more information, see the  _Development basics_ section in [Office Add-ins platform overview](../overview/office-add-ins.md).
+To create an add-in, you can use a simple text editor to create an HTML webpage and related JavaScript files, CSS files, and REST queries. In addition to an HTML page or a web application, an add-in requires an XML manifest file for configuration. Project can use a manifest file that includes a **type** attribute that is specified as **TaskPaneExtension**. The manifest file can be used by multiple Office client applications, or you can create a manifest file that is specific for Project. For more information, see the  _Development basics_ section in [Office Add-ins platform overview](../overview/office-add-ins.md).
 
 Be sure to test your add-in as you develop it. Learn about testing and sideloading add-in in the article [Test Office Add-ins](../testing/test-debug-office-add-ins.md).
 

--- a/docs/project/project-add-ins.md
+++ b/docs/project/project-add-ins.md
@@ -18,7 +18,7 @@ For an introduction to Office Add-ins, see [Office Add-ins platform overview](..
 Project managers can use Project task pane add-ins to help with project management activities. Instead of leaving Project and opening another application to search for frequently used information, project managers can directly access the information within Project. The content in a task pane add-in can be context-sensitive, based on the selected task, resource, view, or other data in a cell in a Gantt chart, task usage view, or resource usage view.
 
 > [!NOTE]
-> With Project Professional, you can develop task pane add-ins that access Project on the web, on-premises installations of Project Server, and on-premises or online SharePoint. Project Standard does not support direct integration with Project Server data or SharePoint task lists that are synchronized with Project Server.
+> With Project Professional, you can develop task pane add-ins that access Project on the web, on-premises installations of Project Server, and on-premises or online SharePoint. Project Standard doesn't support direct integration with Project Server data or SharePoint task lists that are synchronized with Project Server.
 
 Add-in scenarios for Project include the following:
 
@@ -32,7 +32,7 @@ Add-in scenarios for Project include the following:
 
 - **Work packages** Search for specified kinds of project templates within SharePoint libraries and online template collections. For example, find templates for construction projects and add them to your Project template collection.
 
-- **Related items** View metadata, documents, and messages that are related to specific tasks in a project plan. For example, you can use Project Professional to manage a project that was imported from a SharePoint task list, and still synchronize the task list with changes in the project. A task pane add-in can show additional fields or metadata that Project did not import for tasks in the SharePoint list.
+- **Related items**: View metadata, documents, and messages that are related to specific tasks in a project plan. For example, you can use Project Professional to manage a project that was imported from a SharePoint task list, and still synchronize the task list with changes in the project. A task pane add-in can show additional fields or metadata that Project didn't import for tasks in the SharePoint list.
 
 - **Use the Project Server object models** Use the GUID of a selected task with methods in the Project Server Interface (PSI) or the client-side object model (CSOM) of Project Server. For example, the web application for an add-in can read and update the statusing data of a selected task and resource, or integrate with an external timesheet application.
 
@@ -44,7 +44,7 @@ Add-in scenarios for Project include the following:
 
 Project supports add-ins made with the JavaScript API, but there's currently no JavaScript API designed specifically for interacting with Project. You can use the [Common API](/javascript/api/office) to create Project add-ins. For information about the Common API, see [Office JavaScript API object model](../develop/office-javascript-api-object-model.md).
 
-To create an add-in, you can use a simple text editor to create an HTML webpage and related JavaScript files, CSS files, and REST queries. In addition to an HTML page or a web application, an add-in requires an XML manifest file for configuration. Project can use a manifest file that includes a **type** attribute that is specified as **TaskPaneExtension**. The manifest file can be used by multiple Office client applications, or you can create a manifest file that is specific for Project. For more information, see the  _Development basics_ section in [Office Add-ins platform overview](../overview/office-add-ins.md).
+To create an add-in, you can use a simple text editor to create an HTML webpage and related JavaScript files, CSS files, and REST queries. In addition to an HTML page or a web application, an add-in requires an XML manifest file for configuration. Project can use a manifest file that includes a **type** attribute that's specified as **TaskPaneExtension**. The manifest file can be used by multiple Office client applications, or you can create a manifest file that's specific for Project. For more information, see the  _Development basics_ section in [Office Add-ins platform overview](../overview/office-add-ins.md).
 
 Be sure to test your add-in as you develop it. Learn about testing and sideloading add-in in the article [Test Office Add-ins](../testing/test-debug-office-add-ins.md).
 


### PR DESCRIPTION
Fixes #4430.

This PR removes the references to Project 2013, since the same information applies to subsequent versions of Project.