### PR TITLE
[All Hosts] (manifest) Tooltip only supported in Outlook Group

### DIFF
--- a/docs/develop/create-addin-commands.md
+++ b/docs/develop/create-addin-commands.md
@@ -1,7 +1,7 @@
 ---
 title: Create add-in commands with the add-in only manifest
 description: Configure an add-in only manifest to define add-in commands for Excel, Outlook, PowerPoint, and Word. Use add-in commands to create UI elements, add buttons or menus, and perform actions.
-ms.date: 02/29/2024
+ms.date: 09/05/2024
 ms.localizationpriority: medium
 ---
 
@@ -129,7 +129,6 @@ The following examples show how to use the **\<ExtensionPoint\>** element with *
         <bt:Image size="32" resid="icon1_32x32" />
         <bt:Image size="80" resid="icon1_32x32" />
       </Icon>
-      <Tooltip resid="residToolTip" />
       <Control xsi:type="Button" id="Button1Id1">
 
         <!-- information about the control -->
@@ -163,7 +162,6 @@ A [button control](/javascript/api/manifest/control-button) performs a single ac
 <!-- Define a control that calls a JavaScript function. -->
 <Control xsi:type="Button" id="Button1Id1">
   <Label resid="residLabel" />
-  <Tooltip resid="residToolTip" />
   <Supertip>
     <Title resid="residLabel" />
     <Description resid="residToolTip" />
@@ -181,7 +179,6 @@ A [button control](/javascript/api/manifest/control-button) performs a single ac
 <!-- Define a control that shows a task pane. -->
 <Control xsi:type="Button" id="Button2Id1">
   <Label resid="residLabel2" />
-  <Tooltip resid="residToolTip" />
   <Supertip>
     <Title resid="residLabel" />
     <Description resid="residToolTip" />
@@ -246,7 +243,6 @@ The following example shows how to define a menu item with two submenu items. Th
 ```xml
 <Control xsi:type="Menu" id="TestMenu2">
   <Label resid="residLabel3" />
-  <Tooltip resid="residToolTip" />
   <Supertip>
     <Title resid="residLabel" />
     <Description resid="residToolTip" />

--- a/docs/develop/manifest-element-ordering.md
+++ b/docs/develop/manifest-element-ordering.md
@@ -1,7 +1,7 @@
 ---
 title: How to find the proper order of manifest elements
 description: Learn how to find the correct order in which to place child elements in a parent element.
-ms.date: 03/20/2023
+ms.date: 09/5/2024
 ms.localizationpriority: medium
 ---
 
@@ -204,7 +204,7 @@ The following sections show the manifest elements in the order in which they mus
                                     <Title>
                                     <FunctionName>
                     <CustomTab>
-                        <Group> (can be below <ControlGroup>)
+                        <Group>
                             <OverriddenByRibbonApi>
                             <Label>
                             <Icon>
@@ -235,7 +235,6 @@ The following sections show the manifest elements in the order in which they mus
                                             <SourceLocation>
                                             <Title>
                                             <FunctionName>
-                        <ControlGroup> (can be above <Group>)
                         <Label>
                         <InsertAfter> (or <InsertBefore>)
                     <OfficeMenu>
@@ -400,6 +399,7 @@ The following sections show the manifest elements in the order in which they mus
                 <OfficeTab>
                     <Group>
                         <Label>
+                        <Tooltip>
                         <Control>
                             <Label>
                             <Supertip>


### PR DESCRIPTION
1. Partially fixes verbatim. There will also be a correlative PR in the -reference repo. The `<Tooltip>` element is only supported in Outlook and only as a child of `<Group>`. 
2. Also removing mention of **entirely mythical** `<ControlGroup>` element that I added 4 years ago. I have absolutely no record or memory of why I did. 