### PR TITLE
[all hosts] (yo office) Remove warning about Node v20 support

### DIFF
--- a/docs/excludes/outlook-quickstart-json-manifest-typescript.md
+++ b/docs/excludes/outlook-quickstart-json-manifest-typescript.md
@@ -46,8 +46,6 @@ You can create an Office Add-in with the unified manifest by using the [Yeoman g
 
     After you complete the wizard, the generator will create the project and install supporting Node components.
 
-    [!include[Node.js version 20 warning](../includes/node-20-warning-note.md)]
-
     [!include[Yeoman generator next steps](../includes/yo-office-next-steps.md)]
 
 1. Navigate to the root folder of the web application project.

--- a/docs/includes/node-20-warning-note.md
+++ b/docs/includes/node-20-warning-note.md
@@ -1,2 +1,0 @@
-> [!NOTE]
-> If you're using Node.js version 20.0.0 or later, you may see a warning when the generator runs the installation that you have an unsupported engine. We're working on a fix for this. In the meantime, the warning doesn't affect the generator or the project you generate, so it can be ignored.

--- a/docs/quickstarts/excel-quickstart-jquery.md
+++ b/docs/quickstarts/excel-quickstart-jquery.md
@@ -33,8 +33,6 @@ In this article, you'll walk through the process of building an Excel task pane 
 
 After you complete the wizard, the generator creates the project and installs supporting Node components.
 
-[!include[Node.js version 20 warning](../includes/node-20-warning-note.md)]
-
 [!include[Yeoman generator next steps](../includes/yo-office-next-steps.md)]
 
 ### Explore the project

--- a/docs/quickstarts/excel-quickstart-react.md
+++ b/docs/quickstarts/excel-quickstart-react.md
@@ -27,8 +27,6 @@ In this article, you'll walk through the process of building an Excel task pane 
 
 After you complete the wizard, the generator creates the project and installs supporting Node components.
 
-[!include[Node.js version 20 warning](../includes/node-20-warning-note.md)]
-
 [!include[Yeoman generator next steps](../includes/yo-office-next-steps.md)]
 
 ## Explore the project

--- a/docs/quickstarts/onenote-quickstart.md
+++ b/docs/quickstarts/onenote-quickstart.md
@@ -27,8 +27,6 @@ In this article, you'll walk through the process of building a OneNote task pane
 
 After you complete the wizard, the generator creates the project and installs supporting Node components.
 
-[!include[Node.js version 20 warning](../includes/node-20-warning-note.md)]
-
 [!include[Yeoman generator next steps](../includes/yo-office-next-steps.md)]
 
 ## Explore the project

--- a/docs/quickstarts/outlook-quickstart.md
+++ b/docs/quickstarts/outlook-quickstart.md
@@ -46,8 +46,6 @@ You can create an Office Add-in by using the Yeoman generator for Office Add-ins
 
     After you complete the wizard, the generator will create the project and install supporting Node components.
 
-    [!include[Node.js version 20 warning](../includes/node-20-warning-note.md)]
-
     [!include[Yeoman generator next steps](../includes/yo-office-next-steps.md)]
 
 1. Navigate to the root folder of the web application project.

--- a/docs/quickstarts/powerpoint-quickstart.md
+++ b/docs/quickstarts/powerpoint-quickstart.md
@@ -33,8 +33,6 @@ In this article, you'll walk through the process of building a PowerPoint task p
 
 After you complete the wizard, the generator creates the project and installs supporting Node components.
 
-[!include[Node.js version 20 warning](../includes/node-20-warning-note.md)]
-
 [!include[Yeoman generator next steps](../includes/yo-office-next-steps.md)]
 
 ### Explore the project

--- a/docs/quickstarts/project-quickstart.md
+++ b/docs/quickstarts/project-quickstart.md
@@ -29,8 +29,6 @@ In this article, you'll walk through the process of building a Project task pane
 
 After you complete the wizard, the generator creates the project and installs supporting Node components.
 
-[!include[Node.js version 20 warning](../includes/node-20-warning-note.md)]
-
 [!include[Yeoman generator next steps](../includes/yo-office-next-steps.md)]
 
 ## Explore the project

--- a/docs/quickstarts/sso-quickstart.md
+++ b/docs/quickstarts/sso-quickstart.md
@@ -43,8 +43,6 @@ In this article, you'll use the Yeoman generator for Office Add-ins to create an
 
 After you complete the wizard, the generator creates the project and installs supporting Node components.
 
-[!include[Node.js version 20 warning](../includes/node-20-warning-note.md)]
-
 [!include[Yeoman generator next steps](../includes/yo-office-next-steps.md)]
 
 ## Explore the project

--- a/docs/quickstarts/word-quickstart.md
+++ b/docs/quickstarts/word-quickstart.md
@@ -33,8 +33,6 @@ In this article, you'll walk through the process of building a Word task pane ad
 
 After you complete the wizard, the generator creates the project and installs supporting Node components.
 
-[!include[Node.js version 20 warning](../includes/node-20-warning-note.md)]
-
 [!include[Yeoman generator next steps](../includes/yo-office-next-steps.md)]
 
 ### Explore the project

--- a/docs/tutorials/excel-tutorial-create-custom-functions.md
+++ b/docs/tutorials/excel-tutorial-create-custom-functions.md
@@ -39,8 +39,6 @@ In this tutorial, you will:
 
     The Yeoman generator will create the project files and install supporting Node components.
 
-    [!include[Node.js version 20 warning](../includes/node-20-warning-note.md)]
-
     [!include[Yeoman generator next steps](../includes/yo-office-next-steps.md)]
 
 1. Navigate to the root folder of the project.

--- a/docs/tutorials/excel-tutorial.md
+++ b/docs/tutorials/excel-tutorial.md
@@ -42,8 +42,6 @@ In this tutorial, you'll create an Excel task pane add-in that:
 
 After you complete the wizard, the generator creates the project and installs supporting Node components. You may need to manually run `npm install` in the root folder of your project if something fails during the initial setup.
 
-[!include[Node.js version 20 warning](../includes/node-20-warning-note.md)]
-
 [!include[Yeoman generator next steps](../includes/yo-office-next-steps.md)]
 
 ## Create a table

--- a/docs/tutorials/outlook-tutorial.md
+++ b/docs/tutorials/outlook-tutorial.md
@@ -130,8 +130,6 @@ The add-in that you'll create in this tutorial will read [gists](https://gist.gi
 
     After you complete the wizard, the generator creates the project and installs supporting Node components.
 
-    [!include[Node.js version 20 warning](../includes/node-20-warning-note.md)]
-
     [!include[Yeoman generator next steps](../includes/yo-office-next-steps.md)]
 
 1. Navigate to the root directory of the project.

--- a/docs/tutorials/powerpoint-tutorial.md
+++ b/docs/tutorials/powerpoint-tutorial.md
@@ -47,8 +47,6 @@ In this tutorial, you'll use Visual Studio Code (VS Code), Visual Studio, or you
 
 After you complete the wizard, the generator creates the project and installs supporting Node components.
 
-[!include[Node.js version 20 warning](../includes/node-20-warning-note.md)]
-
 [!include[Yeoman generator next steps](../includes/yo-office-next-steps.md)]
 
 ### Complete setup

--- a/docs/tutorials/word-tutorial.md
+++ b/docs/tutorials/word-tutorial.md
@@ -41,8 +41,6 @@ In this tutorial, you'll create a Word task pane add-in that:
 
 After you complete the wizard, the generator creates the project and installs supporting Node components.
 
-[!include[Node.js version 20 warning](../includes/node-20-warning-note.md)]
-
 [!include[Yeoman generator next steps](../includes/yo-office-next-steps.md)]
 
 ## Insert a range of text


### PR DESCRIPTION
I haven't seen this warning about Node.js version 20 not being supported. I think the underlying yo office bits have updated. As such, we should remove this note in the docs.