### PR TITLE
[all hosts] Add stop/uninstall instructions to non quick starts

### DIFF
--- a/docs/develop/configure-your-add-in-to-use-a-shared-runtime.md
+++ b/docs/develop/configure-your-add-in-to-use-a-shared-runtime.md
@@ -166,11 +166,17 @@ You can confirm that you are using the shared runtime correctly by using the fol
 
 1. Save your changes and run the project.
 
-   ```command line
+   ```command&nbsp;line
    npm start
    ```
 
 Each time you open the task pane, the count of how many times it has been opened will be incremented. The value of **_count** will not be lost because the shared runtime keeps your code running even when the task pane is closed.
+
+When you're ready to stop the dev server and uninstall the add-in, run the following command.
+
+```command&nbsp;line
+npm stop
+```
 
 ## Runtime lifetime
 

--- a/docs/develop/convert-xml-to-json-manifest.md
+++ b/docs/develop/convert-xml-to-json-manifest.md
@@ -110,6 +110,7 @@ You can sideload the add-in using the Teams Toolkit or in a command prompt, bash
 1. Open a system prompt, bash shell, or the Visual Studio Code **TERMINAL**, and navigate to the root of the project.
 1. Run the command `npm run start:desktop`. The project builds and a Node dev-server window opens. This process may take a couple of minutes then Outlook desktop opens.
 1. You can now work with your add-in.
+1. When you're done working with your add-in, make sure to run the command `npm run stop`.
 
 ### Projects created with the Office Yeoman Generator (aka "Yo Office")
 
@@ -119,10 +120,12 @@ If the project was created with the Office Yeoman Generator and you don't want t
 
     ```command&nbsp;line
     npx office-addin-project convert -m <relative-path-to-XML-manifest>
-    ``` 
-    
+    ```
+
 1. Run `npm install`.
-1. To sideload the add-in, run `npm run start:desktop`. This command puts the unified manifest and the two image files into a zip file and sideloads it to the Office application. It also starts server in a separate NodeJS window to host the add-in files on localhost.
+1. To sideload the add-in, run `npm run start:desktop`. This command puts the unified manifest and the two image files into a zip file and sideloads it to the Office application. It also starts the server in a separate NodeJS window to host the add-in files on localhost.
+
+When you're ready to stop the dev server and uninstall the add-in, run the command `npm run stop`.
 
 ### NodeJS and npm projects that aren't created with Yeoman Generator
 

--- a/docs/develop/create-sso-office-add-ins-nodejs.md
+++ b/docs/develop/create-sso-office-add-ins-nodejs.md
@@ -417,6 +417,18 @@ The sample must handle both fallback authentication through MSAL and SSO authent
 > [!NOTE]
 > If you were previously signed into Office with a different ID, and some Office applications that were open at the time are still open, Office may not reliably change your ID even if it appears to have done so. If this happens, the call to Microsoft Graph may fail or data from the previous ID may be returned. To prevent this, be sure to _close all other Office applications_ before you press **Get OneDrive File Names**.
 
+## Stop running the project
+
+When you're ready to stop the middle-tier server and uninstall the add-in, follow these instructions:
+
+1. Run the following command to stop the middle-tier server.
+
+    ```command&nbsp;line
+    npm stop
+    ```
+
+1. To uninstall or remove the add-in, see the specific sideload article you used for details.
+
 ## Security notes
 
 - The `/getuserfilenames` route in `getFilesroute.js` uses a literal string to compose the call for Microsoft Graph. If you change the call so that any part of the string comes from user input, sanitize the input so that it cannot be used in a Response header injection attack.

--- a/docs/develop/use-sso-to-get-office-signed-in-user-token.md
+++ b/docs/develop/use-sso-to-get-office-signed-in-user-token.md
@@ -343,6 +343,18 @@ The add-in will display the name, email, and ID of the account you signed in wit
 > [!NOTE]
 > If you encounter any errors, review the registration steps in this article for the app registration. Missing a detail when setting up the app registration is a common cause of issues working with SSO. If you still can't get the add-in to run successfully, see [Troubleshoot error messages for single sign-on (SSO)](troubleshoot-sso-in-office-add-ins.md).
 
+## Stop the add-in
+
+# [Visual Studio 2019](#tab/vs2019)
+
+Choose **Stop Debugging**, or press **Shift+F5**.
+
+# [Yo Office](#tab/yooffice)
+
+Run `npm stop` from the command line.
+
+---
+
 ## See also
 
 [Using claims to reliably identify a user (Subject and Object ID)](/azure/active-directory/develop/id-tokens#using-claims-to-reliably-identify-a-user-subject-and-object-id)

--- a/docs/excel/custom-functions-debugging.md
+++ b/docs/excel/custom-functions-debugging.md
@@ -36,19 +36,19 @@ You can use the browser developer tools to debug custom functions that don't use
 ### Run your add-in from Visual Studio Code
 
 1. Open your custom functions root project folder in [Visual Studio Code (VS Code)](https://code.visualstudio.com/).
-2. Choose **Terminal > Run Task** and type or select **Watch**. This will monitor and rebuild for any file changes.
-3. Choose **Terminal > Run Task** and type or select **Dev Server**.
+1. Choose **Terminal** > **Run Task** and type or select **Watch**. This will monitor and rebuild for any file changes.
+1. Choose **Terminal** > **Run Task** and type or select **Dev Server**.
 
 ### Sideload your add-in
 
 1. Open [Office on the web](https://office.live.com/).
-2. Open a new Excel workbook.
-3. Select **Home** > **Add-ins**, then select **Get Add-ins**.
-4. On the **Office Add-ins** dialog, select the **MY ADD-INS** tab, choose **Manage My Add-ins**, and then **Upload My Add-in**.
+1. Open a new Excel workbook.
+1. Select **Home** > **Add-ins**, then select **Get Add-ins**.
+1. On the **Office Add-ins** dialog, select the **MY ADD-INS** tab, choose **Manage My Add-ins**, and then **Upload My Add-in**.
   
     ![The Office Add-ins dialog with a drop-down in the upper right reading "Manage my add-ins" and a drop-down below it with the option "Upload My Add-in".](../images/office-add-ins-my-account.png)
 
-5. **Browse** to the add-in manifest file, and then select **Upload**.
+1. **Browse** to the add-in manifest file, and then select **Upload**.
   
     ![The upload add-in dialog with buttons for browse, upload, and cancel.](../images/upload-add-in.png)
 
@@ -58,8 +58,8 @@ You can use the browser developer tools to debug custom functions that don't use
 ### Start debugging
 
 1. Open developer tools in the browser. For Chrome and most browsers F12 will open the developer tools.
-2. In developer tools, open your source code script file using **Cmd+P** or **Ctrl+P** (**functions.js** or **functions.ts**).
-3. [Set a breakpoint](https://code.visualstudio.com/Docs/editor/debugging#_breakpoints) in the custom function source code. 
+1. In developer tools, open your source code script file using **Cmd+P** or **Ctrl+P** (**functions.js** or **functions.ts**).
+1. [Set a breakpoint](https://code.visualstudio.com/Docs/editor/debugging#_breakpoints) in the custom function source code. 
 
 If you need to change the code you can make edits in VS Code and save the changes. Refresh the browser to see the changes loaded.
 
@@ -68,9 +68,9 @@ If you need to change the code you can make edits in VS Code and save the change
 If you aren't using VS Code, you can use the command line (such as bash, or PowerShell) to run your add-in. You'll need to use the browser developer tools to debug your code in Excel on the web. You cannot debug the desktop version of Excel using the command line.
 
 1. From the command line run `npm run watch` to watch for and rebuild when code changes occur.
-2. Open a second command line window (the first one will be blocked while running the watch.)
+1. Open a second command line window (the first one will be blocked while running the watch.)
 
-3. If you want to start your add-in in the desktop version of Excel, run the following command.
+1. If you want to start your add-in in the desktop version of Excel, run the following command.
   
     `npm run start:desktop`
   
@@ -82,11 +82,11 @@ If you aren't using VS Code, you can use the command line (such as bash, or Powe
   
     If your add-in doesn't sideload in the document, follow the steps in [Sideload your add-in](#sideload-your-add-in) to sideload your add-in. Then continue to the next section to start debugging.
   
-4. Open developer tools in the browser. For Chrome and most browsers F12 will open the developer tools.
-5. In developer tools, open your source code script file (**functions.js** or **functions.ts**). Your custom functions code may be located near the end of the file.
-6. In the custom function source code, apply a breakpoint by selecting a line of code.
+1. Open developer tools in the browser. For Chrome and most browsers F12 will open the developer tools.
+1. In developer tools, open your source code script file (**functions.js** or **functions.ts**). Your custom functions code may be located near the end of the file.
+1. In the custom function source code, apply a breakpoint by selecting a line of code.
 
-If you need to change the code you can make edits in Visual Studio and save the changes. Refresh the browser to see the changes loaded.
+If you need to change the code, you can make edits in VS Code and save the changes. Refresh the browser to see the changes loaded.
 
 ### Commands for building and running your add-in
 

--- a/docs/excludes/outlook-quickstart-json-manifest-typescript.md
+++ b/docs/excludes/outlook-quickstart-json-manifest-typescript.md
@@ -118,7 +118,7 @@ The add-in project that you've created with the Yeoman generator contains sample
 
 1. Scroll to the bottom of the task pane and choose the **Run** link to copy the message's subject to the task pane.
 
-1. End the debugging session with the following command:
+1. End the debugging session with the following command.
 
     ```command&nbsp;line
     npm stop
@@ -244,7 +244,7 @@ Add a custom button to the ribbon that inserts text into a message body.
 
     The phrase "Hello World" will be inserted at the cursor.
 
-1. End the debugging session with the following command:
+1. End the debugging session with the following command.
 
     ```command&nbsp;line
     npm stop

--- a/docs/outlook/append-on-send.md
+++ b/docs/outlook/append-on-send.md
@@ -430,6 +430,8 @@ In this section, you'll implement the JavaScript code to append a sample company
     > [!TIP]
     > Because content is only prepended or appended once the message is sent, the sender will only be able to view the added content from their **Inbox** or **Sent Items** folder. If you require the sender to view the added content before the message is sent, see [Insert data in the body when composing an appointment or message in Outlook](insert-data-in-the-body.md).
 
+1. [!include[Instructions to stop web server and uninstall dev add-in](../includes/stop-uninstall-outlook-dev-add-in.md)]
+
 ## Review feature behavior and limitations
 
 As you implement prepend-on-send and append-on-send in your add-in, keep the following in mind.

--- a/docs/outlook/contextless.md
+++ b/docs/outlook/contextless.md
@@ -210,7 +210,7 @@ To activate your add-in with the Reading Pane turned off or without a message se
 
 1. From a terminal, run the following code in the root directory of your project. This starts the local web server and sideloads your add-in.
 
-    ```command line
+    ```command&nbsp;line
     npm start
     ```
 
@@ -225,6 +225,8 @@ To activate your add-in with the Reading Pane turned off or without a message se
 1. Select **Show Taskpane** from the ribbon.
 
 1. Explore and test the suggestions listed in the task pane.
+
+1. [!include[Instructions to stop web server and uninstall dev add-in](../includes/stop-uninstall-outlook-dev-add-in.md)]
 
 ## Support for the item multi-select and pinnable task pane features
 

--- a/docs/outlook/item-multi-select.md
+++ b/docs/outlook/item-multi-select.md
@@ -251,7 +251,7 @@ Now that you've registered an event handler, you then call the [getSelectedItems
 
 1. From a terminal, run the following code in the root directory of your project. This starts the local web server and sideloads your add-in.
 
-    ```command line
+    ```command&nbsp;line
     npm start
     ```
 
@@ -267,6 +267,8 @@ Now that you've registered an event handler, you then call the [getSelectedItems
 1. In the task pane, select **Run** to view a list of the selected messages' subject lines.
 
     :::image type="content" source="../images/outlook-multi-select.png" alt-text="A sample list of subject lines retrieved from multiple selected messages.":::
+
+1. [!include[Instructions to stop web server and uninstall dev add-in](../includes/stop-uninstall-outlook-dev-add-in.md)]
 
 ## Item multi-select behavior and limitations
 

--- a/docs/outlook/on-new-compose-events-walkthrough.md
+++ b/docs/outlook/on-new-compose-events-walkthrough.md
@@ -332,6 +332,8 @@ In event-based add-ins, classic Outlook on Windows uses a JavaScript file, while
 
     ![A message window in classic Outlook on Windows with the subject set on compose.](../images/outlook-win-autolaunch.png)
 
+1. [!include[Instructions to stop web server and uninstall dev add-in](../includes/stop-uninstall-outlook-dev-add-in.md)]
+
 ## Next steps
 
 To learn more about event-based activation and other events that you can implement in your add-in, see [Configure your Outlook add-in for event-based activation](autolaunch.md).

--- a/docs/outlook/onmessagefromchanged-onappointmentfromchanged-events.md
+++ b/docs/outlook/onmessagefromchanged-onappointmentfromchanged-events.md
@@ -405,6 +405,8 @@ Event handlers must be configured for the `OnNewMessageCompose` and `OnMessageFr
 
    :::image type="content" source="../images/OnMessageFromChanged_update_signature.png" alt-text="A sample of an updated signature with a logo when the account in the From field is changed.":::
 
+1. [!include[Instructions to stop web server and uninstall dev add-in](../includes/stop-uninstall-outlook-dev-add-in.md)]
+
 ## Troubleshoot your add-in
 
 For guidance on how to troubleshoot your event-based activation add-in, see [Troubleshoot event-based and spam-reporting add-ins](troubleshoot-event-based-and-spam-reporting-add-ins.md).

--- a/docs/outlook/sideload-outlook-add-ins-for-testing.md
+++ b/docs/outlook/sideload-outlook-add-ins-for-testing.md
@@ -90,9 +90,11 @@ To learn how to access a sideloaded add-in in your Outlook client, see [Use add-
 
 ## Remove a sideloaded add-in
 
-On all versions of Outlook, the key to removing a sideloaded add-in is the **Add-Ins for Outlook** dialog, which lists your installed add-ins. To access the dialog on your Outlook client, use the steps listed for [manual sideloading](#sideload-manually) in the previous section of this article.
+If you ran the `npm start` command and your add-in was automatically sideloaded, then run the command `npm stop` when you're ready to stop the dev server and uninstall your add-in. If you ran `npm run start`, then run the command `npm run stop` instead.
 
-To remove a sideloaded add-in from Outlook, in the **Add-Ins for Outlook** dialog, navigate to the **Custom Addins** section. Choose the ellipsis (`...`) for the add-in, then choose **Remove**.
+Otherwise, on all versions of Outlook, the key to removing a sideloaded add-in is the **Add-Ins for Outlook** dialog, which lists your installed add-ins. To access the dialog on your Outlook client, use the steps listed for [manual sideloading](#sideload-manually) in the previous section of this article.
+
+To manually remove a sideloaded add-in from Outlook, in the **Add-Ins for Outlook** dialog, navigate to the **Custom Addins** section. Choose the ellipsis (`...`) for the add-in, then choose **Remove**.
 
 ## See also
 

--- a/docs/outlook/smart-alerts-onmessagesend-walkthrough.md
+++ b/docs/outlook/smart-alerts-onmessagesend-walkthrough.md
@@ -656,6 +656,8 @@ If you implemented the optional steps to customize the **Don't Send** button or 
 
 1. Send the message. There should be no alert this time.
 
+1. [!include[Instructions to stop web server and uninstall dev add-in](../includes/stop-uninstall-outlook-dev-add-in.md)]
+
 ### Try out overriding the send mode option at runtime (optional)
 
 If you implemented the optional step to override the send mode option at runtime, perform the following to try it out.

--- a/docs/overview/create-an-office-add-in-from-script-lab.md
+++ b/docs/overview/create-an-office-add-in-from-script-lab.md
@@ -161,6 +161,12 @@ npm start
 
 Office will start and you can open the task pane for your add-in from the ribbon. Congratulations! Now you can continue building your add-in as a standalone project.
 
+When you're ready to stop the dev server and uninstall the add-in, run the following command.
+
+```command&nbsp;line
+npm stop
+```
+
 ## Console logging
 
 Many snippets in Script Lab write output to a console section at the bottom of the task pane. The Yo Office project doesn't have a console section. All `console.log*` statements will write to the default debug console (such as your browser developer tools). If you want the output to go to your task pane, you'll need to update the code.

--- a/docs/quickstarts/fluent-react-quickstart.md
+++ b/docs/quickstarts/fluent-react-quickstart.md
@@ -100,7 +100,13 @@ The add-in project that you've created with the Yeoman generator contains sample
 
 1. Enter text into the text box and then select **Insert text**.
 
-![Custom text inserted into the document after selecting the Insert button from the add-in task pane.](../images/word-task-pane-react-component.png)
+    ![Custom text inserted into the document after selecting the Insert button from the add-in task pane.](../images/word-task-pane-react-component.png)
+
+1. When you're ready to stop the dev server and uninstall the add-in, run the following command.
+
+    ```command&nbsp;line
+    npm stop
+    ```
 
 ## Migrate to Fluent UI React v9
 

--- a/docs/testing/sideload-office-add-ins-for-testing.md
+++ b/docs/testing/sideload-office-add-ins-for-testing.md
@@ -96,7 +96,9 @@ This method doesn't use the command line and can be accomplished using commands 
 
 ## Remove a sideloaded add-in
 
-To remove an add-in sideloaded to Office on the web, simply clear your browser's cache. If you make changes to your add-in's manifest (for example, update file names of icons or text of add-in commands), you may need to clear your browser's cache and then re-sideload the add-in using the updated manifest. Doing so allows Office on the web to render the add-in as it's described by the updated manifest.
+If you ran the `npm start` command and your add-in was automatically sideloaded, then run `npm stop` when you're ready to stop the dev server and uninstall your add-in.
+
+Otherwise, to remove an add-in sideloaded to Office on the web, simply clear your browser's cache. If you make changes to your add-in's manifest (for example, update file names of icons or text of add-in commands), you may need to clear your browser's cache and then re-sideload the add-in using the updated manifest. Doing so allows Office on the web to render the add-in as it's described by the updated manifest.
 
 ## See also
 

--- a/docs/tutorials/excel-tutorial.md
+++ b/docs/tutorials/excel-tutorial.md
@@ -201,6 +201,8 @@ In this step of the tutorial, you'll programmatically test that your add-in supp
 
     ![Excel displaying an add-in task pane with a Create Table button, and a table in the worksheet populated with Date, Merchant, Category, and Amount data.](../images/excel-tutorial-create-table-2.png)
 
+1. [!include[Instructions to stop web server and uninstall dev add-in](../includes/stop-uninstall-dev-add-in.md)]
+
 ## Filter and sort a table
 
 In this step of the tutorial, you'll filter and sort the table that you created previously.

--- a/docs/tutorials/outlook-tutorial.md
+++ b/docs/tutorials/outlook-tutorial.md
@@ -215,6 +215,8 @@ Before going any further, let's test the basic add-in that the generator created
 
     ![The Show Taskpane button and Git the gist task pane added by the sample.](../images/button-and-pane.png)
 
+1. [!include[Instructions to stop web server and uninstall dev add-in](../includes/stop-uninstall-outlook-dev-add-in.md)]
+
 ## Define buttons
 
 Now that you've verified the base add-in works, you can customize it to add more functionality. By default, the manifest only defines buttons for the read message window. Let's update the manifest to remove the buttons from the read message window and define two new buttons for the compose message window:

--- a/docs/tutorials/powerpoint-tutorial.md
+++ b/docs/tutorials/powerpoint-tutorial.md
@@ -237,6 +237,8 @@ Complete the following steps to add code that inserts an image into a slide.
 
     ![The PowerPoint add-in with the Insert Image button highlighted.](../images/powerpoint-tutorial-yo-insert-image-button.png)
 
+1. [!include[Instructions to stop web server and uninstall dev add-in](../includes/stop-uninstall-dev-add-in.md)]
+
 ## Customize user interface (UI) elements
 
 Complete the following steps to add markup that customizes the task pane UI.

--- a/docs/tutorials/share-data-and-events-between-custom-functions-and-the-task-pane-tutorial.md
+++ b/docs/tutorials/share-data-and-events-between-custom-functions-and-the-task-pane-tutorial.md
@@ -113,7 +113,7 @@ The following instructions show how to share a global variable between custom fu
 
 - Start the project by using the following command.
 
-    ```command line
+    ```command&nbsp;line
     npm run start
     ```
 
@@ -121,6 +121,12 @@ Once Excel starts, you can use the task pane buttons to store or get shared data
 
 > [!NOTE]
 > Calling some Office APIs from custom functions using a shared runtime is possible. [See Call Microsoft Excel APIs from a custom function](../excel/call-excel-apis-from-custom-function.md) for more details.
+
+When you're ready to stop the dev server and uninstall the add-in, run the following command.
+
+```command&nbsp;line
+npm run stop
+```
 
 ## See also
 

--- a/docs/tutorials/word-tutorial.md
+++ b/docs/tutorials/word-tutorial.md
@@ -157,6 +157,8 @@ In this step of the tutorial, you'll programmatically test that your add-in supp
 
     ![The Insert Paragraph button in the add-in.](../images/word-tutorial-insert-paragraph-2.png)
 
+1. [!include[Instructions to stop web server and uninstall dev add-in](../includes/stop-uninstall-dev-add-in.md)]
+
 ## Format text
 
 In this step of the tutorial, you'll apply a built-in style to text, apply a custom style to text, and change the font of text.


### PR DESCRIPTION
Already added stop / uninstall instructions to quick starts. Now adding instructions for other places that use `npm start` or `npm run start`.