### PR TITLE
[all] (Script Lab) Add note about importing gist links with Script Lab

### DIFF
--- a/docs/overview/explore-with-script-lab.md
+++ b/docs/overview/explore-with-script-lab.md
@@ -49,7 +49,7 @@ To call preview APIs within a snippet, you need to update the snippet's librarie
 
 By default, snippets that you open in Script Lab are saved to your browser cache or local storage. To save a snippet permanently, select **Copy** and paste the resulting clipboard content into a new .yml file. Use this to share snippets with colleagues or provide code for community sites, such as Stack Overflow.
 
-To import a snippet into Script Lab, select **Import** from the menu and paste in the complete YAML for the snippet. If you have saved the YAML as a [GitHub gist](https://gist.github.com/), you can paste a link to the gist instead.
+To import a snippet into Script Lab, select **Import** from the menu and paste in the complete YAML for the snippet. If you've saved the YAML as a [GitHub gist](https://gist.github.com/), you can paste a link to the gist instead.
 
 ## Supported clients
 

--- a/docs/overview/explore-with-script-lab.md
+++ b/docs/overview/explore-with-script-lab.md
@@ -1,7 +1,7 @@
 ---
 title: Explore Office JavaScript API using Script Lab
 description: Use Script Lab to explore the Office JS API and to prototype functionality.
-ms.date: 04/08/2024
+ms.date: 06/14/2024
 ms.topic: concept-article
 ms.custom: scenarios:getting-started
 ms.localizationpriority: high
@@ -49,7 +49,7 @@ To call preview APIs within a snippet, you need to update the snippet's librarie
 
 By default, snippets that you open in Script Lab are saved to your browser cache or local storage. To save a snippet permanently, select **Copy** and paste the resulting clipboard content into a new .yml file. Use this to share snippets with colleagues or provide code for community sites, such as Stack Overflow.
 
-To import a snippet into Script Lab, select **Import** from the menu and paste in the complete YAML for the snippet.
+To import a snippet into Script Lab, select **Import** from the menu and paste in the complete YAML for the snippet. If you have saved the YAML as a [GitHub gist](https://gist.github.com/), you can paste a link to the gist instead.
 
 ## Supported clients
 


### PR DESCRIPTION
While the ability to save snippets from Script Lab as gists was removed, the import option still exists. This PR clarifies that behavior. 