### PR TITLE
[Outlook] (DevX) Add note referencing Outlook

### DIFF
--- a/docs/testing/sideload-office-add-ins-for-testing.md
+++ b/docs/testing/sideload-office-add-ins-for-testing.md
@@ -1,11 +1,14 @@
 ---
 title: Sideload Office Add-ins to Office on the web
 description: Test your Office Add-in in Office on the web by sideloading.
-ms.date: 08/17/2023
+ms.date: 12/26/2024
 ms.localizationpriority: medium
 ---
 
 # Sideload Office Add-ins to Office on the web
+
+> [!NOTE]
+> This article primarily applies to **Excel**, **OneNote**, **PowerPoint**, and **Word** add-ins. For information on sideloading **Outlook** add-ins, see the article [Sideload Outlook add-ins for testing](../outlook/sideload-outlook-add-ins-for-testing.md).
 
 When you sideload an add-in, you're able to install the add-in without first putting it in an add-in catalog. This is useful when testing and developing your add-in because you can see how your add-in will appear and function.
 


### PR DESCRIPTION
We had a comment saying the reader couldn't find the Outlook sideloading instructions. If you're skimming the article, I think it's easy to miss the link in the second list, so I added an explicit note up top. Open to thoughts on the necessity or strategy.