### PR TITLE
[Excel, Word, PowerPoint] (Application-specific APIs) Document partial undo support

### DIFF
--- a/docs/design/contextual-tabs.md
+++ b/docs/design/contextual-tabs.md
@@ -39,9 +39,6 @@ The user experience for custom contextual tabs follows the pattern of built-in O
 - If more than one add-in has a contextual tab that's visible in a specific context, then they appear in the order in which the add-ins were launched.
 - Custom *contextual* tabs, unlike custom core tabs, aren't added permanently to the Office application's ribbon. They're present only in Office documents on which your add-in is running.
 
-> [!WARNING]
-> Currently, the use of custom contextual tabs may prevent the user from undoing their previous Excel actions. This is a known issue (see [this GitHub thread](https://github.com/OfficeDev/office-js/issues/4814)) and under active investigation.
-
 ## Major steps for including a contextual tab in an add-in
 
 The following are the major steps for including a custom contextual tab in an add-in.

--- a/docs/develop/application-specific-api-model.md
+++ b/docs/develop/application-specific-api-model.md
@@ -1,7 +1,7 @@
 ---
 title: Using the application-specific API model
 description: Learn about the promise-based API model for Excel, OneNote, PowerPoint, Visio, and Word add-ins.
-ms.date: 10/20/2023
+ms.date: 02/12/2025
 ms.localizationpriority: medium
 ---
 
@@ -288,9 +288,11 @@ await Excel.run(async (context) => {
 });
 ```
 
-## Application undo stack
+## Undo support
 
-When an application-specific API is processed, the undo stack of the application is cleared. This means that you can't undo changes made prior to any action done by an add-in (unless that add-in only uses Common APIs or doesn't interact with the file). The same is true for changes made by the add-in.
+Undo is partially supported by the application-specific Office JavaScript APIs. This means that users may be able to revert changes made by add-ins through the undo command. If an undo for a particular API is not supported, the application's undo stack is cleared. This means that you won't be able to undo the effects of that API or anything prior to calling that API.
+
+API support for undo is continuing to expand but is currently incomplete. We advise against designing your add-in in such a way that it relies on undo support.
 
 ## See also
 

--- a/docs/develop/application-specific-api-model.md
+++ b/docs/develop/application-specific-api-model.md
@@ -290,7 +290,7 @@ await Excel.run(async (context) => {
 
 ## Undo support
 
-Undo is partially supported by the application-specific Office JavaScript APIs. This means that users may be able to revert changes made by add-ins through the undo command. If an undo for a particular API is not supported, the application's undo stack is cleared. This means that you won't be able to undo the effects of that API or anything prior to calling that API.
+Undo is partially supported by the application-specific Office JavaScript APIs. This means that users may be able to revert changes made by add-ins through the undo command. If a particular API doesn't support undo, the application's undo stack is cleared. This means that you won't be able to undo the effects of that API or anything prior to calling that API.
 
 API support for undo is continuing to expand but is currently incomplete. We advise against designing your add-in in such a way that it relies on undo support.
 


### PR DESCRIPTION
Application-specific APIs no longer universally clear the undo stack. This PR changes the docs to reflect that. It also removes a warning linked to a closed issue.