### PR TITLE
Update landing page

### DIFF
--- a/docs/onenote/index.yml
+++ b/docs/onenote/index.yml
@@ -77,7 +77,7 @@ landingContent:
           - text: Report issues
             url: https://github.com/officedev/office-js/issues
           - text: Join Office Add-ins community call
-            url: https://aka.ms/M365DevCalls
+            url: https://learn.microsoft.com/office/dev/add-ins/overview/office-add-ins-community-call
           - text: Office Add-ins additional resources
             url: ../resources/resources-links-help.md
           - text: Join the developer community

--- a/docs/onenote/index.yml
+++ b/docs/onenote/index.yml
@@ -80,7 +80,5 @@ landingContent:
             url: https://learn.microsoft.com/office/dev/add-ins/overview/office-add-ins-community-call
           - text: Office Add-ins additional resources
             url: ../resources/resources-links-help.md
-          - text: Join the developer community
-            url: https://pnp.github.io/
           - text: Download OneNote samples
             url: https://developer.microsoft.com/microsoft-365/gallery/?search=&filterBy=OneNote,Samples         

--- a/docs/onenote/index.yml
+++ b/docs/onenote/index.yml
@@ -66,7 +66,7 @@ landingContent:
             url: ../publish/publish.md
             
   # Card (optional)
-  - title: OneNote Developer Resources
+  - title: Resources
     linkLists:
       - linkListType: reference
         links:

--- a/docs/onenote/index.yml
+++ b/docs/onenote/index.yml
@@ -66,19 +66,21 @@ landingContent:
             url: ../publish/publish.md
             
   # Card (optional)
-  - title: OneNote developer resources
+  - title: OneNote Developer Resources
     linkLists:
       - linkListType: reference
         links:
+          - text: Ask questions
+            url: https://stackoverflow.com/questions/tagged/office-js
+          - text: Request features
+            url: https://feedbackportal.microsoft.com/feedback/forum/c06dcc30-2e1c-ec11-b6e7-0022481f8472
+          - text: Report issues
+            url: https://github.com/officedev/office-js/issues
+          - text: Join Office Add-ins community call
+            url: https://aka.ms/M365DevCalls
           - text: Office Add-ins additional resources
             url: ../resources/resources-links-help.md
           - text: Join the developer community
             url: https://pnp.github.io/
           - text: Download OneNote samples
             url: https://developer.microsoft.com/microsoft-365/gallery/?search=&filterBy=OneNote,Samples         
-          - text: Join Office Add-ins community call
-            url: https://aka.ms/M365DevCalls
-          - text: Read Office Add-ins blog
-            url: https://devblogs.microsoft.com/microsoft365dev/category/office-add-ins/
-          - text: Submit feedback or idea
-            url: https://feedbackportal.microsoft.com/feedback/forum/c06dcc30-2e1c-ec11-b6e7-0022481f8472

--- a/docs/onenote/index.yml
+++ b/docs/onenote/index.yml
@@ -64,7 +64,21 @@ landingContent:
             url: ../testing/test-debug-office-add-ins.md
           - text: Deploy and publish a OneNote add-in
             url: ../publish/publish.md
+            
+  # Card (optional)
+  - title: OneNote developer resources
+    linkLists:
       - linkListType: reference
         links:
           - text: Office Add-ins additional resources
             url: ../resources/resources-links-help.md
+          - text: Join the developer community
+            url: https://pnp.github.io/
+          - text: Download OneNote samples
+            url: https://developer.microsoft.com/microsoft-365/gallery/?search=&filterBy=OneNote,Samples         
+          - text: Join Office Add-ins community call
+            url: https://aka.ms/M365DevCalls
+          - text: Read Office Add-ins blog
+            url: https://devblogs.microsoft.com/microsoft365dev/category/office-add-ins/
+          - text: Submit feedback or idea
+            url: https://feedbackportal.microsoft.com/feedback/forum/c06dcc30-2e1c-ec11-b6e7-0022481f8472

--- a/docs/onenote/index.yml
+++ b/docs/onenote/index.yml
@@ -80,5 +80,5 @@ landingContent:
             url: https://learn.microsoft.com/office/dev/add-ins/overview/office-add-ins-community-call
           - text: Office Add-ins additional resources
             url: ../resources/resources-links-help.md
-          - text: Download OneNote samples
+          - text: Download samples
             url: https://developer.microsoft.com/microsoft-365/gallery/?search=&filterBy=OneNote,Samples         

--- a/docs/project/index.yml
+++ b/docs/project/index.yml
@@ -58,8 +58,14 @@ landingContent:
           - text: Ask questions
             url: https://stackoverflow.com/questions/tagged/office-js
           - text: Request features
-            url: https://aka.ms/m365dev-suggestions
+            url: https://feedbackportal.microsoft.com/feedback/forum/40792262-301c-ec11-b6e7-0022481f8472
           - text: Report issues
             url: https://github.com/officedev/office-js/issues
+          - text: Join Office Add-ins community call
+            url: https://aka.ms/M365DevCalls
           - text: Office Add-ins additional resources
             url: ../resources/resources-links-help.md
+          - text: Join the developer community
+            url: https://pnp.github.io/
+        
+

--- a/docs/project/index.yml
+++ b/docs/project/index.yml
@@ -51,7 +51,7 @@ landingContent:
             url: ../develop/develop-overview.md
 
   # Card
-  - title: Resources
+  - title: Project Developer Resources
     linkLists:
       - linkListType: reference
         links:
@@ -67,5 +67,7 @@ landingContent:
             url: ../resources/resources-links-help.md
           - text: Join the developer community
             url: https://pnp.github.io/
+          - text: Download samples
+            url: https://developer.microsoft.com/microsoft-365/gallery/?filterBy=Project,Samples
         
 

--- a/docs/project/index.yml
+++ b/docs/project/index.yml
@@ -62,11 +62,9 @@ landingContent:
           - text: Report issues
             url: https://github.com/officedev/office-js/issues
           - text: Join Office Add-ins community call
-            url: https://aka.ms/M365DevCalls
+            url: https://learn.microsoft.com/office/dev/add-ins/overview/office-add-ins-community-call
           - text: Office Add-ins additional resources
             url: ../resources/resources-links-help.md
-          - text: Join the developer community
-            url: https://pnp.github.io/
           - text: Download samples
             url: https://developer.microsoft.com/microsoft-365/gallery/?filterBy=Project,Samples
         

--- a/docs/project/index.yml
+++ b/docs/project/index.yml
@@ -8,7 +8,7 @@ metadata:
   description: Resources for learning about Project add-ins.  # Required; article description that is displayed in search results. < 160 chars.
   ms.service: project #Required
   ms.topic: landing-page # Required
-  ms.date: 01/24/2024 #Required; mm/dd/yyyy format.
+  ms.date: 10/05/2024 #Required; mm/dd/yyyy format.
   ms.localizationpriority: medium
 
 # linkListType: architecture | concept | deploy | download | get-started | how-to-guide | learn | overview | quickstart | reference | sample | tutorial | video | whats-new

--- a/docs/project/index.yml
+++ b/docs/project/index.yml
@@ -51,7 +51,7 @@ landingContent:
             url: ../develop/develop-overview.md
 
   # Card
-  - title: Project Developer Resources
+  - title: Resources
     linkLists:
       - linkListType: reference
         links:

--- a/docs/visio/index.yml
+++ b/docs/visio/index.yml
@@ -8,7 +8,7 @@ metadata:
   description: Resources for learning about embedding Visio diagrams in SharePoint. # Required; article description that is displayed in search results. < 160 chars.
   ms.service: visio #Required
   ms.topic: landing-page # Required
-  ms.date: 101 #Required; mm/dd/yyyy format.
+  ms.date: 10/03/2024 #Required; mm/dd/yyyy format.
   ms.localizationpriority: high
 
 # linkListType: architecture | concept | deploy | download | get-started | how-to-guide | learn | overview | quickstart | reference | sample | tutorial | video | whats-new

--- a/docs/visio/index.yml
+++ b/docs/visio/index.yml
@@ -33,7 +33,7 @@ landingContent:
             url: /javascript/api/visio
 
   # Card
-  - title: Visio Developer Resources
+  - title: Resources
     linkLists:
       - linkListType: reference
         links:

--- a/docs/visio/index.yml
+++ b/docs/visio/index.yml
@@ -33,7 +33,7 @@ landingContent:
             url: /javascript/api/visio
 
   # Card
-  - title: Resources
+  - title: Visio Developer Resources
     linkLists:
       - linkListType: reference
         links:
@@ -49,3 +49,5 @@ landingContent:
             url: ../resources/resources-links-help.md
           - text: Join the developer community
             url: https://pnp.github.io/
+          - text: Download samples
+            url: https://developer.microsoft.com/microsoft-365/gallery/?filterBy=Visio,Samples

--- a/docs/visio/index.yml
+++ b/docs/visio/index.yml
@@ -44,10 +44,8 @@ landingContent:
           - text: Report issues
             url: https://github.com/officedev/office-js/issues
           - text: Join Office Add-ins community call
-            url: https://aka.ms/M365DevCalls
+            url: https://learn.microsoft.com/office/dev/add-ins/overview/office-add-ins-community-call
           - text: Office Add-ins additional resources
             url: ../resources/resources-links-help.md
-          - text: Join the developer community
-            url: https://pnp.github.io/
           - text: Download samples
             url: https://developer.microsoft.com/microsoft-365/gallery/?filterBy=Visio,Samples

--- a/docs/visio/index.yml
+++ b/docs/visio/index.yml
@@ -8,7 +8,7 @@ metadata:
   description: Resources for learning about embedding Visio diagrams in SharePoint. # Required; article description that is displayed in search results. < 160 chars.
   ms.service: visio #Required
   ms.topic: landing-page # Required
-  ms.date: 03/29/2021 #Required; mm/dd/yyyy format.
+  ms.date: 101 #Required; mm/dd/yyyy format.
   ms.localizationpriority: high
 
 # linkListType: architecture | concept | deploy | download | get-started | how-to-guide | learn | overview | quickstart | reference | sample | tutorial | video | whats-new
@@ -40,8 +40,12 @@ landingContent:
           - text: Ask questions
             url: https://stackoverflow.com/questions/tagged/office-js
           - text: Request features
-            url: https://aka.ms/m365dev-suggestions
+            url: https://feedbackportal.microsoft.com/feedback/forum/42d29dfb-3e1c-ec11-b6e7-0022481f8472
           - text: Report issues
             url: https://github.com/officedev/office-js/issues
+          - text: Join Office Add-ins community call
+            url: https://aka.ms/M365DevCalls
           - text: Office Add-ins additional resources
             url: ../resources/resources-links-help.md
+          - text: Join the developer community
+            url: https://pnp.github.io/


### PR DESCRIPTION
This PR adds links to landing page that are in the "Resource" swimlane of the dev portals. We are retiring Visio, Project, OneNote and so I added these missing resources to the landing page so the transition from Portal back to Learn has the same content.