### PR TITLE
[Outlook] (Deployment) Corrects support for Outlook through Integrated Apps

### DIFF
--- a/docs/publish/publish.md
+++ b/docs/publish/publish.md
@@ -26,10 +26,10 @@ The deployment options that are available depend on the Office application that 
 
 | Extension point | Sideloading | Network share                                 | AppSource | Microsoft 365 admin center | SharePoint catalog\* | Exchange server |
 |:----------------|:-----------:|:---------------------------------------------:|:---------:|:--------------------------:|:--------------------:|:---------------:|
-| Content         | Supported   | Supported                                     | Supported | Supported                  | Supported            | Not supported |
-| Task pane       | Supported   | Supported                                     | Supported | Supported                  | Supported            | Not supported |
-| Command         | Supported   | Support for Excel, PowerPoint, and Word only  | Supported | Supported                  | Not supported        | Not supported |
-| Mail app        | Supported   | Not supported                                 | Supported | Supported                  | Not supported        | Supported |
+| Content         | Supported   | Supported                                     | Supported | Supported                  | Supported            | Not supported   |
+| Task pane       | Supported   | Supported                                     | Supported | Supported                  | Supported            | Not supported   |
+| Command         | Supported   | Support for Excel, PowerPoint, and Word only  | Supported | Supported                  | Not supported        | Not supported   |
+| Mail app        | Supported   | Not supported                                 | Supported | Supported                  | Not supported        | Supported       |
 
 \* SharePoint catalogs don't support Office on Mac.
 

--- a/docs/publish/publish.md
+++ b/docs/publish/publish.md
@@ -24,12 +24,12 @@ You can use one of several methods to deploy your Office Add-in for testing or d
 
 The deployment options that are available depend on the Office application that you're targeting and the type of add-in you create.
 
-| Extension point | Sideloading | Network share                                 | AppSource | Microsoft 365 admin center | SharePoint catalog\* |
-|:----------------|:-----------:|:---------------------------------------------:|:---------:|:--------------------------:|:--------------------:|
-| Content         | Supported   | Supported                                     | Supported | Supported                  | Supported            |
-| Task pane       | Supported   | Supported                                     | Supported | Supported                  | Supported            |
-| Command         | Supported   | Support for Excel, PowerPoint, and Word only  | Supported | Supported                  | Not supported        |
-| Mail app        | Supported   | Not supported                                 | Supported | Supported                  | Not supported        |
+| Extension point | Sideloading | Network share                                 | AppSource | Microsoft 365 admin center | SharePoint catalog\* | Exchange server |
+|:----------------|:-----------:|:---------------------------------------------:|:---------:|:--------------------------:|:--------------------:|:---------------:|
+| Content         | Supported   | Supported                                     | Supported | Supported                  | Supported            | Not supported |
+| Task pane       | Supported   | Supported                                     | Supported | Supported                  | Supported            | Not supported |
+| Command         | Supported   | Support for Excel, PowerPoint, and Word only  | Supported | Supported                  | Not supported        | Not supported |
+| Mail app        | Supported   | Not supported                                 | Supported | Supported                  | Not supported        | Supported |
 
 \* SharePoint catalogs don't support Office on Mac.
 

--- a/docs/publish/publish.md
+++ b/docs/publish/publish.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy and publish Office Add-ins
 description: Methods and options to deploy your Office Add-in for testing or distribution to users.
-ms.date: 04/12/2024
+ms.date: 06/13/2024
 ms.localizationpriority: high
 ---
 
@@ -24,22 +24,14 @@ You can use one of several methods to deploy your Office Add-in for testing or d
 
 The deployment options that are available depend on the Office application that you're targeting and the type of add-in you create.
 
-### Deployment options for Word, Excel, and PowerPoint add-ins
-
-| Extension point | Sideloading | Network share | AppSource | Microsoft 365 admin center | SharePoint catalog\* |
-|:----------------|:-----------:|:-------------:|:---------:|:--------------------------:|:--------------------:|
-| Content         | Supported   | Supported     | Supported | Supported                  | Supported            |
-| Task pane       | Supported   | Supported     | Supported | Supported                  | Supported            |
-| Command         | Supported   | Supported     | Supported | Supported                  | Not available        |
+| Extension point | Sideloading | Network share                                 | AppSource | Microsoft 365 admin center | SharePoint catalog\* |
+|:----------------|:-----------:|:---------------------------------------------:|:---------:|:--------------------------:|:--------------------:|
+| Content         | Supported   | Supported                                     | Supported | Supported                  | Supported            |
+| Task pane       | Supported   | Supported                                     | Supported | Supported                  | Supported            |
+| Command         | Supported   | Support for Excel, PowerPoint, and Word only  | Supported | Supported                  | Not supported        |
+| Mail app        | Supported   | Not supported                                 | Supported | Supported                  | Not supported        |
 
 \* SharePoint catalogs don't support Office on Mac.
-
-### Deployment options for Outlook add-ins
-
-| Extension point | Sideloading | AppSource | Exchange server |
-|:----------------|:-----------:|:---------:|:---------------:|
-| Mail app        | Supported   | Supported | Supported       |
-| Command         | Supported   | Supported | Supported       |
 
 ## Production deployment methods
 
@@ -71,7 +63,7 @@ If you are deploying add-ins in an on-premises environment, use a SharePoint cat
 > [!NOTE]
 > SharePoint catalogs don't support Office on Mac. To deploy Office Add-ins to Mac clients, you must submit them to [AppSource](/office/dev/store/submit-to-the-office-store).
 
-### Outlook add-in deployment
+### Outlook add-in Exchange server deployment
 
 For on-premises and online environments that don't use the Azure AD identity service, you can deploy Outlook add-ins via the Exchange server.
 

--- a/docs/publish/publish.md
+++ b/docs/publish/publish.md
@@ -16,7 +16,7 @@ You can use one of several methods to deploy your Office Add-in for testing or d
 |[AppSource][AppSource]|To distribute your add-in publicly to users.|
 |[Microsoft 365 admin center](/microsoft-365/admin/manage/test-and-deploy-microsoft-365-apps)|In a cloud deployment, to distribute your add-in to users in your organization by using the Microsoft 365 admin center. This is done through [Integrated Apps](/microsoft-365/admin/manage/test-and-deploy-microsoft-365-apps) or [Centralized Deployment](/microsoft-365/admin/manage/centralized-deployment-of-add-ins). |
 |[SharePoint catalog](publish-task-pane-and-content-add-ins-to-an-add-in-catalog.md)|In an on-premises environment, to distribute your add-in to users in your organization. Doesn't support add-ins that use the [unified manifest for Microsoft 365](../develop/unified-manifest-overview.md).|
-|[Exchange server](#outlook-add-in-deployment)|In an on-premises or online environment, to distribute Outlook add-ins to users.|
+|[Exchange server](#outlook-add-in-exchange-server-deployment)|In an on-premises or online environment, to distribute Outlook add-ins to users.|
 
 [!INCLUDE [publish policies note](../includes/note-publish-policies.md)]
 


### PR DESCRIPTION
Fixes #4613.

Outlook add-ins can be deployed through Integrated Apps (as mentioned [here](https://learn.microsoft.com/en-us/microsoft-365/admin/manage/test-and-deploy-microsoft-365-apps?view=o365-worldwide#what-controls-are-available-on-the-integrated-apps-portal)). This PR corrects the publishing table to reflect that.