### PR TITLE
[Outlook] (attachments) Clarify support for BMP attachments

### DIFF
--- a/docs/outlook/add-and-remove-attachments-to-an-item-in-a-compose-form.md
+++ b/docs/outlook/add-and-remove-attachments-to-an-item-in-a-compose-form.md
@@ -1,7 +1,7 @@
 ---
 title: Add and remove attachments in an Outlook add-in
 description: Use various attachment APIs to manage the files or Outlook items attached to the item the user is composing.
-ms.date: 02/18/2025
+ms.date: 03/12/2025
 ms.topic: how-to
 ms.localizationpriority: medium
 ---
@@ -47,7 +47,10 @@ To check for the outcome of an asynchronous method call in the callback function
 You can attach a file to a message or appointment in a compose form by using the `addFileAttachmentAsync` method and specifying the URI of the file. You can also use the `addFileAttachmentFromBase64Async` method, specifying the Base64-encoded string as input. If the file is protected, you can include an appropriate identity or authentication token as a URI query string parameter. Exchange will make a call to the URI to get the attachment, and the web service which protects the file will need to use the token as a means of authentication.
 
 > [!NOTE]
-> The URI of the file to be attached must support caching in production. The server hosting the image shouldn't return a `Cache-Control` header that specifies `no-cache`, `no-store`, or similar options in the HTTP response. However, when you're developing the add-in and making changes to files, caching can prevent you from seeing your changes. We recommend using `Cache-Control` headers during development.
+>
+> - The URI of the file to be attached must support caching in production. The server hosting the image shouldn't return a `Cache-Control` header that specifies `no-cache`, `no-store`, or similar options in the HTTP response. However, when you're developing the add-in and making changes to files, caching can prevent you from seeing your changes. We recommend using `Cache-Control` headers during development.
+>
+> - The `addFileAttachmentAsync` method doesn't support bitmap (BMP) images if they're added as inline attachments.
 
 The following JavaScript example is a compose add-in that attaches a file, **picture.png**, from a web server to the message or appointment being composed. The callback function takes `asyncResult` as a parameter, checks for the result status, and gets the attachment ID if the method succeeds.
 


### PR DESCRIPTION
Related PR: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/72187