### PR TITLE
Update Fabric Core URLs which were blocked by CORS policy

### DIFF
--- a/docs/design/fabric-core.md
+++ b/docs/design/fabric-core.md
@@ -22,7 +22,7 @@ If your add-in's UI isn't React-based, you can also make use of a set of non-Rea
 1. Add the content delivery network (CDN) reference to the HTML on your page.
 
     ```html
-    <link rel="stylesheet" href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/9.6.1/css/fabric.min.css">
+    <link rel="stylesheet" href="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-core/9.6.1/css/fabric.min.css">
     ```
 
 2. Use Fabric Core icons and fonts.

--- a/docs/design/fabric-core.md
+++ b/docs/design/fabric-core.md
@@ -22,7 +22,7 @@ If your add-in's UI isn't React-based, you can also make use of a set of non-Rea
 1. Add the content delivery network (CDN) reference to the HTML on your page.
 
     ```html
-    <link rel="stylesheet" href="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-core/9.6.1/css/fabric.min.css">
+    <link rel="stylesheet" href="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-core/11.0.0/css/fabric.min.css">
     ```
 
 2. Use Fabric Core icons and fonts.

--- a/docs/tutorials/excel-tutorial.md
+++ b/docs/tutorials/excel-tutorial.md
@@ -726,7 +726,7 @@ In this final step of the tutorial, you'll open a dialog in your add-in, pass a 
             <meta name="viewport" content="width=device-width, initial-scale=1">
 
             <!-- For more information on Fluent UI, visit https://developer.microsoft.com/fluentui. -->
-            <link rel="stylesheet" href="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-core/9.6.1/css/fabric.min.css"/>
+            <link rel="stylesheet" href="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-core/11.0.0/css/fabric.min.css"/>
 
             <script type="text/javascript" src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js"></script>
             <script type="text/javascript" src="popup.js"></script>

--- a/docs/tutorials/excel-tutorial.md
+++ b/docs/tutorials/excel-tutorial.md
@@ -726,7 +726,7 @@ In this final step of the tutorial, you'll open a dialog in your add-in, pass a 
             <meta name="viewport" content="width=device-width, initial-scale=1">
 
             <!-- For more information on Fluent UI, visit https://developer.microsoft.com/fluentui. -->
-            <link rel="stylesheet" href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/9.6.1/css/fabric.min.css"/>
+            <link rel="stylesheet" href="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-core/9.6.1/css/fabric.min.css"/>
 
             <script type="text/javascript" src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js"></script>
             <script type="text/javascript" src="popup.js"></script>

--- a/docs/tutorials/outlook-tutorial.md
+++ b/docs/tutorials/outlook-tutorial.md
@@ -524,7 +524,7 @@ Let's start by creating the UI for the dialog.
       <script type="text/javascript" src="https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js"></script>
     
     <!-- For more information on Fluent UI, visit https://developer.microsoft.com/fluentui. -->
-      <link rel="stylesheet" href="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-core/9.6.1/css/fabric.min.css"/>
+      <link rel="stylesheet" href="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-core/11.0.0/css/fabric.min.css"/>
     
       <!-- Template styles -->
       <link href="dialog.css" rel="stylesheet" type="text/css" />
@@ -1213,7 +1213,7 @@ This add-in's **Insert gist** button opens a task pane and displays the user's g
         <script type="text/javascript" src="https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js"></script>
     
        <!-- For more information on Fluent UI, visit https://developer.microsoft.com/fluentui. -->
-        <link rel="stylesheet" href="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-core/9.6.1/css/fabric.min.css"/>
+        <link rel="stylesheet" href="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-core/11.0.0/css/fabric.min.css"/>
     
         <!-- Template styles -->
         <link href="taskpane.css" rel="stylesheet" type="text/css" />

--- a/docs/tutorials/outlook-tutorial.md
+++ b/docs/tutorials/outlook-tutorial.md
@@ -524,7 +524,7 @@ Let's start by creating the UI for the dialog.
       <script type="text/javascript" src="https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js"></script>
     
     <!-- For more information on Fluent UI, visit https://developer.microsoft.com/fluentui. -->
-      <link rel="stylesheet" href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/9.6.1/css/fabric.min.css"/>
+      <link rel="stylesheet" href="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-core/9.6.1/css/fabric.min.css"/>
     
       <!-- Template styles -->
       <link href="dialog.css" rel="stylesheet" type="text/css" />
@@ -1213,7 +1213,7 @@ This add-in's **Insert gist** button opens a task pane and displays the user's g
         <script type="text/javascript" src="https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js"></script>
     
        <!-- For more information on Fluent UI, visit https://developer.microsoft.com/fluentui. -->
-        <link rel="stylesheet" href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/9.6.1/css/fabric.min.css"/>
+        <link rel="stylesheet" href="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-core/9.6.1/css/fabric.min.css"/>
     
         <!-- Template styles -->
         <link href="taskpane.css" rel="stylesheet" type="text/css" />


### PR DESCRIPTION
This PR updates the stylesheet URLs for Fabric Core, in alignment with the current [Fabric Core documentation](https://developer.microsoft.com/en-us/fluentui#/get-started/web#fabric-core).

Sometime on 2024-09-18 the CORS policy changed for the files hosted on https://static2.sharepointonline.com.
![CORS-block](https://github.com/user-attachments/assets/d0c83923-9562-41ec-8c42-47b0beafb653)
This caused a broad outage for our Outlook Addin and users were prevented from sending specific emails. It would appear that the CORS policy has been reverted for now.