### PR TITLE
[All hosts](deployment) Add article on admin consent

### DIFF
--- a/docs/develop/enable-nested-app-authentication-in-your-add-in.md
+++ b/docs/develop/enable-nested-app-authentication-in-your-add-in.md
@@ -1,7 +1,7 @@
 ---
 title: Enable SSO in an Office Add-in using nested app authentication
 description: Learn how to enable SSO in an Office Add-in using nested app authentication.
-ms.date: 11/22/2024
+ms.date: 12/18/2024
 ms.topic: how-to
 ms.localizationpriority: high
 ---
@@ -45,7 +45,11 @@ To enable NAA, your app registration must include a specific redirect URI to ind
 
 `brk-multihub://your-add-in-domain`
 
-For example if you were testing your add-in on port 3000 on the localhost server, you would use `brk-multihub://localhost:3000` as the redirect value.
+Your domain must include only the origin and not its subpaths. For example:
+
+✔️ brk-multihub://localhost:3000<br>
+✔️ brk-multihub://www.contoso.com<br>
+❌ brk-multihub://www.contoso.com/go
 
 Trusted broker groups are dynamic by design and can be updated in the future to include additional hosts where your add-in may use NAA flows. Currently the brk-multihub group includes Office Word, Excel, PowerPoint, Outlook, and Teams (for when Office is activated inside).
 

--- a/docs/outlook/faq-nested-app-auth-outlook-legacy-tokens.md
+++ b/docs/outlook/faq-nested-app-auth-outlook-legacy-tokens.md
@@ -4,7 +4,7 @@ description: Nested app authentication and Outlook legacy tokens deprecation FAQ
 ms.service: microsoft-365
 ms.subservice: add-ins
 ms.topic: faq
-ms.date: 12/12/2024
+ms.date: 12/18/2024
 ---
 
 # Nested app authentication and Outlook legacy tokens deprecation FAQ
@@ -38,11 +38,15 @@ The general availability (GA) date for NAA depends on which channel you are usin
 | Jan 2025 | NAA will GA in Semi-Annual Channel. |
 | Jun 2025 | NAA will GA in Semi-Annual Extended Channel. |
 
+### Are COM Add-ins affected by the deprecation of legacy Exchange Online tokens?
+
+It's very unlikely any COM add-ins are affected by the deprecation of legacy Exchange Online tokens. Outlook web add-ins are primarily affected because they can use Office.js APIs that rely on Exchange tokens. For more information, see[How do i know if my outlook add in relies on legacy tokens](#how-do-i-know-if-my-outlook-add-in-relies-on-legacy-tokens). The Exchange tokens are used to access Exchange Web Services (EWS) or Outlook REST APIs, both of which are also deprecated. If you suspect a COM add-in might be affected, you can test it by using it on a tenant with Exchange tokens turned off. For more information, see [Turn legacy Exchange Online tokens on or off](turn-exchange-tokens-on-off.md).
+
 ## Microsoft 365 administrator questions
 
 ### Can I turn Exchange Online legacy tokens back on?
 
-Yes, there are PowerShell commands you can use to turn legacy tokens on or off in any tenant. For more information on how to turn legacy tokens on or off, see [Turn legacy Exchange Online tokens on or off](turn-exchange-tokens-on-off.md).
+Yes, there are PowerShell commands you can use to turn legacy tokens on or off in any tenant. For more information on how to turn legacy tokens on or off, see [Turn legacy Exchange Online tokens on or off](turn-exchange-tokens-on-off.md). If you use the commands to enable legacy Exchange Online tokens, they will not be turned off in February 2025. They will remain on until June 2025, or until you use the tooling to turn them off.
 
 In June 2025, legacy tokens will be turned off and you won't be able to turn them back on without a specific exception granted by Microsoft. In October 2025, it won't be possible to turn on legacy tokens and they'll be disabled for all tenants. We'll update this FAQ with additional information once the tool is available.
 

--- a/docs/outlook/turn-exchange-tokens-on-off.md
+++ b/docs/outlook/turn-exchange-tokens-on-off.md
@@ -4,7 +4,7 @@ description: Turn legacy Exchange Online tokens on or off
 ms.service: microsoft-365
 ms.subservice: add-ins
 ms.topic: how-to
-ms.date: 12/12/2024
+ms.date: 12/18/2024
 ---
 
 # Turn legacy Exchange Online tokens on or off
@@ -31,6 +31,9 @@ To turn legacy tokens off, run the following command.
 `Set-AuthenticationPolicy –BlockLegacyExchangeTokens -Identity "LegacyExchangeTokens"`
 
 The command turns off legacy tokens for the entire tenant. If an Outlook add-in requests a legacy token, it won’t be issued a token.
+
+> [!NOTE]
+> If you've confirmed that your tenant is not using any add-ins that require legacy Exchange Online tokens, we recommend you turn off legacy Exchange Online tokens as a security best practice. For more information on how to determine if you tenant has add-ins using legacy tokens, see the [Nested app authentication and Outlook legacy tokens deprecation FAQ](faq-nested-app-auth-outlook-legacy-tokens.md).
 
 ## Turn on legacy Exchange Online tokens
 

--- a/docs/outlook/turn-exchange-tokens-on-off.md
+++ b/docs/outlook/turn-exchange-tokens-on-off.md
@@ -22,7 +22,7 @@ To run the commands you need to connect to Exchange Online PowerShell.
 1. To be sure you are on the latest version of the module, run the command `Update-Module -Name ExchangeOnlineManagement`.
 1. Run the command `Connect-ExchangeOnline`. Sign in with your Microsoft 365 administrator credentials.
 
-## Turn off legacy Exchange Online tokens in a test tenant
+## Turn off legacy Exchange Online tokens
 
 The `Set-AuthenticationPolicy` command controls the issuance of legacy Exchange Online tokens. When issuance is turned off, add-ins can no longer request user identity tokens or callback tokens. Existing tokens already issued will continue to work until they expire. It can take up to 24 hours before all request from Outlook add-ins for legacy Exchange Online tokens are blocked.
 
@@ -32,7 +32,7 @@ To turn legacy tokens off, run the following command.
 
 The command turns off legacy tokens for the entire tenant. If an Outlook add-in requests a legacy token, it won’t be issued a token.
 
-## Turn on legacy Exchange Online tokens in a test tenant
+## Turn on legacy Exchange Online tokens
 
 To turn legacy tokens on, run the following command. It can take up to 24 hours before all requests from Outlook add-ins for legacy tokens are allowed.
 

--- a/docs/publish/publish-nested-app-auth-add-in.md
+++ b/docs/publish/publish-nested-app-auth-add-in.md
@@ -19,9 +19,9 @@ To publish updates there are three things to consider.
 
 ## Deploy updates to your add-in code
 
-Once you've updated and tested your add-in code, you'll need to deploy those updates to your web server. Follow your own update process (such as staging and production). Once deployed, all users of your add-in will see the changes and start using the updated add-in code. There is no need for admins or users to take any actions to see the updates.
+Once you've updated and tested your add-in code, you'll need to deploy them to your web server. Follow your own update process (such as staging and production). Once deployed, all users of your add-in will see the changes and start using the updated add-in code. There is no need for admins or users to take any actions to see the updates.
 
-Any Microsoft Graph scopes used by your add-in require consent from either the user or the admin of a tenant. If the admin doesn't consent, then when your add-in requests an access token through MSAL, the user will be prompted to provide consent. In general the best user experience is to avoid prompting users for consent at all. You can have the admin consent for the entire tenant.
+Any Microsoft Graph scopes used by your add-in require consent from either the user or the admin of a tenant. If the admin doesn't consent, the user will be prompted to provide consent when your add-in requests an access token through MSAL. For the best user experience, avoid prompting users for consent at all. Instead, ask your admin to provide consent for the entire tenant.
 
 There are two ways to get admin consent; use an admin consent URI, or use the unified manifest.
 
@@ -48,11 +48,11 @@ https://login.microsoftonline.com/organizations/v2.0/adminconsent?client_id=c6c1
 ```
 
 > [!IMPORTANT]
-> The redirect page must be added to the list of SPA redirects in your app registration along with the `brk-multihub` redirect or the admin consent URI will fail.
+> The redirect page must be added to the list of single-page application (SPA) redirects in your app registration along with the `brk-multihub` redirect or the admin consent URI will fail.
 
 ## Get admin consent via the unified manifest
 
-You can also get admin consent as an automatic part of the deployment workflow when your add-in is deployed. To do this you add the `webApplicationInfo` property to your unified manifest. Then the admin deploys the updated manifest, either through central deployment, or from an update through Microsoft AppSource. When the admin deploys the updated manifest they are automatically prompted to consent to the scopes required by the add-in. If they don't consent, the updated add-in will not deploy.
+You can also get admin consent as an automatic part of the deployment workflow when your add-in is deployed. To do this, add the `webApplicationInfo` property to your unified manifest. Then the admin deploys the updated manifest, either through central deployment, or from an update through Microsoft AppSource. When the admin deploys the updated manifest, they are automatically prompted to consent to the scopes required by the add-in. If they don't consent, the updated add-in will not deploy.
 
 ### Add Graph scopes to app registration
 
@@ -101,7 +101,7 @@ To get admin consent as part of the deployment workflow, add the `webApplication
 
 If you deployed your add-in through Microsoft AppSource, you'll need to submit your updated unified manifest for approval. For more information, see [Microsoft AppSource submission FAQ](/partner-center/marketplace-offers/appsource-submission-faq).
 
-If you deployed you add-in by providing the manifest to admins for central deployment, you'll need to provide admins with an updated [app package](/microsoftteams/platform/concepts/build-and-test/apps-package) that contains the updated manifest.
+If you deployed your add-in by providing the manifest to admins for central deployment, you'll need to provide admins with an updated [app package](/microsoftteams/platform/concepts/build-and-test/apps-package) that contains the updated manifest.
 
 ## Related content
 

--- a/docs/publish/publish-nested-app-auth-add-in.md
+++ b/docs/publish/publish-nested-app-auth-add-in.md
@@ -1,0 +1,111 @@
+---
+title: Publish an add-in that requires admin consent for Microsoft Graph scopes
+description: Learn how to publish updates to an Office Add-in to use Microsoft Graph scopes and require admin consent.
+ms.service: microsoft-365
+ms.subservice: add-ins
+ms.topic: how-to 
+ms.date: 12/16/2024
+---
+
+# Publish an add-in that requires admin consent for Microsoft Graph scopes
+
+In this article you'll learn how to publish updates to an Office Add-in to use Microsoft Graph scopes and require admin consent. This is a common scenario if you have moved your Outlook add-in from legacy Exchange Online tokens to using the Microsoft authentication library (MSAL) with nested app authentication (NAA) and Entra ID tokens with Microsoft Graph APIs.
+
+To publish updates there are three things to consider.
+
+1. How to deploy changes made in the add-in code to your web server.
+1. How to obtain admin consent to the Microsoft Graph scopes.
+1. How to deploy updates in your manifest.
+
+## Deploy updates to your add-in code
+
+Once you've updated and tested your add-in code, you'll need to deploy those updates to your web server. Follow your own update process (such as staging and production). Once deployed, all users of your add-in will see the changes and start using the updated add-in code. There is no need for admins or users to take any actions to see the updates.
+
+Any Microsoft Graph scopes used by your add-in require consent from either the user or the admin of a tenant. If the admin doesn't consent, then when your add-in requests an access token through MSAL, the user will be prompted to provide consent. In general the best user experience is to avoid prompting users for consent at all. You can have the admin consent for the entire tenant.
+
+There are two ways to get admin consent; use an admin consent URI, or use the unified manifest.
+
+## Get admin consent via admin consent URI
+
+You can get admin consent by providing an admin consent URI. It provides a link that an admin can select. A dialog box prompts them to sign in with admin credentials, and consent to the Microsoft Graph scopes your add-in requires.
+
+To construct the admin URI, use the following pattern.
+
+```html
+https://login.microsoftonline.com/organizations/v2.0/adminconsent?client_id={client_id}&scope={scopes}&redirect_uri={redirect_uri}
+```
+
+where:
+
+- `client_id`: The ID of your app registration.
+- `scope`: Each scope (such as Microsoft Graph scopes) that requires admin consent using the space as delimiter.
+- `redirect_uri`: A redirect page for when consent is completed. The Microsoft identity platform will redirect to this page after an admin consents. The redirect page is sent a success or fail JSON message as specified in [Admin consent on the Microsoft identity platform](/entra/identity-platform/v2-admin-consent). On the page you can indicate the consent status to the admin as well as provide more information or next steps about your add-in.
+
+The following admin URI example shows how to specify the `User.Read` and `Files.Read` scopes and redirect to a page on your web server named `consentRedirect.html`.
+
+```html
+https://login.microsoftonline.com/organizations/v2.0/adminconsent?client_id=c6c1f32b-5e55-4997-881a-753cc1d563b7&scope=https://graph.microsoft.com/User.Read https://graph.microsoft.com/Files.Read&redirect_uri=https://localhost:3000/consentRedirect.html
+```
+
+> [!IMPORTANT]
+> The redirect page must be added to the list of SPA redirects in your app registration along with the `brk-multihub` redirect or the admin consent URI will fail.
+
+## Get admin consent via the unified manifest
+
+You can also get admin consent as an automatic part of the deployment workflow when your add-in is deployed. To do this you add the `webApplicationInfo` property to your unified manifest. Then the admin deploys the updated manifest, either through central deployment, or from an update through Microsoft AppSource. When the admin deploys the updated manifest they are automatically prompted to consent to the scopes required by the add-in. If they don't consent, the updated add-in will not deploy.
+
+### Add Graph scopes to app registration
+
+When the admin deploys the updated manifest of your add-in, the consent process will read your app registration for which scopes to require the admin for consent. Be sure to add all permissions your add-in requires using the following steps.
+
+1. Sign in to the [Azure Portal](https://portal.azure.com/) and open your app registration.
+
+1. From the left pane, select **API permissions**.
+
+    :::image type="content" source="../images/azure-portal-api-permissions.png" alt-text="The API permissions pane.":::
+
+    The **API permissions** pane opens.
+
+1. Select **Add a permission**.
+
+    :::image type="content" source="../images/azure-portal-add-a-permission.png" alt-text="Adding a permission on the API permissions pane.":::
+
+    The **Request API permissions** pane opens.
+
+1. Select **Microsoft Graph**.
+
+    :::image type="content" source="../images/azure-portal-request-api-permissions-graph.png" alt-text="The Request API permissions pane with Microsoft Graph button.":::
+
+1. Select **Delegated permissions**.
+
+    :::image type="content" source="../images/azure-portal-request-api-permissions-delegated.png" alt-text="The Request API permissions pane with delegated permissions button.":::
+
+1. In the **Select permissions** search box, search for the permissions your add-in needs. For example, for an Outlook add-in, you might use `profile`, `openid`, `Files.ReadWrite`, and `Mail.Read`.
+
+1. Select the checkbox for each permission as it appears. Note that the permissions will not remain visible in the list as you select each one. After selecting the permissions that your add-in needs, select **Add permissions**.
+
+    :::image type="content" source="../images/azure-portal-request-api-permissions-add-permissions.png" alt-text="The Request API permissions pane with some permissions selected.":::
+
+### Add the webApplicatoinInfo property
+
+To get admin consent as part of the deployment workflow, add the `webApplicationInfo` property to your unified manifest. Set the `id` property to your app registration ID. Set the `resource` property to the value of your domain. The following example shows the `webApplicationInfo` property for an app registration for contoso.com.
+
+```json
+    "webApplicationInfo": {
+        "id": "a92ace55-9daf-47bc-84e9-065e9a6e70e3",
+        "resource": "https://contoso.com"
+    },
+```
+
+### Deploy the updated manifest
+
+If you deployed your add-in through Microsoft AppSource, you'll need to submit your updated unified manifest for approval. For more information, see [Microsoft AppSource submission FAQ](/partner-center/marketplace-offers/appsource-submission-faq).
+
+If you deployed you add-in by providing the manifest to admins for central deployment, you'll need to provide admins with an updated [app package](/microsoftteams/platform/concepts/build-and-test/apps-package) that contains the updated manifest.
+
+## Related content
+
+- [Microsoft AppSource submission FAQ](/partner-center/marketplace-offers/appsource-submission-faq)
+- [Admin consent on the Microsoft identity platform](/entra/identity-platform/v2-admin-consent)
+- [webApplicationInfo property](/microsoftteams/platform/resources/schema/manifest-schema)
+- [Nested app authentication and Outlook legacy tokens deprecation FAQ](https://naafaq)

--- a/docs/publish/publish-nested-app-auth-add-in.md
+++ b/docs/publish/publish-nested-app-auth-add-in.md
@@ -4,7 +4,7 @@ description: Learn how to publish updates to an Office Add-in to use Microsoft G
 ms.service: microsoft-365
 ms.subservice: add-ins
 ms.topic: how-to 
-ms.date: 12/16/2024
+ms.date: 12/18/2024
 ---
 
 # Publish an add-in that requires admin consent for Microsoft Graph scopes
@@ -38,17 +38,20 @@ https://login.microsoftonline.com/organizations/v2.0/adminconsent?client_id={cli
 where:
 
 - `client_id`: The ID of your app registration.
-- `scope`: Each scope (such as Microsoft Graph scopes) that requires admin consent using the space as delimiter.
+- `scope`: Each scope (such as Microsoft Graph scopes) that requires admin consent using the space as delimiter. Because the Microsoft authentication library (MSAL) always requests an ID and refresh token, you should always include the `openid`, `profile`, and `offline_access` scopes. These are requested by default by MSAL even if your add-in does no request them.
 - `redirect_uri`: A redirect page for when consent is completed. The Microsoft identity platform will redirect to this page after an admin consents. The redirect page is sent a success or fail JSON message as specified in [Admin consent on the Microsoft identity platform](/entra/identity-platform/v2-admin-consent). On the page you can indicate the consent status to the admin as well as provide more information or next steps about your add-in.
-
-The following admin URI example shows how to specify the `User.Read` and `Files.Read` scopes and redirect to a page on your web server named `consentRedirect.html`.
-
-```html
-https://login.microsoftonline.com/organizations/v2.0/adminconsent?client_id=c6c1f32b-5e55-4997-881a-753cc1d563b7&scope=https://graph.microsoft.com/User.Read https://graph.microsoft.com/Files.Read&redirect_uri=https://localhost:3000/consentRedirect.html
-```
 
 > [!IMPORTANT]
 > The redirect page must be added to the list of single-page application (SPA) redirects in your app registration along with the `brk-multihub` redirect or the admin consent URI will fail.
+
+The following admin URI example shows how to specify the `openid`, `profile`, `offline_access`, `user.read` and `files.read` scopes and redirect to a page on your web server named `consentRedirect.html`.
+
+```html
+https://login.microsoftonline.com/organizations/v2.0/adminconsent?client_id=63e62b68-c5c7-48f9-82bf-8c41d5637b49&scope=offline_access openid profile user.read files.read&redirect_uri=https://localhost:3000/consentRedirect.html
+```
+
+> [!NOTE]
+> In requests to the authorization, token or consent endpoints for the Microsoft identity platform, if the resource identifier is omitted in the scope parameter, the resource is assumed to be Microsoft Graph. For example, `User.Read` is equivalent to `https://graph.microsoft.com/User.Read`.
 
 ## Get admin consent via the unified manifest
 
@@ -86,7 +89,7 @@ When the admin deploys the updated manifest of your add-in, the consent process 
 
     :::image type="content" source="../images/azure-portal-request-api-permissions-add-permissions.png" alt-text="The Request API permissions pane with some permissions selected.":::
 
-### Add the webApplicatoinInfo property
+### Add the webApplicationInfo property
 
 To get admin consent as part of the deployment workflow, add the `webApplicationInfo` property to your unified manifest. Set the `id` property to your app registration ID. Set the `resource` property to the value of your domain. The following example shows the `webApplicationInfo` property for an app registration for contoso.com.
 
@@ -107,5 +110,6 @@ If you deployed your add-in by providing the manifest to admins for central depl
 
 - [Microsoft AppSource submission FAQ](/partner-center/marketplace-offers/appsource-submission-faq)
 - [Admin consent on the Microsoft identity platform](/entra/identity-platform/v2-admin-consent)
+- [Requesting permissions through consent](/entra/identity-platform/consent-types-developer)
 - [webApplicationInfo property](/microsoftteams/platform/resources/schema/manifest-schema)
 - [Nested app authentication and Outlook legacy tokens deprecation FAQ](https://naafaq)

--- a/docs/publish/publish-nested-app-auth-add-in.md
+++ b/docs/publish/publish-nested-app-auth-add-in.md
@@ -51,7 +51,7 @@ https://login.microsoftonline.com/organizations/v2.0/adminconsent?client_id=63e6
 ```
 
 > [!NOTE]
-> In requests to the authorization, token or consent endpoints for the Microsoft identity platform, if the resource identifier is omitted in the scope parameter, the resource is assumed to be Microsoft Graph. For example, `User.Read` is equivalent to `https://graph.microsoft.com/User.Read`.
+> If the resource identifier is omitted in the scope parameter, the resource is assumed to be Microsoft Graph. For example, `User.Read` is equivalent to `https://graph.microsoft.com/User.Read`.
 
 ## Get admin consent via the unified manifest
 

--- a/docs/publish/publish-nested-app-auth-add-in.md
+++ b/docs/publish/publish-nested-app-auth-add-in.md
@@ -23,7 +23,7 @@ Once you've updated and tested your add-in code, you'll need to deploy them to y
 
 Any Microsoft Graph scopes used by your add-in require consent from either the user or the admin of a tenant. If the admin doesn't consent, the user will be prompted to provide consent when your add-in requests an access token through MSAL. For the best user experience, avoid prompting users for consent at all. Instead, ask your admin to provide consent for the entire tenant.
 
-There are two ways to get admin consent; use an admin consent URI, or use the unified manifest.
+There are two ways to get admin consent: use an admin consent URI or use the unified manifest.
 
 ## Get admin consent via admin consent URI
 
@@ -38,7 +38,7 @@ https://login.microsoftonline.com/organizations/v2.0/adminconsent?client_id={cli
 where:
 
 - `client_id`: The ID of your app registration.
-- `scope`: Each scope (such as Microsoft Graph scopes) that requires admin consent using the space as delimiter. Because the Microsoft authentication library (MSAL) always requests an ID and refresh token, you should always include the `openid`, `profile`, and `offline_access` scopes. These are requested by default by MSAL even if your add-in does no request them.
+- `scope`: Each scope (such as Microsoft Graph scopes) requires admin consent using the space as delimiter. Because the Microsoft authentication library (MSAL) always requests an ID and refresh token, you should always include the `openid`, `profile`, and `offline_access` scopes. These are requested by default by MSAL even if your add-in does not request them.
 - `redirect_uri`: A redirect page for when consent is completed. The Microsoft identity platform will redirect to this page after an admin consents. The redirect page is sent a success or fail JSON message as specified in [Admin consent on the Microsoft identity platform](/entra/identity-platform/v2-admin-consent). On the page you can indicate the consent status to the admin as well as provide more information or next steps about your add-in.
 
 > [!IMPORTANT]

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -401,6 +401,8 @@ items:
       href: publish/publish-office-add-ins-to-appsource.md
     - name: AppSource validation policies
       href: /legal/marketplace/certification-policies
+    - name: Publish an add-in that requires admin consent
+      href: publish/publish-nested-app-auth-add-in.md
     - name: Publish add-ins to a SharePoint app catalog
       href: publish/publish-task-pane-and-content-add-ins-to-an-add-in-catalog.md
     - name: Guidance for deploying on government clouds


### PR DESCRIPTION
This article is a how to on adding admin consent to your Office add-in deployment when updating. You can use either an admin consent URI, or the unified manifest.
also some updates to the FAQ and other articles based on recent activity.