### PR TITLE
[PowerPoint] (tables) Change way to update values in existing table

### DIFF
--- a/docs/powerpoint/work-with-tables.md
+++ b/docs/powerpoint/work-with-tables.md
@@ -383,7 +383,7 @@ The previous sample creates a table with two merged areas as shown in the follow
 
 ## Get and set table cell values
 
-After a table is created you can get or set string values in the cells. Note that this is the only part of a table you can change. You can't change borders, fonts, widths, or other cell properties. If you need to update a table, delete it and recreate it. The following code sample shows how to find an existing table and set a new value for a cell in the table.
+After a table is created, you can get or set string values in the cells. Note that this is the only part of a table you can change. You can't change borders, fonts, widths, or other cell properties. If you need to update a table, delete it and recreate it. The following code sample shows how to find an existing table and set a new value for a cell in the table.
 
 ```javascript
 await PowerPoint.run(async (context) => {

--- a/docs/powerpoint/work-with-tables.md
+++ b/docs/powerpoint/work-with-tables.md
@@ -2,7 +2,7 @@
 title: Work with tables using the PowerPoint JavaScript API
 description: Learn how to create tables and control formatting using the PowerPoint JavaScript API.
 ms.topic: how-to
-ms.date: 04/30/2025
+ms.date: 05/02/2025
 ms.localizationpriority: medium
 ---
 
@@ -383,7 +383,7 @@ The previous sample creates a table with two merged areas as shown in the follow
 
 ## Get and set table cell values
 
-After a table is created you can get or set string values in the cells. Note that this is the only part of a table you can change. You can't change borders, fonts, widths, or other cell properties. If you need to update a table, delete it and recreate it. The following code sample shows how to find an existing table and set a new value for a cell in the table.
+After a table is created, you can't change values, borders, fonts, widths, or other cell properties. If you need to update a table, delete it and recreate it. The following code sample shows how to find an existing table and set a new value for a cell in the table.
 
 ```javascript
 await PowerPoint.run(async (context) => {
@@ -394,11 +394,22 @@ await PowerPoint.run(async (context) => {
     // Find the first shape of type table.
     const shape = shapes.items.find((shape) => shape.type === PowerPoint.ShapeType.table)
     const table = shape.getTable();
-    table.load("values");
+    table.load();
     await context.sync();
+    // Delete the original table.
+    shape.delete();
     // Set the value of the specified table cell.
     let values = table.values;
     values[1][1] = "A new value";
+    // Create a new table with updated values.
+    const newShape = shapes.addTable(
+      table.rowCount,
+      table.columnCount,
+      {
+        values: values
+        // Map other properties from the original table.
+      }
+    );
     table.values = values;
     await context.sync();
 });

--- a/docs/powerpoint/work-with-tables.md
+++ b/docs/powerpoint/work-with-tables.md
@@ -383,7 +383,7 @@ The previous sample creates a table with two merged areas as shown in the follow
 
 ## Get and set table cell values
 
-After a table is created, you can't change values, borders, fonts, widths, or other cell properties. If you need to update a table, delete it and recreate it. The following code sample shows how to find an existing table and set a new value for a cell in the table.
+After a table is created you can get or set string values in the cells. Note that this is the only part of a table you can change. You can't change borders, fonts, widths, or other cell properties. If you need to update a table, delete it and recreate it. The following code sample shows how to find an existing table and set a new value for a cell in the table.
 
 ```javascript
 await PowerPoint.run(async (context) => {
@@ -396,21 +396,9 @@ await PowerPoint.run(async (context) => {
     const table = shape.getTable();
     table.load();
     await context.sync();
-    // Delete the original table.
-    shape.delete();
     // Set the value of the specified table cell.
-    let values = table.values;
-    values[1][1] = "A new value";
-    // Create a new table with updated values.
-    const newShape = shapes.addTable(
-      table.rowCount,
-      table.columnCount,
-      {
-        values: values
-        // Map other properties from the original table.
-      }
-    );
-    await context.sync();
+    const cell = table.getCellOrNullObject(1, 1);
+    cell.text = "A new value";
 });
 ```
 

--- a/docs/powerpoint/work-with-tables.md
+++ b/docs/powerpoint/work-with-tables.md
@@ -410,7 +410,6 @@ await PowerPoint.run(async (context) => {
         // Map other properties from the original table.
       }
     );
-    table.values = values;
     await context.sync();
 });
 ```


### PR DESCRIPTION
In the current version of the [Table object](https://learn.microsoft.com/javascript/api/powerpoint/powerpoint.table), the properties and methods seem to be read-only / gets, including `values`.