### PR TITLE
[Outlook] (Script Lab) Remove note about Script Lab not working on the web

### DIFF
--- a/docs/includes/script-lab-outlook-web.md
+++ b/docs/includes/script-lab-outlook-web.md
@@ -1,2 +1,0 @@
-> [!NOTE]
-> Starting in Version 115 of Chromium-based browsers, such as Chrome and Edge, [storage partitioning](https://developers.google.com/privacy-sandbox/3pcd/storage-partitioning) is enabled to prevent specific side-channel cross-site tracking (see also [Microsoft Edge browser policies](/deployedge/microsoft-edge-policies#defaultthirdpartystoragepartitioningsetting)). This change is preventing Script Lab snippets from running in Outlook on the web.

--- a/docs/outlook/delay-delivery.md
+++ b/docs/outlook/delay-delivery.md
@@ -76,8 +76,6 @@ Get the [Script Lab for Outlook add-in](https://appsource.microsoft.com/product/
 
 :::image type="content" source="../images/outlook-delay-delivery-script-lab.png" alt-text="The message delivery sample snippet in Script Lab.":::
 
-[!INCLUDE [script-lab-outlook-web](../includes/script-lab-outlook-web.md)]
-
 ## See also
 
 - [Create Outlook add-ins for compose forms](compose-scenario.md)

--- a/docs/outlook/get-and-set-recurrence.md
+++ b/docs/outlook/get-and-set-recurrence.md
@@ -201,8 +201,6 @@ To learn more about Script Lab, see [Explore Office JavaScript API using Script 
 
 :::image type="content" source="../images/outlook-recurrence-script-lab.png" alt-text="The recurrence sample snippet in Script Lab.":::
 
-[!INCLUDE [script-lab-outlook-web](../includes/script-lab-outlook-web.md)]
-
 ## See also
 
 - [RecurrenceChanged event](/javascript/api/office/office.eventtype)

--- a/docs/overview/explore-with-script-lab.md
+++ b/docs/overview/explore-with-script-lab.md
@@ -1,7 +1,7 @@
 ---
 title: Explore Office JavaScript API using Script Lab
 description: Use Script Lab to explore the Office JS API and to prototype functionality.
-ms.date: 06/14/2024
+ms.date: 09/05/2024
 ms.topic: concept-article
 ms.custom: scenarios:getting-started
 ms.localizationpriority: high
@@ -62,9 +62,6 @@ Script Lab is supported for Excel, Word, and PowerPoint on the following clients
 Script Lab for Outlook is available on the following clients.
 
 - Outlook on the web when using Chrome, Microsoft Edge, or Safari browsers
-
-    [!INCLUDE [script-lab-outlook-web](../includes/script-lab-outlook-web.md)]
-
 - Outlook on Windows\*
 - Outlook on Mac
 

--- a/docs/overview/set-up-your-dev-environment.md
+++ b/docs/overview/set-up-your-dev-environment.md
@@ -149,8 +149,6 @@ Install the latest version of Visual Studio from [Visual Studio Downloads](https
 
 Script Lab is a tool for quickly prototyping code that calls the Office JavaScript Library APIs. Script Lab is itself an Office Add-in and can be installed from AppSource at [Script Lab](https://appsource.microsoft.com/marketplace/apps?search=script%20lab&page=1). There's a version for Excel, PowerPoint, and Word, and a separate version for Outlook. For information about how to use Script Lab, see [Explore Office JavaScript API using Script Lab](explore-with-script-lab.md).
 
-[!INCLUDE [script-lab-outlook-web](../includes/script-lab-outlook-web.md)]
-
 ## Next steps
 
 Try creating your own add-in or use [Script Lab](explore-with-script-lab.md) to try built-in samples.


### PR DESCRIPTION
Script Lab was recently updated to overcome the documented challenge around storage partitioning. Since the add-in now works on Outlook on the web, this PR removes the note indicating it does not. 