### PR TITLE
[admin] (TOC) Deprioritize SSO quick start

### DIFF
--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -30,8 +30,6 @@ items:
       href: quickstarts/project-quickstart.md
     - name: Word add-in
       href: quickstarts/word-quickstart-yo.md
-    - name: Single sign-on (SSO)
-      href: quickstarts/sso-quickstart.md
   - name: Explore Office JS APIs using Script Lab
     href: overview/explore-with-script-lab.md
     displayName: Excel, Word, PowerPoint


### PR DESCRIPTION
A quick PR to remove the SSO quick start from prominence in the TOC. When we get an NAA quick start, we should reexamine where to put that.