### PR TITLE
[all hosts] Remove (s)

### DIFF
--- a/docs/develop/json-manifest-overview.md
+++ b/docs/develop/json-manifest-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Compare the XML manifest with the unified manifest for Microsoft 365
-description: Get a comparison of the XML manifest with the unified manifest for Microsoft 365.
+description: Gets a comparison of the XML manifest with the unified manifest for Microsoft 365.
 ms.topic: overview
 ms.date: 04/12/2024
 ms.localizationpriority: high
@@ -94,7 +94,7 @@ The following table shows a mapping of some high level child properties of the "
 
 #### "ribbons" table
 
-The following table maps the child properties of the anonymous child objects in the "ribbons" array onto XML elements in the current manifest. 
+The following table maps the child properties of the anonymous child objects in the "ribbons" array onto XML elements in the current manifest.
 
 |JSON property|Purpose|XML elements|Comments|
 |:-----|:-----|:-----|:-----|
@@ -105,4 +105,4 @@ For a full sample unified manifest, see [Sample unified manifest](unified-manife
 
 ## Next steps
 
-- [Build your first Outlook add-in](../quickstarts/outlook-quickstart.md).
+- [Build your first Outlook add-in](../quickstarts/outlook-quickstart.md)

--- a/docs/develop/troubleshoot-sso-in-office-add-ins.md
+++ b/docs/develop/troubleshoot-sso-in-office-add-ins.md
@@ -121,7 +121,7 @@ In certain configurations of identity in AAD and Microsoft 365, it is possible f
 
 Your code should test for this `claims` property. Depending on your add-in's architecture, you may test for it on the client-side, or you may test for it on the server-side and relay it to the client. You need this information in the client because Office handles authentication for SSO add-ins. If you relay it from the server-side, the message to the client can be either an error (such as `500 Server Error` or `401 Unauthorized`) or in the body of a success response (such as `200 OK`). In either case, the (failure or success) callback of your code's client-side AJAX call to your add-in's web API should test for this response.
 
-Regardless of your architecture, if the claims value has been sent from AAD, your code should recall `getAccessToken` and pass the option `authChallenge: CLAIMS-STRING-HERE` in the `options` parameter. When AAD sees this string, it prompts the user for the additional factor(s) and then returns a new access token which will be accepted in the on-behalf-of flow.
+Regardless of your architecture, if the claims value has been sent from AAD, your code should recall `getAccessToken` and pass the option `authChallenge: CLAIMS-STRING-HERE` in the `options` parameter. When AAD sees this string, it prompts the user for the additional factors and then returns a new access token which will be accepted in the on-behalf-of flow.
 
 ### Consent missing errors
 

--- a/docs/excel/excel-add-ins-events.md
+++ b/docs/excel/excel-add-ins-events.md
@@ -54,7 +54,7 @@ Events within an Excel workbook can be triggered by:
 - Office Add-in (JavaScript) code that changes the workbook
 - VBA add-in (macro) code that changes the workbook
 
-Any change that complies with default behavior of Excel will trigger the corresponding event(s) in a workbook.
+Any change that complies with default behavior of Excel will trigger the corresponding events in a workbook.
 
 ### Lifecycle of an event handler
 

--- a/docs/excel/excel-add-ins-multiple-ranges.md
+++ b/docs/excel/excel-add-ins-multiple-ranges.md
@@ -24,7 +24,7 @@ Some examples:
 - `RangeAreas.cellCount` gets the total number of cells in all the ranges in the `RangeAreas`.
 - `RangeAreas.calculate` recalculates the cells of all the ranges in the `RangeAreas`.
 - `RangeAreas.getEntireColumn` and `RangeAreas.getEntireRow` return another `RangeAreas` object that represents all of the columns (or rows) in all the ranges in the `RangeAreas`. For example, if the `RangeAreas` represents "A1:C4" and "F14:L15", then `RangeAreas.getEntireColumn` returns a `RangeAreas` object that represents "A:C" and "F:L".
-- `RangeAreas.copyFrom` can take either a `Range` or a `RangeAreas` parameter representing the source range(s) of the copy operation.
+- `RangeAreas.copyFrom` can take either a `Range` or a `RangeAreas` parameter representing the source ranges of the copy operation.
 
 ### Complete list of Range members that are also available on RangeAreas
 

--- a/docs/outlook/testing-and-tips.md
+++ b/docs/outlook/testing-and-tips.md
@@ -11,7 +11,7 @@ ms.localizationpriority: high
 As part of the process of developing an Outlook add-in, you'll probably find yourself iteratively deploying and installing the add-in for testing, which involves the following steps.
 
 1. Creating a manifest file that describes the add-in.
-1. Deploying the add-in UI file(s) to a web server.
+1. Deploying the add-in UI files to a web server.
 1. Installing the add-in in your mailbox.
 1. Testing the add-in, making appropriate changes to the UI or manifest files, and repeating steps 2 and 3 to test the changes.
 

--- a/docs/tutorials/powerpoint-tutorial.md
+++ b/docs/tutorials/powerpoint-tutorial.md
@@ -997,7 +997,7 @@ Complete the following steps to add code that retrieves metadata for the selecte
     <button class="Button Button--primary" id="get-slide-metadata">
         <span class="Button-icon"><i class="ms-Icon ms-Icon--plus"></i></span>
         <span class="Button-label">Get Slide Metadata</span>
-        <span class="Button-description">Gets metadata for the selected slide(s).</span>
+        <span class="Button-description">Gets metadata for the selected slides.</span>
     </button>
     ```
 
@@ -1007,7 +1007,7 @@ Complete the following steps to add code that retrieves metadata for the selecte
     $('#get-slide-metadata').on("click", getSlideMetadata);
     ```
 
-1. In the **Home.js** file, replace `TODO7` with the following code to define the `getSlideMetadata` function. This function retrieves metadata for the selected slide(s) and writes it to a popup dialog window within the add-in task pane.
+1. In the **Home.js** file, replace `TODO7` with the following code to define the `getSlideMetadata` function. This function retrieves metadata for the selected slides and writes it to a popup dialog window within the add-in task pane.
 
     ```js
     function getSlideMetadata() {
@@ -1016,7 +1016,7 @@ Complete the following steps to add code that retrieves metadata for the selecte
                 if (asyncResult.status === Office.AsyncResultStatus.Failed) {
                     showNotification("Error", asyncResult.error.message);
                 } else {
-                    showNotification("Metadata for selected slide(s):", JSON.stringify(asyncResult.value), null, 2);
+                    showNotification("Metadata for selected slides:", JSON.stringify(asyncResult.value), null, 2);
                 }
             }
         );


### PR DESCRIPTION
Updating [per guidance](https://learn.microsoft.com/en-us/style-guide/grammar/nouns-pronouns#plural-nouns) that we shouldn't use "(s)" to indicate variable singular vs plural. Also, screen readers don't read it properly.