### PR TITLE
[all hosts] (DevX) Remove unnecessary Windows-specific runtime logging instructions

### DIFF
--- a/docs/outlook/debug-autolaunch.md
+++ b/docs/outlook/debug-autolaunch.md
@@ -163,4 +163,4 @@ Event-based add-ins that run in Outlook on Mac use the browser runtime. Because 
 - [Configure your Outlook add-in for event-based activation](autolaunch.md)
 - [Implement an integrated spam-reporting add-in](spam-reporting.md)
 - [Troubleshoot event-based and spam-reporting add-ins](troubleshoot-event-based-and-spam-reporting-add-ins.md)
-- [Debug your add-in with runtime logging](../testing/runtime-logging.md#runtime-logging-on-windows)
+- [Debug your add-in with runtime logging](../testing/runtime-logging.md)

--- a/docs/testing/runtime-logging.md
+++ b/docs/testing/runtime-logging.md
@@ -1,7 +1,7 @@
 ---
 title: Debug your add-in with runtime logging
 description: Learn how to use runtime logging to debug your add-in.
-ms.date: 05/05/2023
+ms.date: 11/08/2024
 ms.localizationpriority: medium
 ---
 
@@ -17,9 +17,9 @@ You can use runtime logging to debug your add-in's manifest as well as several i
 
 ## Use runtime logging from the command line
 
-Enabling runtime logging from the command line is the fastest way to use this logging tool. These use npx, which is provided by default as part of npm@5.2.0+. If you have an earlier version of [npm](https://www.npmjs.com/), try [Runtime logging on Windows](#runtime-logging-on-windows) or [Runtime logging on Mac](#runtime-logging-on-mac) instructions, or [install npx](https://www.npmjs.com/package/npx).
+Enabling runtime logging from the command line is the fastest way to use this logging tool.
 
-[!INCLUDE[Office settings tool not supported on Mac](../includes/tool-nonsupport-mac-note.md)]
+[!INCLUDE[Office settings tool not supported on Mac](../includes/tool-nonsupport-mac-note.md)] See the section [Runtime logging on Mac](#runtime-logging-on-mac) for Mac-specific instructions.
 
 - To enable runtime logging:
 
@@ -50,28 +50,6 @@ Enabling runtime logging from the command line is the fastest way to use this lo
     ```command&nbsp;line
     npx office-addin-dev-settings runtime-log --help
     ```
-
-## Runtime logging on Windows
-
-1. Make sure that you are running Office 2016 desktop build **16.0.7019** or later.
-
-1. Add the `RuntimeLogging` registry key under `HKEY_CURRENT_USER\SOFTWARE\Microsoft\Office\16.0\WEF\Developer\`.
-
-    [!include[Developer registry key](../includes/developer-registry-key.md)]
-
-1. Set the default value of the **RuntimeLogging** key to the full path of the file where you want the log to be written. The following example run in a `.reg` file sets the logging to the `C:\ClientLogs\log.txt` folder.
-
-    ```registry
-    [HKEY_CURRENT_USER\SOFTWARE\Microsoft\Office\16.0\Wef\Developer\RuntimeLogging]
-    @="C:\\ClientLogs\\log.txt"`
-    ```
-
-    > [!NOTE]
-    > The directory in which the log file will be written must already exist, and you must have write permissions to it.
-
-The following image shows what the registry should look like. To turn the feature off, remove the `RuntimeLogging` key from the registry.
-
-![The registry editor with a RuntimeLogging registry key.](../images/runtime-logging-registry.png)
 
 ## Runtime logging on Mac
 


### PR DESCRIPTION
The Windows-only instructions for runtime logging aren't needed, since the easier-to-use tool now works with all supported versions of npm.