### PR TITLE
[all hosts] (Troubleshooting) Update HTTP intercept recommendations

### DIFF
--- a/docs/develop/troubleshoot-sso-in-office-add-ins.md
+++ b/docs/develop/troubleshoot-sso-in-office-add-ins.md
@@ -18,8 +18,8 @@ This article provides some guidance about how to troubleshoot problems with sing
 We strongly recommend that you use a tool that can intercept and display the HTTP Requests from, and Responses to, your add-in's web service when you are developing. Some of the most popular are:
 
 - [Fiddler](https://www.telerik.com/fiddler): Free for 10 days ([Documentation](https://docs.telerik.com/fiddler-everywhere/introduction))
-- [Charles](https://www.charlesproxy.com): Free for 30 days. ([Documentation](https://www.charlesproxy.com/documentation/))
-- [Requestly](https://requestly.com/): Free basic service. ([Documentation](https://developers.requestly.com/))
+- [Charles](https://www.charlesproxy.com): Free for 30 days. ([Documentation](https://www.charlesproxy.com/documentation))
+- [Requestly](https://requestly.com/downloads): Free basic service. ([Documentation](https://developers.requestly.com))
 
 ## Causes and handling of errors from getAccessToken
 

--- a/docs/develop/troubleshoot-sso-in-office-add-ins.md
+++ b/docs/develop/troubleshoot-sso-in-office-add-ins.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshoot error messages for single sign-on (SSO)
 description: Guidance about how to troubleshoot problems with single sign-on (SSO) in Office Add-ins, and handle special conditions or errors.
-ms.date: 08/14/2023
+ms.date: 07/08/2024
 ms.localizationpriority: medium
 ---
 
@@ -15,10 +15,11 @@ This article provides some guidance about how to troubleshoot problems with sing
 
 ## Debugging tools
 
-We strongly recommend that you use a tool that can intercept and display the HTTP Requests from, and Responses to, your add-in's web service when you are developing. Two of the most popular are:
+We strongly recommend that you use a tool that can intercept and display the HTTP Requests from, and Responses to, your add-in's web service when you are developing. Some of the most popular are:
 
-- [Fiddler](https://www.telerik.com/fiddler): Free ([Documentation](https://docs.telerik.com/fiddler/configure-fiddler/tasks/configurefiddler))
+- [Fiddler](https://www.telerik.com/fiddler): Free for 10 days ([Documentation](https://docs.telerik.com/fiddler-everywhere/introduction))
 - [Charles](https://www.charlesproxy.com): Free for 30 days. ([Documentation](https://www.charlesproxy.com/documentation/))
+- [Requestly](https://requestly.com/): Free basic service. ([Documentation](https://developers.requestly.com/))
 
 ## Causes and handling of errors from getAccessToken
 

--- a/docs/testing/testing-and-troubleshooting.md
+++ b/docs/testing/testing-and-troubleshooting.md
@@ -10,7 +10,7 @@ ms.localizationpriority: medium
 
 At times your users might encounter issues with Office Add-ins that you develop. For example, an add-in fails to load or is inaccessible. Use the information in this article to help resolve common issues that your users encounter with your Office Add-in.
 
-You can also use tools to intercept HTTP messages to identify and debug issues with your add-ins. Popular choices include [Fiddler](https://www.telerik.com/fiddler), [Charles](https://www.charlesproxy.com), and [Requestly](https://requestly.com/).
+You can also use tools to intercept HTTP messages to identify and debug issues with your add-ins. Popular choices include [Fiddler](https://www.telerik.com/fiddler), [Charles](https://www.charlesproxy.com), and [Requestly](https://requestly.com/downloads/).
 
 ## Common errors and troubleshooting steps
 

--- a/docs/testing/testing-and-troubleshooting.md
+++ b/docs/testing/testing-and-troubleshooting.md
@@ -10,7 +10,7 @@ ms.localizationpriority: medium
 
 At times your users might encounter issues with Office Add-ins that you develop. For example, an add-in fails to load or is inaccessible. Use the information in this article to help resolve common issues that your users encounter with your Office Add-in.
 
-You can also use tools to intercept HTTP messages to identify and debug issues with your add-ins. Popular choices include [Fiddler](https://www.telerik.com/fiddler), [Charles](https://www.charlesproxy.com), and [Requestly](https://requestly.com/downloads/).
+You can also use tools to intercept HTTP messages to identify and debug issues with your add-ins. Popular choices include [Fiddler](https://www.telerik.com/fiddler), [Charles](https://www.charlesproxy.com), and [Requestly](https://requestly.com/downloads).
 
 ## Common errors and troubleshooting steps
 

--- a/docs/testing/testing-and-troubleshooting.md
+++ b/docs/testing/testing-and-troubleshooting.md
@@ -2,7 +2,7 @@
 title: Troubleshoot user errors with Office Add-ins
 description: Learn how to troubleshoot user errors in Office Add-ins.
 ms.topic: troubleshooting-problem-resolution
-ms.date: 06/13/2024
+ms.date: 07/08/2024
 ms.localizationpriority: medium
 ---
 
@@ -10,7 +10,7 @@ ms.localizationpriority: medium
 
 At times your users might encounter issues with Office Add-ins that you develop. For example, an add-in fails to load or is inaccessible. Use the information in this article to help resolve common issues that your users encounter with your Office Add-in.
 
-You can also use [Fiddler](https://www.telerik.com/fiddler) to identify and debug issues with your add-ins.
+You can also use tools to intercept HTTP messages to identify and debug issues with your add-ins. Popular choices include [Fiddler](https://www.telerik.com/fiddler), [Charles](https://www.charlesproxy.com), and [Requestly](https://requestly.com/).
 
 ## Common errors and troubleshooting steps
 


### PR DESCRIPTION
Fiddler now has a free trial instead of a free plan. This PR updates our documentation to reflect that. It also adds another HTTP intercept option, Requestly, for people looking for a free (or freemium) service.