### PR TITLE
[All Hosts] (devx) Split manifest conversion and Teams Toolkit articles

### DIFF
--- a/docs/develop/convert-xml-to-json-manifest.md
+++ b/docs/develop/convert-xml-to-json-manifest.md
@@ -2,24 +2,19 @@
 title: Convert an add-in to use the unified manifest for Microsoft 365
 description: Learn the various methods for converting an add-in with an add-in only manifest to the unified manifest for Microsoft 365 and sideload the add-in.
 ms.topic: how-to
-ms.date: 04/22/2025
+ms.date: 05/08/2025
 ms.localizationpriority: medium
 ---
 
 # Convert an add-in to use the unified manifest for Microsoft 365
 
-To add Teams capabilities to an add-in that uses the add-in only manifest, or to just future proof the add-in, you need to convert it to use the unified manifest for Microsoft 365.
-
-> [!NOTE]
->
-> - Projects created in Visual Studio, as distinct from Visual Studio Code, can't be converted at this time.
-> - If you [created the project with Teams Toolkit](teams-toolkit-overview.md) or with the "unified manifest" option in the [Yeoman generator for Office Add-ins (Yo Office)](yeoman-generator-overview.md), it already uses the unified manifest.
+To add Teams capabilities or a Copilot extension to an add-in that uses the add-in only manifest, or to just future proof the add-in, you need to convert it to use the unified manifest for Microsoft 365.
 
    [!INCLUDE [Unified manifest support note for Office applications](../includes/unified-manifest-support-note.md)]
 
 There are three basic tasks to converting an add-in project from the add-in only manifest to the unified manifest.
 
-- Ensure that your add-in is ready to convert.
+- Ensure that your manifest is ready to convert.
 - Convert the XML-formatted add-in only manifest itself to the JSON format of the unified manifest.
 - Package the new manifest and two icon image files (described later) into a zip file for sideloading or deployment. *Depending on how you sideload the converted add-in, this task may be done for you automatically.*
 
@@ -31,7 +26,7 @@ There are three basic tasks to converting an add-in project from the add-in only
 > - Projects created in Visual Studio, as distinct from Visual Studio Code, can't be converted at this time.
 > - If you [created the project with Teams Toolkit](teams-toolkit-overview.md) or with the "unified manifest" option in the [Office Yeoman Generator](yeoman-generator-overview.md), it already uses the unified manifest.
 
-## Ensure that your add-in is ready to convert
+## Ensure that your manifest is ready to convert
 
 The following sections describe conditions that must be met before you convert the manifest.
 
@@ -66,7 +61,7 @@ The following markup is an example.
 
 ### Reduce the number of add-in commands as needed
 
-An add-in that uses the unified manifest may not have more than 20 [add-in commands](../design/add-in-commands.md). If the total number of  [**\<Action\>** elements](/javascript/api/manifest/action) in the add-in only manifest is greater than 20, you must redesign the add-in to have no more than 20.
+An add-in that uses the unified manifest may not have more than 20 [add-in commands](../design/add-in-commands.md). If the total number of [**\<Action\>** elements](/javascript/api/manifest/action) in the add-in only manifest is greater than 20, you must redesign the add-in to have no more than 20.
 
 ### Update the add-in ID, version, domain, and function names in the manifest
 
@@ -83,7 +78,7 @@ An add-in that uses the unified manifest may not have more than 20 [add-in comma
 
 ### Shorten string values as needed
 
-Review and change, as needed, the manifest values in light of the following effects of the conversion.
+Review and change, as needed, manifest values in light of the following effects of the conversion.
 
 - The first 30 characters of `<DisplayName>` becomes the value of [`"name.short"`](/microsoft-365/extensibility/schema/root-name#short) in the unified manifest.
 - The first 100 characters of `<DisplayName>` becomes the value of [`"name.full"`](/microsoft-365/extensibility/schema/root-name#full) in the unified manifest.
@@ -103,52 +98,15 @@ Resolve any problems before you attempt to convert the project.
 
 There are several ways to carry out the remaining tasks, depending on the IDE and other tools you want to use for your project, and on the tool you used to create the project.
 
-- [Convert the project with Teams Toolkit](#convert-the-project-with-teams-toolkit)
 - [Convert projects created with the Yeoman generator for Office Add-ins (aka "Yo Office")](#convert-projects-created-with-the-yeoman-generator-for-office-add-ins-aka-yo-office)
 - [Convert NodeJS and npm projects that weren't created with the Yeoman generator for Office Add-ins (Yo Office)](#convert-nodejs-and-npm-projects-that-werent-created-with-the-yeoman-generator-for-office-add-ins-yo-office)
 
-### Convert the project with Teams Toolkit
-
-The easiest way to convert is to use Teams Toolkit.
-
-#### Prerequisites
-
-- Install [Visual Studio Code](https://code.visualstudio.com/)
-- Install [Teams Toolkit](/microsoftteams/platform/toolkit/install-teams-toolkit?tabs=vscode#install-teams-toolkit-for-visual-studio-code)
-
-#### Import the add-in project to Teams Toolkit
-
-1. Open Visual Studio Code and select the Teams Toolkit icon on the **Activity Bar**.
-
-    :::image type="content" source="../images/teams-toolkit-icon.png" alt-text="Teams Toolkit icon.":::
-
-1. Select **Create a New App**.
-1. The **New Project** dropdown menu opens. The options listed will vary depending on your version of Teams Toolkit. Select **Office Add-in**.
-
-    :::image type="content" source="../images/teams-toolkit-create-office-add-in.png" alt-text="The options in New Project dropdown menu. One option is called 'Office Add-in'.":::
-
-1. The **App Features Using an Office Add-in** dropdown menu opens. The options listed will vary depending on your version of Teams Toolkit. Select **Upgrade an Existing Office Add-in**.
-
-    :::image type="content" source="../images/teams-toolkit-create-office-import-capability.png" alt-text="The options in the App Features Using an Office Add-in dropdown menu. The 'Upgrade an Existing Office Add-in' option is selected.":::
-
-1. In the **Existing add-in project folder** dropdown menu, browse to the root folder of the add-in project.
-1. In the **Select import project manifest file** dropdown menu, browse to the add-in only manifest file, typically named **manifest.xml**.
-1. In the **Workspace folder** dialog, select the folder where you want to put the converted project.
-1. In the **Application name** dialog, give a name to the project (with no spaces). Teams Toolkit creates the project with your source files and scaffolding. It then opens the project *in a second Visual Studio Code window*. Close the original Visual Studio Code window.
-
-#### Sideload the add-in in Visual Studio Code
-
-You can sideload the add-in using the Teams Toolkit or in a command prompt, bash shell, or terminal. For more information, see:
-
-- [Sideload with Teams toolkit](../testing/sideload-add-in-with-unified-manifest.md#sideload-with-the-teams-toolkit)
-- [Sideload with a system prompt, bash shell, or terminal](../testing/sideload-add-in-with-unified-manifest.md#sideload-with-a-system-prompt-bash-shell-or-terminal)
-
 > [!NOTE]
-> Add-ins that use the unified manifest can be sideloaded only on Office Version 2304 (Build 16320.20000) or later.
+> Conversion of the manifest is one of the effects of importing the add-in project into Teams Toolkit if you do so using the toolkit's importation feature. For details, see [Import an add-in project to Teams Toolkit](import-teams-toolkit.md) 
 
 ### Convert projects created with the Yeoman generator for Office Add-ins (aka "Yo Office")
 
-If the project was created with the Yeoman generator for Office Add-ins and you don't want to use the Teams Toolkit, convert it using the following steps.
+If the project was created with the Yeoman generator for Office Add-ins, convert it using the following steps.
 
 1. In the root of the project, open a command prompt or bash shell and run the following command. This converts the manifest and updates the package.json to specify current tooling packages. The new unified manifest is in the root of the project and the old add-in only manifest is in a backup.zip file. For details about this command, see [Office-Addin-Project](https://www.npmjs.com/package/office-addin-project).
 
@@ -161,7 +119,7 @@ If the project was created with the Yeoman generator for Office Add-ins and you 
 
 ### Convert NodeJS and npm projects that weren't created with the Yeoman generator for Office Add-ins (Yo Office)
 
-If you don't want to use the Teams Toolkit and your project wasn't created with Yo Office, use the office-addin-manifest-converter tool.
+If your project wasn't created with Yo Office, use the office-addin-manifest-converter tool.
 
 In the root of the project, open a command prompt or bash shell and run the following command. This command puts the unified manifest in a subfolder with the same name as the filename stem of the original add-in only manifest. For example, if the manifest is named **MyManifest.xml**, the unified manifest is created at **.\MyManifest\MyManifest.json**. For more details about this command, see [Office-Addin-Manifest-Converter](https://www.npmjs.com/package/office-addin-manifest-converter).
 
@@ -170,6 +128,9 @@ npx office-addin-manifest-converter convert <relative-path-to-XML-manifest>
 ```
 
 Once you have the unified manifest created, there are two ways to create the zip file and sideload it. For more information, see [Sideload other NodeJS and npm projects](../testing/sideload-add-in-with-unified-manifest.md#sideload-other-nodejs-and-npm-projects).
+
+> [!NOTE]
+> If the original add-in only manifest used any **\<Override\>** elements to localize strings in the manifest, then the conversion process produces JSON string files for each localized language. These files must also be included in the zip file, and they must be at the relative path indicated in the [`"localizationInfo.additionalLanguages.file"`](/microsoft-365/extensibility/schema/root-localization-info-additional-languages#file) property.
 
 ## Next steps
 

--- a/docs/develop/import-teams-toolkit.md
+++ b/docs/develop/import-teams-toolkit.md
@@ -78,11 +78,12 @@ It is possible that sideloading problems are the result of a file and folder str
 
 ### Post importation: Adjust the project structure and settings as needed
 
-The importation process creates some folders and files that Visual Studio Code or Teams Toolkit need, but it doesn't reorganize your source files; such as HTML, JavaScript, and CSS files. It also doesn't change the content of any files in the project, including tool configuration. We recommend that you change your project to match the pattern of projects that are created in Teams Toolkit. As you work, keep the following points in mind.
+The importation process creates some folders and files that Visual Studio Code or Teams Toolkit need, but it doesn't reorganize your source files; such as HTML, JavaScript, and CSS files. It also doesn't change the content of any files in the project, including tool configuration files. We recommend that you change your project to match the pattern of projects that are created in Teams Toolkit. As you work, keep the following points in mind.
 
-- HTML files in toolkit projects don't have inline `<script>` elements. They only use `<script>` elements with a `src` attribute that loads an external file.
+- HTML files in the toolkit projects don't have inline `<script>` elements. They only use `<script>` elements with a `src` attribute that loads an external file.
 - Source files in a new toolkit project are in a folder named **\src**. Within this folder, the source files are further divided into subfolders based on the runtimes in which they normally are run. The following is a typical structure.
 
+   ```command&nbsp;line
    \src
       \commands
          commands.html
@@ -91,6 +92,7 @@ The importation process creates some folders and files that Visual Studio Code o
          taskpane.css
          taskpane.html
          taskpane.js
+   ```
 
 - Teams Toolkit projects have a folder named **\appPackage**. The manifest and any other files that should be in the app package zip file are in this folder.
 
@@ -104,7 +106,7 @@ The importation process creates some folders and files that Visual Studio Code o
 As an alternative to using the toolkit's importation feature, you can create a brand new add-in project in the toolkit and move files from the existing project into it and make changes to other files. The following are the tasks that you need to carry out.
 
 1. If the existing project uses the add-in only manifest, convert it. See [Convert an add-in to use the unified manifest for Microsoft 365](convert-xml-to-json-manifest.md).
-1. Create a new add-in project in Teams Toolkit. For each choice the toolkit asks you to make, make the choice that best matches your existing add-in. See [Create Office Add-in projects with Teams Toolkit](teams-toolkit-overview.md).
+1. Create a new add-in project in Teams Toolkit. For each choice the toolkit asks you to make, such as the choice between JavaScript and TypeScript, make the choice that best matches your existing add-in. See [Create Office Add-in projects with Teams Toolkit](teams-toolkit-overview.md).
 1. Replace the manifest in the new project's **\appPackage** folder with your converted manifest.
 
    > [!NOTE]
@@ -115,7 +117,7 @@ As an alternative to using the toolkit's importation feature, you can create a b
 1. Inspect the configuration files in the new project to ensure that they are compatible with the organization of the project.
 
    > [!TIP]
-   > When the old project and the new both have a configuration file with the same name (such as **babel.config.json**), use a file comparison ("diff) tool to find the differences. For each difference, determine which file is correct for the new project and change the file in the new project as needed.
+   > When the old project and the new both have a configuration file with the same name (such as **babel.config.json**), use a file comparison ("diff") tool to find the differences. For each difference, determine which file is correct for the new project and change the file in the new project as needed.
 
 1. The **webpack.config.js** is likely to need editing. It isn't possible to give universal rules for that file, but the following principles apply in most cases.
 

--- a/docs/develop/import-teams-toolkit.md
+++ b/docs/develop/import-teams-toolkit.md
@@ -74,7 +74,7 @@ Sideload the add-in using the instructions at [Sideload with Teams toolkit](../t
 
 If you encounter problems, as a troubleshooting step, try [sideloading with a system prompt, bash shell, or terminal](../testing/sideload-add-in-with-unified-manifest.md#sideload-with-a-system-prompt-bash-shell-or-terminal). If you can, then the problem is isolated to the toolkit.
 
-It is possible that sideloading problems are the result of a file and folder structure, or configuration settings, that are different from what Teams Toolkit normally expects. See the section [Post importation: Adjust the project structure and settings as needed](#post-importation-adjust-the-project-structure-and-settings-as-needed).
+It's possible that sideloading problems are the result of a file and folder structure, or configuration settings, that are different from what Teams Toolkit normally expects. See the section [Post importation: Adjust the project structure and settings as needed](#post-importation-adjust-the-project-structure-and-settings-as-needed).
 
 ### Post importation: Adjust the project structure and settings as needed
 
@@ -83,7 +83,7 @@ The importation process creates some folders and files that Visual Studio Code o
 - HTML files in the toolkit projects don't have inline `<script>` elements. They only use `<script>` elements with a `src` attribute that loads an external file.
 - Source files in a new toolkit project are in a folder named **\src**. Within this folder, the source files are further divided into subfolders based on the runtimes in which they normally are run. The following is a typical structure.
 
-   ```command&nbsp;line
+   ```console
    \src
       \commands
          commands.html

--- a/docs/develop/import-teams-toolkit.md
+++ b/docs/develop/import-teams-toolkit.md
@@ -1,0 +1,127 @@
+---
+title: Import an add-in project to Teams Toolkit
+description: Learn how to import an add-in project to Teams Toolkit.
+ms.topic: how-to
+ms.date: 05/08/2025
+ms.localizationpriority: medium
+---
+
+# Import an add-in project to Teams Toolkit
+
+The [Teams Toolkit extension for Visual Studio Code](/microsoftteams/platform/toolkit/teams-toolkit-fundamentals) is a richly featured tool for working with extensions on the Microsoft 365 developer platform, including Teams apps, Office Add-ins, and Copilot extensions, among others. It also makes it easy to work with extensions that transcend the boundaries between Teams apps, add-ins, and Copilot extensions. For example, it makes sideloading such cross-boundary extensions easier.
+
+There can be no algorithmic procedure for importing an add-in into the toolkit because an algorithm would have to make assumptions about the following aspects of the project.
+
+- The folder and file structure of the existing add-in. But these structures vary depending on which tool was used to create the project and what version of that tool. The developer of the add-in might also have changed the structure after the project was created.
+- The settings in various configuration files. But these settings also vary depending on how the project was created and changes made to the configuration since it was created.
+- Which language, TypeScript or JavaScript, was used for the client-side source code of the web application.
+
+However, we can make some general recommendations.
+
+> [!NOTE]
+>
+> - This article doesn't apply to add-in projects that were created with Visual Studio. Such projects are based on the ASP.NET web application framework and are designed to run on Internet Information Server (IIS). Converting such a project to work in Teams Toolkit would significantly more difficult and is out-of-scope for this article.
+> - Add-in projects in Teams Toolkit must use the [unified manifest for Microsoft 365](unified-manifest-overview.md). If your add-in project uses a feature that isn't yet supported with the unified manifest, then you can't import it to Teams Toolkit unless you first redesign it so that it doesn't use unsupported features.
+> - Currently, add-ins that use the unified manifest can't be sideloaded on a Mac. If your development computer is a Mac, don't import your project into Teams Toolkit until sideloading on the Mac is supported.
+
+There are two basic strategies available.
+
+- [Use the importation feature of the toolkit](#use-the-importation-feature-of-the-toolkit)
+- [Start with a new toolkit project](#start-with-a-new-toolkit-project)
+
+Regardless of which you choose, begin by ensuring that you have installed [Visual Studio Code](https://code.visualstudio.com/) and the [Teams Toolkit](/microsoftteams/platform/toolkit/install-teams-toolkit?tabs=vscode#install-teams-toolkit-for-visual-studio-code) extension.
+
+## Use the importation feature of the toolkit
+
+There are four tasks to using the importation feature.
+
+- [Prepare the existing manifest](#prepare-the-existing-manifest)
+- [Import the project](#import-the-project)
+- [Verify that the add-in can be sideloaded](#verify-that-the-add-in-can-be-sideloaded)
+- [Post importation: Adjust the project structure as needed](#post-importation-adjust-the-project-structure-and-settings-as-needed)
+
+### Prepare the existing manifest
+
+> [!IMPORTANT]
+> If the existing project uses the add-in only manifest, the importation feature automatically converts it to a unified manifest. So, you must carry out the steps in [Ensure that your manifest is ready to convert](convert-xml-to-json-manifest.md#ensure-that-your-manifest-is-ready-to-convert) before you import the project.
+
+### Import the project
+
+1. Open Visual Studio Code and select the Teams Toolkit icon on the **Activity Bar**.
+
+    :::image type="content" source="../images/teams-toolkit-icon.png" alt-text="Teams Toolkit icon.":::
+
+1. Select **Create a New App**.
+1. The **New Project** dropdown menu opens. The options listed vary depending on your version of Teams Toolkit. Select **Office Add-in**.
+
+    :::image type="content" source="../images/teams-toolkit-create-office-add-in.png" alt-text="The options in New Project dropdown menu. One option is called 'Office Add-in'.":::
+
+1. The **App Features Using an Office Add-in** dropdown menu opens. The options listed vary depending on your version of Teams Toolkit. Select **Upgrade an Existing Office Add-in**.
+
+    :::image type="content" source="../images/teams-toolkit-create-office-import-capability.png" alt-text="The options in the App Features Using an Office Add-in dropdown menu. The 'Upgrade an Existing Office Add-in' option is selected.":::
+
+1. In the **Existing add-in project folder** dropdown menu, browse to the root folder of the add-in project.
+1. In the **Select import project manifest file** dropdown menu, browse to the add-in only manifest file, typically named **manifest.xml**.
+1. In the **Workspace folder** dialog, select the folder where you want to put the converted project.
+1. In the **Application name** dialog, give a name to the project (with no spaces). Teams Toolkit creates the project with your source files and scaffolding. It then opens the project *in a second Visual Studio Code window*. Close the original Visual Studio Code window.
+
+### Verify that the add-in can be sideloaded
+
+> [!NOTE]
+> Add-ins that use the unified manifest can be sideloaded only on Office Version 2304 (Build 16320.20000) or later.
+
+Sideload the add-in using the instructions at [Sideload with Teams toolkit](../testing/sideload-add-in-with-unified-manifest.md#sideload-with-the-teams-toolkit).
+
+If you encounter problems, as a troubleshooting step, try [sideloading with a system prompt, bash shell, or terminal](../testing/sideload-add-in-with-unified-manifest.md#sideload-with-a-system-prompt-bash-shell-or-terminal). If you can, then the problem is isolated to the toolkit.
+
+It is possible that sideloading problems are the result of a file and folder structure, or configuration settings, that are different from what Teams Toolkit normally expects. See the section [Post importation: Adjust the project structure and settings as needed](#post-importation-adjust-the-project-structure-and-settings-as-needed).
+
+### Post importation: Adjust the project structure and settings as needed
+
+The importation process creates some folders and files that Visual Studio Code or Teams Toolkit need, but it doesn't reorganize your source files; such as HTML, JavaScript, and CSS files. It also doesn't change the content of any files in the project, including tool configuration. We recommend that you change your project to match the pattern of projects that are created in Teams Toolkit. As you work, keep the following points in mind.
+
+- HTML files in toolkit projects don't have inline `<script>` elements. They only use `<script>` elements with a `src` attribute that loads an external file.
+- Source files in a new toolkit project are in a folder named **\src**. Within this folder, the source files are further divided into subfolders based on the runtimes in which they normally are run. The following is a typical structure.
+
+   \src
+      \commands
+         commands.html
+         commands.js
+      \taskpane
+         taskpane.css
+         taskpane.html
+         taskpane.js
+
+- Teams Toolkit projects have a folder named **\appPackage**. The manifest and any other files that should be in the app package zip file are in this folder.
+
+> [!IMPORTANT]
+>
+> - The URLs in manifest will reflect the original structure of the project. Change these URLs as needed if you make changes in the file and folder structure.
+> - Tool configuration files, such as webpack.config.js, may have URLs. Change these as needed.
+
+## Start with a new toolkit project
+
+As an alternative to using the toolkit's importation feature, you can create a brand new add-in project in the toolkit and move files from the existing project into it and make changes to other files. The following are the tasks that you need to carry out.
+
+1. If the existing project uses the add-in only manifest, convert it. See [Convert an add-in to use the unified manifest for Microsoft 365](convert-xml-to-json-manifest.md).
+1. Create a new add-in project in Teams Toolkit. For each choice the toolkit asks you to make, make the choice that best matches your existing add-in. See [Create Office Add-in projects with Teams Toolkit](teams-toolkit-overview.md).
+1. Replace the manifest in the new project's **\appPackage** folder with your converted manifest.
+
+   > [!NOTE]
+   > If the conversion process produced any language string files, such as **fr-fr.json**, add these to the **\appPackage** folder.
+
+1. Replace the files in the **\src** folder of the new project with the source files from your old project. To maximize compatibility with the configuration files in the new project, we recommend that you divide your source files into subfolders based on the runtimes in which they normally are run. For example, have separate folders for the source files of function commands, the taskpane, autorun events, and Excel custom functions.
+1. Edit the manifest to ensure that any URLs in it are compatible with the new structure of the project.
+1. Inspect the configuration files in the new project to ensure that they are compatible with the organization of the project.
+
+   > [!TIP]
+   > When the old project and the new both have a configuration file with the same name (such as **babel.config.json**), use a file comparison ("diff) tool to find the differences. For each difference, determine which file is correct for the new project and change the file in the new project as needed.
+
+1. The **webpack.config.js** is likely to need editing. It isn't possible to give universal rules for that file, but the following principles apply in most cases.
+
+   - Ensure that URLs match the structure of the project.
+   - Ensure that there is an `entry` subproperty for each subfolder under the **\src** folder.
+   - Ensure that the `plugins` array also takes account of each subfolder under the **\src** folder.
+   - Ensure that the `extensions` and `rules` properties take account of the file types in your project that should be handled by loaders and bundled.
+
+1. Ensure that you can sideload the add-in in the new project. See [Verify that the add-in can be sideloaded](#verify-that-the-add-in-can-be-sideloaded).

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -295,6 +295,8 @@ items:
         href: develop/yeoman-generator-overview.md
       - name: Create add-ins with the Teams Toolkit
         href: develop/teams-toolkit-overview.md
+      - name: Import an add-in project to Teams Toolkit
+        href: develop/import-teams-toolkit.md
       - name: Develop add-ins with Visual Studio Code
         href: develop/develop-add-ins-vscode.md
       - name: Create and Develop add-ins with Visual Studio


### PR DESCRIPTION
This PR responds to customer confusion by splitting an article in two. There are now separate articles for (1) converting an XML manifest to JSON, and (2) importing a project into Teams Toolkit.