### PR TITLE
[All Hosts] (manifest) correct placement of RequestedWidth/Height elements

### DIFF
--- a/docs/develop/manifest-element-ordering.md
+++ b/docs/develop/manifest-element-ordering.md
@@ -137,8 +137,8 @@ The following sections show the manifest elements in the order in which they mus
     <DefaultSettings>
         <SourceLocation>
             <Override>
-    <RequestedWidth>
-    <RequestedHeight>
+        <RequestedWidth>
+        <RequestedHeight>
     <Permissions>
     <AllowSnapshot>
     <VersionOverrides>*


### PR DESCRIPTION
These are children of DefaultSettings, not peers. 
Doesn't need a review.

Fixes [4974](https://github.com/OfficeDev/office-js-docs-pr/issues/4974)