### PR TITLE
Include Appfluence Priority Matrix in the list of updated add-ins

### DIFF
--- a/docs/outlook/faq-nested-app-auth-outlook-legacy-tokens.md
+++ b/docs/outlook/faq-nested-app-auth-outlook-legacy-tokens.md
@@ -180,6 +180,7 @@ There are two views for permissions; Admin consent, and User consent. Select Use
 
 Some widely used Outlook add-in publishers have already updated their add-ins as listed below.
 
+- [Appfluence Priority Matrix for Outlook](https://appsource.microsoft.com/en-us/product/office/wa104381735)
 - [Atlassian Jira Cloud for Outlook](https://marketplace.atlassian.com/apps/1220666/jira-cloud-for-outlook-official?tab=overview&hosting=cloud)
 - [Box for Outlook](https://appsource.microsoft.com/product/office/WA200000015)
 - [Clickup for Outlook](https://appsource.microsoft.com/product/office/WA104382026)

--- a/docs/outlook/faq-nested-app-auth-outlook-legacy-tokens.md
+++ b/docs/outlook/faq-nested-app-auth-outlook-legacy-tokens.md
@@ -180,7 +180,7 @@ There are two views for permissions; Admin consent, and User consent. Select Use
 
 Some widely used Outlook add-in publishers have already updated their add-ins as listed below.
 
-- [Appfluence Priority Matrix for Outlook](https://appsource.microsoft.com/en-us/product/office/wa104381735)
+- [Appfluence Priority Matrix for Outlook](https://appsource.microsoft.com/product/office/wa104381735)
 - [Atlassian Jira Cloud for Outlook](https://marketplace.atlassian.com/apps/1220666/jira-cloud-for-outlook-official?tab=overview&hosting=cloud)
 - [Box for Outlook](https://appsource.microsoft.com/product/office/WA200000015)
 - [Clickup for Outlook](https://appsource.microsoft.com/product/office/WA104382026)


### PR DESCRIPTION
Priority Matrix for Outlook was in the first wave of add-ins that migrated to using NAA, and was featured in Microsoft's own post about it: https://techcommunity.microsoft.com/blog/microsoft_365blog/app-assure-puts-security-first-for-microsoft-outlook-customers/4398151
It has also been in the "Editor's choice" category for years.