### PR TITLE
[Outlook] (debugging) Document how to debug add-ins using Microsoft Edge Inspect

### DIFF
--- a/docs/includes/outlook-bundle-js.md
+++ b/docs/includes/outlook-bundle-js.md
@@ -1,5 +1,5 @@
 > [!TIP]
-> If the **bundle.js** file doesn't appear in the **Wef** folder, try the following:
 >
-> - If your add-in is installed or sideloaded, restart Outlook.
-> - [Remove your add-in](../outlook/sideload-outlook-add-ins-for-testing.md#remove-a-sideloaded-add-in) from Outlook, then [sideload](../outlook/sideload-outlook-add-ins-for-testing.md) it again.
+> - There's no direct method to determine the Outlook profile GUID and mail account encoding used in the **bundle.js** file path. The most effective approach to locate your add-in's **bundle.js** file is to manually inspect each folder until you locate the **Javascript** folder that contains your add-in's ID.
+>
+> - If the **bundle.js** file doesn't appear in the **Wef** folder and your add-in is installed or sideloaded, restart Outlook. Alternatively, [remove your add-in](../outlook/sideload-outlook-add-ins-for-testing.md#remove-a-sideloaded-add-in) from Outlook, then [sideload](../outlook/sideload-outlook-add-ins-for-testing.md) it again.

--- a/docs/outlook/debug-autolaunch.md
+++ b/docs/outlook/debug-autolaunch.md
@@ -1,7 +1,7 @@
 ---
 title: Debug your event-based or spam-reporting Outlook add-in
 description: Learn how to debug your Outlook add-in that implements event-based activation or integrated spam reporting.
-ms.date: 10/24/2024
+ms.date: 12/19/2024
 ms.topic: how-to
 ms.localizationpriority: medium
 ---
@@ -78,6 +78,10 @@ You can debug your add-in using the Microsoft Edge Inspect tool or Visual Studio
     > It may take some time for your add-in to appear in the **Remote Target** section. You may need to refresh the page for the add-in to appear.
 
 1. In the **Sources** tab, go to **file://** > **Users/[User]/AppData/Microsoft/Office/16.0/Wef/{[Outlook profile GUID]}/[Outlook mail account encoding]/Javascript/[Add-in ID]\_[Add-in Version]_[locale]** > **bundle.js**.
+
+    > [!TIP]
+    > There's no direct method to determine the Outlook profile GUID or mail account encoding used in the **bundle.js** file path. If you're debugging multiple add-ins simultaneously, the easiest way to access an add-in's **bundle.js** file from the DevTools window is to locate the add-in's ID in the file path.
+
 1. In the **bundle.js** file, place breakpoints where you want the debugger to stop.
 1. [Run the debugger](#run-the-debugger).
 

--- a/docs/outlook/debug-autolaunch.md
+++ b/docs/outlook/debug-autolaunch.md
@@ -145,7 +145,7 @@ Configure the debugger in Visual Studio Code. Follow the steps applicable to you
 
 The **bundle.js** file of an add-in contains the JavaScript code of your add-in. It's created when classic Outlook on Windows is opened. When Outlook starts, the **bundle.js** file of each installed add-in is cached in the **Wef** folder of your machine.
 
-1. To find the add-in's **bundle.js** file, navigate to the following folder in File Explorer. Replace text enclosed in `[]` with your applicable Outlook and add-in information.
+1. To find the add-in's **bundle.js** file, navigate to the following folder in File Explorer. The text enclosed in `[]` represents your applicable Outlook and add-in information.
 
     ```text
     %LOCALAPPDATA%\Microsoft\Office\16.0\Wef\{[Outlook profile GUID]}\[Outlook mail account encoding]\Javascript\[Add-in ID]_[Add-in Version]_[locale]

--- a/docs/outlook/debug-autolaunch.md
+++ b/docs/outlook/debug-autolaunch.md
@@ -1,7 +1,7 @@
 ---
 title: Debug your event-based or spam-reporting Outlook add-in
 description: Learn how to debug your Outlook add-in that implements event-based activation or integrated spam reporting.
-ms.date: 07/09/2024
+ms.date: 10/24/2024
 ms.topic: how-to
 ms.localizationpriority: medium
 ---
@@ -28,7 +28,7 @@ For more information, see the "Debug your add-in" section of [Develop Outlook ad
 
 # [Windows (classic)](#tab/windows)
 
-If you used the [Yeoman generator for Office Add-ins](../develop/yeoman-generator-overview.md) to create your add-in project (for example, by completing an [event-based activation walkthrough](on-new-compose-events-walkthrough.md)), follow the **Created with Yeoman generator** option throughout this article. Otherwise, follow the **Other** steps. Visual Studio Code should be at least version 1.56.1.
+If you used the [Yeoman generator for Office Add-ins](../develop/yeoman-generator-overview.md) to create your add-in project (for example, by completing an [event-based activation walkthrough](on-new-compose-events-walkthrough.md)), follow the **Created with Yeoman generator** option throughout this article. Otherwise, follow the **Other** steps.
 
 ## Mark your add-in for debugging and set the debugger port
 
@@ -37,19 +37,19 @@ If you used the [Yeoman generator for Office Add-ins](../develop/yeoman-generato
     - **Add-in only manifest**: Use the value of the **\<Id\>** element child of the root **\<OfficeApp\>** element.
     - **Unified manifest for Microsoft 365**: Use the value of the "id" property of the root anonymous `{ ... }` object.
 
-1. Create a registry `DWORD` value named `UseDirectDebugger` in `HKEY_CURRENT_USER\SOFTWARE\Microsoft\Office\16.0\Wef\Developer\[Add-in ID]`. Replace `[Add-in ID]` with your add-in's ID from the manifest.
+1. In the registry, mark your add-in for debugging.
 
-    [!include[Developer registry key](../includes/developer-registry-key.md)]
+    - **Created with Yeoman generator**: In a command line window, navigate to the root of your add-in folder then run the following command.
 
-    **Created with Yeoman generator**: In a command line window, navigate to the root of your add-in folder then run the following command.
+        ```command&nbsp;line
+        npm start
+        ```
 
-    ```command&nbsp;line
-    npm start
-    ```
+        In addition to building the code and starting the local server, this command sets the data of the `HKEY_CURRENT_USER\SOFTWARE\Microsoft\Office\16.0\WEF\Developer\[Add-in ID]\UseDirectDebugger` registry DWORD value for this add-in to `1`. `[Add-in ID]` is your add-in's ID from the manifest.
 
-    In addition to building the code and starting the local server, this command sets the `UseDirectDebugger` registry DWORD value data for this add-in to `1`.
+    - **Other**: In the `HKEY_CURRENT_USER\SOFTWARE\Microsoft\Office\16.0\WEF\Developer\[Add-in ID]\UseDirectDebugger` registry DWORD value, where `[Add-in ID]` is your add-in's ID from the manifest, set its data to `1`.
 
-    **Other**: In the `HKEY_CURRENT_USER\SOFTWARE\Microsoft\Office\16.0\WEF\Developer\[Add-in ID]\UseDirectDebugger` registry DWORD value, where `[Add-in ID]` is your add-in's ID from the manifest, set the value data to `1`.
+        [!include[Developer registry key](../includes/developer-registry-key.md)]
 
 1. In the registry key `HKEY_CURRENT_USER\SOFTWARE\Microsoft\Office\16.0\Wef\Developer\[Add-in ID]`, where `[Add-in ID]` is your add-in's ID from the manifest, create a new `DWORD` value with the following configuration.
 
@@ -63,11 +63,35 @@ If you used the [Yeoman generator for Office Add-ins](../develop/yeoman-generato
 
     ![The Debug Event-based handler dialog in Windows.](../images/outlook-win-autolaunch-debug-dialog.png)
 
-## Configure Visual Studio Code
+## Configure and attach the debugger
 
-### Created with Yeoman generator
+You can debug your add-in using the Microsoft Edge Inspect tool or Visual Studio Code.
 
-1. Back in the command line window, run the following to open your add-in project in Visual Studio Code.
+### Debug with Microsoft Edge
+
+1. Open Microsoft Edge and go to **edge://inspect/#devices**.
+1. In the **Remote Target** section, look for your add-in using its ID from the manifest. Then, select **Inspect**.
+
+    The DevTools window appears.
+
+    > [!NOTE]
+    > It may take some time for your add-in to appear in the **Remote Target** section. You may need to refresh the page for the add-in to appear.
+
+1. In the **Sources** tab, go to **file://** > **Users/[User]/AppData/Microsoft/Office/16.0/Wef/{[Outlook profile GUID]}/[Outlook mail account encoding]/Javascript/[Add-in ID]\_[Add-in Version]_[locale]** > **bundle.js**.
+1. In the **bundle.js** file, place breakpoints where you want the debugger to stop.
+1. [Run the debugger](#run-the-debugger).
+
+### Debug with Visual Studio Code
+
+To debug your add-in in Visual Studio Code, you must have at least version 1.56.1 installed.
+
+#### Configure the debugger
+
+Configure the debugger in Visual Studio Code. Follow the steps applicable to your add-in project.
+
+##### Created with Yeoman generator
+
+1. In the command line, run the following to open your add-in project in Visual Studio Code.
 
     ```command&nbsp;line
     code .
@@ -86,7 +110,7 @@ If you used the [Yeoman generator for Office Add-ins](../develop/yeoman-generato
     }
     ```
 
-### Other
+##### Other
 
 1. Create a new folder called **Debugging** (perhaps in your **Desktop** folder).
 1. Open Visual Studio Code.
@@ -113,7 +137,7 @@ If you used the [Yeoman generator for Office Add-ins](../develop/yeoman-generato
     }
     ```
 
-## Attach the debugger
+#### Attach the debugger
 
 The **bundle.js** file of an add-in contains the JavaScript code of your add-in. It's created when classic Outlook on Windows is opened. When Outlook starts, the **bundle.js** file of each installed add-in is cached in the **Wef** folder of your machine.
 
@@ -133,9 +157,9 @@ The **bundle.js** file of an add-in contains the JavaScript code of your add-in.
 
 ## Run the debugger
 
-1. After confirming that the debugger is attached, return to Outlook, and in the **Debug Event-based handler** dialog, choose **OK** .
+After confirming that the debugger is attached, return to Outlook. In the **Debug Event-based handler** dialog, choose **OK** .
 
-1. You can now hit your breakpoints in Visual Studio Code, enabling you to debug your event-based activation or spam-reporting code.
+You can now hit your breakpoints to debug your event-based activation or spam-reporting code.
 
 ## Stop the debugger
 

--- a/docs/outlook/troubleshoot-event-based-and-spam-reporting-add-ins.md
+++ b/docs/outlook/troubleshoot-event-based-and-spam-reporting-add-ins.md
@@ -61,7 +61,7 @@ As you develop your [event-based](autolaunch.md) or [spam-reporting](spam-report
 
     :::image type="content" source="../images/outlook-event-based-logs.png" alt-text="A sample of Event Viewer's Filter Current Log settings configured to only show Outlook errors with event ID 63 that occurred in the last hour.":::
 
-  - Verify that the **bundle.js** file is downloaded to the following folder in File Explorer. Replace text enclosed in `[]` with your applicable information.
+  - Verify that the **bundle.js** file is downloaded to the following folder in File Explorer. The text enclosed in `[]` represents your applicable Outlook and add-in information.
   
     ```text
     %LOCALAPPDATA%\Microsoft\Office\16.0\Wef\{[Outlook profile GUID]}\[Outlook mail account encoding]\Javascript\[Add-in ID]_[Add-in Version]_[locale]


### PR DESCRIPTION
- Documents how to debug event-based and spam-reporting add-ins using the Microsoft Edge Inspect tool.
- Adds guidance on how to access an add-in's **bundle.js** file. Fixes #4931.