### PR TITLE
[excel, word] (Tutorials) Remove repeat prereq about Office

### DIFF
--- a/docs/tutorials/excel-tutorial-create-custom-functions.md
+++ b/docs/tutorials/excel-tutorial-create-custom-functions.md
@@ -22,11 +22,6 @@ In this tutorial, you will:
 
 [!include[Yeoman generator prerequisites](../includes/quickstart-yo-prerequisites.md)]
 
-- Office connected to a Microsoft 365 subscription (including Office on the web).
-
-  > [!NOTE]
-  > If you don't already have Office, you might qualify for a Microsoft 365 E5 developer subscription to use for development through the [Microsoft 365 Developer Program](https://aka.ms/m365devprogram); for details, see the [FAQ](/office/developer-program/microsoft-365-developer-program-faq#who-qualifies-for-a-microsoft-365-e5-developer-subscription-). Alternatively, you can [sign up for a 1-month free trial](https://www.microsoft.com/microsoft-365/try) or [purchase a Microsoft 365 plan](https://www.microsoft.com/microsoft-365/business/compare-all-microsoft-365-business-products-g).
-
 ## Create a custom functions project
 
  To start, create the code project to build your custom function add-in. The [Yeoman generator for Office Add-ins](../develop/yeoman-generator-overview.md) will set up your project with some prebuilt custom functions that you can try out. If you've already run the custom functions quick start and generated a project, continue to use that project and skip to [this step](#create-a-custom-function-that-requests-data-from-the-web) instead.

--- a/docs/tutorials/excel-tutorial.md
+++ b/docs/tutorials/excel-tutorial.md
@@ -29,11 +29,6 @@ In this tutorial, you'll create an Excel task pane add-in that:
 
 [!include[Yeoman generator prerequisites](../includes/quickstart-yo-prerequisites.md)]
 
-- Office connected to a Microsoft 365 subscription (including Office on the web).
-
-    > [!NOTE]
-    > If you don't already have Office, you might qualify for a Microsoft 365 E5 developer subscription to use for development through the [Microsoft 365 Developer Program](https://aka.ms/m365devprogram); for details, see the [FAQ](/office/developer-program/microsoft-365-developer-program-faq#who-qualifies-for-a-microsoft-365-e5-developer-subscription-). Alternatively, you can [sign up for a 1-month free trial](https://www.microsoft.com/microsoft-365/try) or [purchase a Microsoft 365 plan](https://www.microsoft.com/microsoft-365/business/compare-all-microsoft-365-business-products-g).
-
 ## Create your add-in project
 
 [!include[Yeoman generator create project guidance](../includes/yo-office-command-guidance.md)]

--- a/docs/tutorials/word-tutorial.md
+++ b/docs/tutorials/word-tutorial.md
@@ -28,11 +28,6 @@ In this tutorial, you'll create a Word task pane add-in that:
 
 [!include[Yeoman generator prerequisites](../includes/quickstart-yo-prerequisites.md)]
 
-- Office connected to a Microsoft 365 subscription (including Office on the web).
-
-    > [!NOTE]
-    > If you don't already have Office, you might qualify for a Microsoft 365 E5 developer subscription to use for development through the [Microsoft 365 Developer Program](https://aka.ms/m365devprogram); for details, see the [FAQ](/office/developer-program/microsoft-365-developer-program-faq#who-qualifies-for-a-microsoft-365-e5-developer-subscription-). Alternatively, you can [sign up for a 1-month free trial](https://www.microsoft.com/microsoft-365/try) or [purchase a Microsoft 365 plan](https://www.microsoft.com/microsoft-365/business/compare-all-microsoft-365-business-products-g).
-
 ## Create your add-in project
 
 [!include[Yeoman generator create project guidance](../includes/yo-office-command-guidance.md)]


### PR DESCRIPTION
The quickstart-yo-prerequisites include file that precedes all of these references already includes a line about needing Office.