### PR TITLE
[all hosts] (Unified Manifest) Update links to the Teams version of the unified manifest reference

### DIFF
--- a/docs/design/add-in-icons-monoline.md
+++ b/docs/design/add-in-icons-monoline.md
@@ -207,7 +207,7 @@ The final icons should be saved as .png image files. Use PNG format with a trans
 
 ### Unified manifest reference
 
-- ["extensions.ribbons" array](/microsoftteams/platform/resources/schema/manifest-schema#extensionsribbons)
+- ["extensions.ribbons" array](/microsoft-365/extensibility/schema/extension-ribbons-array)
 
 ### Add-in only manifest reference
 

--- a/docs/develop/configure-your-add-in-to-use-a-shared-runtime.md
+++ b/docs/develop/configure-your-add-in-to-use-a-shared-runtime.md
@@ -31,7 +31,7 @@ Follow these steps to configure a new or existing project to use a shared runtim
 # [Unified manifest for Microsoft 365](#tab/jsonmanifest)
 
 > [!NOTE]
-> Implementing a shared runtime with the unified manifest for Microsoft 365 is in public developer preview. This shouldn't be used in production add-ins. We invite you to try it out in test or development environments. For more information, see the [Public developer preview app manifest schema](/microsoftteams/platform/resources/schema/manifest-schema-dev-preview).
+> Implementing a shared runtime with the unified manifest for Microsoft 365 is in public developer preview. This shouldn't be used in production add-ins. We invite you to try it out in test or development environments. For more information, see the [Microsoft 365 app manifest schema reference](/microsoft-365/extensibility/schema).
 
 1. Open your add-in project in Visual Studio Code.
 1. Open the **manifest.json** file.

--- a/docs/develop/json-manifest-overview.md
+++ b/docs/develop/json-manifest-overview.md
@@ -83,7 +83,7 @@ The `"extensions"` property in the unified manifest primarily represents charact
 The following table shows a mapping of *some* high-level child properties of the `"extensions"` property in the unified manifest to XML elements in the current manifest. Dot notation is used to reference child properties.
 
 > [!NOTE]
-> This table contains only some selected representative descendant properties of `"extensions"`. *It isn't an exhaustive list of all child properties of `"extensions"`.* For the full reference of the unified manifest, see [Unified manifest for Microsoft 365](/microsoftteams/platform/resources/schema/manifest-schema). For the manifest reference that includes all the latest preview features, see [Public developer preview for the unified manifest for Microsoft 365](/microsoftteams/platform/resources/schema/manifest-schema-dev-preview).
+> This table contains only some selected representative descendant properties of `"extensions"`. *It isn't an exhaustive list of all child properties of `"extensions"`.* For the full reference of the unified manifest, see [Microsoft 365 app manifest schema reference](/microsoft-365/extensibility/schema).
 
 |JSON property|Purpose|XML elements|Comments|
 |:-----|:-----|:-----|:-----|

--- a/docs/develop/unified-manifest-overview.md
+++ b/docs/develop/unified-manifest-overview.md
@@ -28,11 +28,11 @@ We've taken an important first step toward these goals by making it possible for
 
 ## Key properties of the unified manifest
 
-The main reference documentation for the version of the unified app manifest is at [Unified manifest reference](/microsoftteams/platform/resources/schema/manifest-schema). (For the manifest reference that includes all the latest preview features, see [Public developer preview for the unified manifest](/microsoftteams/platform/resources/schema/manifest-schema-dev-preview).) In this article, we provide a brief description of the meaning of base properties when the Teams App is (or includes) an Office Add-in. This is followed by some basic documentation for the [`"extensions"`](/microsoft-365/extensibility/schema/root#extensions) property and its descendant properties. There is a full sample manifest for an add-in at [Sample unified manifest](#sample-unified-manifest).
+The main reference documentation for the version of the unified app manifest is at [Microsoft 365 app manifest schema reference](/microsoft-365/extensibility/schema). In this article, we provide a brief description of the meaning of base properties when the Teams App is (or includes) an Office Add-in. This is followed by some basic documentation for the [`"extensions"`](/microsoft-365/extensibility/schema/root#extensions) property and its descendant properties. There is a full sample manifest for an add-in at [Sample unified manifest](#sample-unified-manifest).
 
 ### Base properties
 
-Each of the base properties listed in the following table has more extensive documentation at [Manifest schema](/microsoftteams/platform/resources/schema/manifest-schema). Base properties not included in this table have no meaning for Office Add-ins.
+Each of the base properties listed in the following table has more extensive documentation at [Microsoft 365 app manifest schema](//microsoft-365/extensibility/schema/root). Base properties not included in this table have no meaning for Office Add-ins.
 
 |JSON property|Purpose|
 |:-----|:-----|
@@ -53,7 +53,7 @@ Each of the base properties listed in the following table has more extensive doc
 We're working hard to complete reference documentation for the `"extensions"` property and its descendant properties. In the meantime, the following provides some basic documentation. Most, but not all, of the properties have an equivalent element (or attribute) in the add-in only manifest for add-ins. For the most part, the description, and restrictions, that apply to the XML element or attribute also apply to its JSON property equivalent in the unified manifest. The tables in the '`"extensions"` property' section of [Compare the add-in only manifest with the unified manifest for Microsoft 365](json-manifest-overview.md#extensions-property) can help you determine the XML equivalent of a JSON property.
 
 > [!NOTE]
-> This table contains only some selected representative descendant properties of `"extensions"`. *It isn't an exhaustive list of all child properties of `"extensions"`.* For the full reference of the unified manifest, see [Unified manifest for Microsoft 365](/microsoftteams/platform/resources/schema/manifest-schema). For the manifest reference that includes all the latest preview features, see [Public developer preview for the unified manifest for Microsoft 365](/microsoftteams/platform/resources/schema/manifest-schema-dev-preview).
+> This table contains only some selected representative descendant properties of `"extensions"`. *It isn't an exhaustive list of all child properties of `"extensions"`.* For the full reference of the unified manifest, see the [Microsoft 365 app manifest schema reference](/microsoft-365/extensibility/schema).
 
 |JSON property|Purpose|
 |:-----|:-----|
@@ -463,4 +463,4 @@ The following is an example of a unified app manifest for an add-in. It doesn't 
 ## See also
 
 - [Create add-in commands with the unified manifest for Microsoft 365](create-addin-commands-unified-manifest.md)
-- [Manifest schema](/microsoftteams/platform/resources/schema/manifest-schema)
+- [Microsoft 365 app manifest schema reference](/microsoft-365/extensibility/schema)

--- a/docs/develop/unified-manifest-overview.md
+++ b/docs/develop/unified-manifest-overview.md
@@ -32,7 +32,7 @@ The main reference documentation for the version of the unified app manifest is 
 
 ### Base properties
 
-Each of the base properties listed in the following table has more extensive documentation at [Microsoft 365 app manifest schema](//microsoft-365/extensibility/schema/root). Base properties not included in this table have no meaning for Office Add-ins.
+Each of the base properties listed in the following table has more extensive documentation at [Microsoft 365 app manifest schema](/microsoft-365/extensibility/schema/root). Base properties not included in this table have no meaning for Office Add-ins.
 
 |JSON property|Purpose|
 |:-----|:-----|

--- a/docs/includes/deploy-updates-that-require-admin-consent.md
+++ b/docs/includes/deploy-updates-that-require-admin-consent.md
@@ -8,4 +8,4 @@ When you add features or fix bugs in your add-in, you'll need to deploy the upda
 > Whenever you make a change to the manifest, you must raise the version number of the manifest.
 >
 > - If the add-in uses the add-in only manifest, see [Version element](/javascript/api/manifest/version).
-> - If the add-in uses the unified manifest, see [version property](/microsoftteams/platform/resources/schema/manifest-schema#version).
+> - If the add-in uses the unified manifest, see [version property](/microsoft-365/extensibility/schema/root#version).

--- a/docs/publish/maintain-breaking-changes.md
+++ b/docs/publish/maintain-breaking-changes.md
@@ -62,7 +62,7 @@ When you update your add-in, there are two pieces to consider: the web applicati
 Whenever you make a change to the manifest, you must raise the version number of the manifest.
 
 - If the add-in uses the add-in only manifest, see [Version element](/javascript/api/manifest/version).
-- If the add-in uses the unified manifest, see [version property](/microsoftteams/platform/resources/schema/manifest-schema#version).
+- If the add-in uses the unified manifest, see [version property](/microsoft-365/extensibility/schema/root#version).
 
 If your add-in is deployed by one or more admins to their organizations, some manifest changes require the admin to consent to the updates. Users are blocked from the add-in until consent is granted. The following manifest changes require the admin to consent again.
 

--- a/docs/publish/publish-nested-app-auth-add-in.md
+++ b/docs/publish/publish-nested-app-auth-add-in.md
@@ -111,5 +111,5 @@ If you deployed your add-in by providing the manifest to admins for central depl
 - [Microsoft AppSource submission FAQ](/partner-center/marketplace-offers/appsource-submission-faq)
 - [Admin consent on the Microsoft identity platform](/entra/identity-platform/v2-admin-consent)
 - [Requesting permissions through consent](/entra/identity-platform/consent-types-developer)
-- [webApplicationInfo property](/microsoftteams/platform/resources/schema/manifest-schema)
+- [webApplicationInfo property](/microsoft-365/extensibility/schema/root#webapplicationinfo)
 - [Nested app authentication and Outlook legacy tokens deprecation FAQ](../outlook/faq-nested-app-auth-outlook-legacy-tokens.md)

--- a/docs/tutorials/excel-tutorial.md
+++ b/docs/tutorials/excel-tutorial.md
@@ -43,7 +43,7 @@ In this tutorial, you'll create an Excel task pane add-in that:
 Next, select the type of manifest that you'd like to use, either the **unified manifest for Microsoft 365** or the **add-in only manifest**. Most of the steps in this tutorial are the same regardless of the manifest type, but the [Protect a worksheet](#protect-a-worksheet) section has separate steps for each manifest type.
 
 > [!NOTE]
-> Using the unified manifest for Microsoft 365 with Excel add-ins is in public developer preview. The unified manifest for Microsoft 365 shouldn't be used in production Excel add-ins. We invite you to try it out in test or development environments. For more information, see the [Public developer preview app manifest schema](/microsoftteams/platform/resources/schema/manifest-schema-dev-preview).
+> Using the unified manifest for Microsoft 365 with Excel add-ins is in public developer preview. The unified manifest for Microsoft 365 shouldn't be used in production Excel add-ins. We invite you to try it out in test or development environments. For more information, see the [Microsoft 365 app manifest schema reference](/microsoft-365/extensibility/schema).
 
 After you complete the wizard, the generator creates the project and installs supporting Node components. You may need to manually run `npm install` in the root folder of your project if something fails during the initial setup.
 
@@ -485,7 +485,7 @@ The steps vary depending on the type of manifest.
 # [Unified manifest for Microsoft 365 (preview)](#tab/jsonmanifest)
 
 > [!NOTE]
-> Using the unified manifest for Microsoft 365 with Excel add-ins is in public developer preview. The unified manifest for Microsoft 365 shouldn't be used in production Excel add-ins. We invite you to try it out in test or development environments. For more information, see the [Public developer preview app manifest schema](/microsoftteams/platform/resources/schema/manifest-schema-dev-preview).
+> Using the unified manifest for Microsoft 365 with Excel add-ins is in public developer preview. The unified manifest for Microsoft 365 shouldn't be used in production Excel add-ins. We invite you to try it out in test or development environments. For more information, see the [Microsoft 365 app manifest schema reference](/microsoft-365/extensibility/schema).
 
 #### Configure the runtime for the ribbon button
 


### PR DESCRIPTION
This PR updates some links that sent readers to the Teams docs instead of the common M365 docs.