### PR TITLE
[admin] Fix VS Code link

### DIFF
--- a/docs/develop/development-kit-overview.md
+++ b/docs/develop/development-kit-overview.md
@@ -13,7 +13,7 @@ The Office Add-ins Development Kit helps set up your environment, create Office 
 
 ## Prerequisites
 
-- Download and install [Visual Studio Code](https://visualstudio.microsoft.com/downloads/).
+- Download and install [Visual Studio Code](https://code.visualstudio.com/).
 - Node.js (the latest LTS version). Visit the [Node.js site](https://nodejs.org/) to download and install the right version for your operating system. To verify if you've already installed these tools, run the commands `node -v` and `npm -v` in your terminal.
 - Office connected to a Microsoft 365 subscription. You might qualify for a Microsoft 365 E5 developer subscription through the [Microsoft 365 Developer Program](https://developer.microsoft.com/microsoft-365/dev-program), see [FAQ](/office/developer-program/microsoft-365-developer-program-faq#who-qualifies-for-a-microsoft-365-e5-developer-subscription-) for details. Alternatively, you can [sign up for a 1-month free trial](https://www.microsoft.com/microsoft-365/try?rtc=1) or [purchase a Microsoft 365 plan](https://www.microsoft.com/microsoft-365/buy/compare-all-microsoft-365-products).
 


### PR DESCRIPTION
The link for downloading VS Code was pointing to Visual Studio instead. This PR fixes that.