### PR TITLE
[all hosts] Remove extra param from convert command

### DIFF
--- a/docs/develop/convert-xml-to-json-manifest.md
+++ b/docs/develop/convert-xml-to-json-manifest.md
@@ -134,7 +134,7 @@ If you don't want to use the Teams Toolkit and your project wasn't created with 
 In the root of the project, open a command prompt or bash shell and run the following command. This command puts the unified manifest in a subfolder with the same name as the filename stem of the original add-in only manifest. For example, if the manifest is named **MyManifest.xml**, the unified manifest is created at **.\MyManifest\MyManifest.json**. For more details about this command, see [Office-Addin-Manifest-Converter](https://www.npmjs.com/package/office-addin-manifest-converter).
 
 ```command&nbsp;line
-npx office-addin-manifest-converter convert -m <relative-path-to-XML-manifest>
+npx office-addin-manifest-converter convert <relative-path-to-XML-manifest>
 ```
 
 Once you have the unified manifest created, there are two ways to create the zip file and sideload it. They are described in the next two subsections.


### PR DESCRIPTION
I tried `npx office-addin-manifest-converter convert -m <relative-path-to-XML-manifest>` but I got an error message "error: unknown option '-m'". When I checked the [npm package docs](https://www.npmjs.com/package/office-addin-manifest-converter), there's no '-m'. I tried without '-m' then the command succeeded.