### PR TITLE
[All hosts] (unified manifest) Correct support for platforms that aren't directly supported

### DIFF
--- a/docs/develop/create-addin-commands-unified-manifest.md
+++ b/docs/develop/create-addin-commands-unified-manifest.md
@@ -599,4 +599,4 @@ You've now completed adding a menu to your add-in. [Sideload and test it](../tes
 ## See also
 
 - [Add-in commands](../design/add-in-commands.md)
-- [Unified manifest for Microsoft 365](json-manifest-overview.md).
+- [Unified manifest for Microsoft 365](json-manifest-overview.md)

--- a/docs/develop/create-addin-commands-unified-manifest.md
+++ b/docs/develop/create-addin-commands-unified-manifest.md
@@ -599,4 +599,4 @@ You've now completed adding a menu to your add-in. [Sideload and test it](../tes
 ## See also
 
 - [Add-in commands](../design/add-in-commands.md)
-- [Unified manifest for Microsoft 365](json-manifest-overview.md)
+- [Unified manifest for Microsoft 365](unified-manifest-overview.md)

--- a/docs/develop/unified-manifest-overview.md
+++ b/docs/develop/unified-manifest-overview.md
@@ -77,11 +77,24 @@ To override this behavior in desktop platforms, add each domain you want to open
 
 ## Client and platform support
 
-Office Add-ins that use the unified manifest for Microsoft 365 are *directly* supported in Office on the web, in [new Outlook on Windows](https://support.microsoft.com/office/656bb8d9-5a60-49b2-a98b-ba7822bc7627), and in Office on Windows connected to a Microsoft 365 subscription, Version 2304 (Build 16320.00000) or later.
+Add-ins that use the unified manifest can be installed if the Office platform *directly* supports it.
 
-When the app package that contains the unified manifest is deployed in [AppSource](https://appsource.microsoft.com/), then an add-in only manifest is generated from the unified manifest and stored. This add-in only manifest enables the add-in to be installed on platforms that don't directly support the unified manifest, including Office on Mac, Office on mobile, subscription versions of Office on Windows earlier than 2304 (Build 16320.00000), and perpetual versions of Office on Windows.
+To run an add-in on platforms that don't directly support the unified manifest, you must publish the add-in to [AppSource](https://appsource.microsoft.com/). When the app package that contains the unified manifest is deployed in AppSource, an add-in only manifest is generated from the unified manifest and stored. This add-in only manifest is then used to install the add-in on platforms that don't directly support the unified manifest.
 
-If you're deploying an add-in in the [Microsoft 365 Admin Center](../publish/publish.md) and require it to run on platforms that don't directly support the unified manifest, the add-in must be a published AppSource add-in. Custom add-ins or line-of-business (LOB) add-ins that use the unified manifest can't currently be deployed in the Microsoft 365 Admin Center.
+The following tables lists which Office platforms directly support add-ins that use the unified manifest.
+
+| Client/platform | Support for add-ins with the unified manifest|
+| ----- | ----- |
+| Office on the web | Directly supported |
+| Office on Windows (Version 2304 (Build 16320.00000) or later) connected to a Microsoft 365 subscription | Directly supported |
+| [new Outlook on Windows](https://support.microsoft.com/office/656bb8d9-5a60-49b2-a98b-ba7822bc7627) | Directly supported |
+| Office on Windows (prior to Version 2304 (Build 16320.00000)) connected to a Microsoft 365 subscription | Not directly supported |
+| Office on Windows (perpetual versions) | Not directly supported |
+| Office on Mac | Not directly supported |
+| Office on mobile | Not directly supported |
+
+> [!NOTE]
+> If you're deploying an add-in in the [Microsoft 365 Admin Center](../publish/publish.md) and require it to run on platforms that don't directly support the unified manifest, the add-in must be a published AppSource add-in. Custom add-ins or line-of-business (LOB) add-ins that use the unified manifest can't currently be deployed in the Microsoft 365 Admin Center.
 
 ## Sample unified manifest
 

--- a/docs/develop/unified-manifest-overview.md
+++ b/docs/develop/unified-manifest-overview.md
@@ -2,7 +2,7 @@
 title: Office Add-ins with the unified app manifest for Microsoft 365
 description: Get an overview of the unified app manifest for Microsoft 365 for Office Add-ins and its uses.
 ms.topic: overview
-ms.date: 02/12/2025
+ms.date: 06/12/2025
 ms.localizationpriority: high
 ---
 
@@ -74,6 +74,14 @@ We're working hard to complete reference documentation for the `"extensions"` pr
 There is a `"validDomains"` array in the manifest file that is used to tell Office which domains your add-in should be allowed to navigate to. As noted in [Specify domains you want to open in the add-in window](add-in-manifests.md#specify-domains-you-want-to-open-in-the-add-in-window), when running in Office on the web, your task pane can be navigated to any URL. However, in desktop platforms, if your add-in tries to go to a URL in a domain other than the domain that hosts the start page, that URL opens in a new browser window outside the add-in pane of the Office application.
 
 To override this behavior in desktop platforms, add each domain you want to open in the add-in window to the list of domains specified in the `"validDomains"` array. If the add-in tries to go to a URL in a domain that is in the list, then it opens in the task pane in both Office on the web and desktop. If it tries to go to a URL that isn't in the list, then in Office on desktop, that URL opens in a new browser window (outside the add-in task pane).
+
+## Client and platform support
+
+Office Add-ins that use the unified manifest for Microsoft 365 are *directly* supported in Office on the web, in [new Outlook on Windows](https://support.microsoft.com/office/656bb8d9-5a60-49b2-a98b-ba7822bc7627), and in Office on Windows connected to a Microsoft 365 subscription, Version 2304 (Build 16320.00000) or later.
+
+When the app package that contains the unified manifest is deployed in [AppSource](https://appsource.microsoft.com/), then an add-in only manifest is generated from the unified manifest and stored. This add-in only manifest enables the add-in to be installed on platforms that don't directly support the unified manifest, including Office on Mac, Office on mobile, subscription versions of Office on Windows earlier than 2304 (Build 16320.00000), and perpetual versions of Office on Windows.
+
+If you're deploying an add-in in the [Microsoft 365 Admin Center](../publish/publish.md) and require it to run on platforms that don't directly support the unified manifest, the add-in must be a published AppSource add-in. Custom add-ins or line-of-business (LOB) add-ins that use the unified manifest can't currently be deployed in the Microsoft 365 Admin Center.
 
 ## Sample unified manifest
 

--- a/docs/develop/unified-manifest-overview.md
+++ b/docs/develop/unified-manifest-overview.md
@@ -2,7 +2,7 @@
 title: Office Add-ins with the unified app manifest for Microsoft 365
 description: Get an overview of the unified app manifest for Microsoft 365 for Office Add-ins and its uses.
 ms.topic: overview
-ms.date: 06/12/2025
+ms.date: 06/17/2025
 ms.localizationpriority: high
 ---
 

--- a/docs/develop/unified-manifest-overview.md
+++ b/docs/develop/unified-manifest-overview.md
@@ -2,7 +2,7 @@
 title: Office Add-ins with the unified app manifest for Microsoft 365
 description: Get an overview of the unified app manifest for Microsoft 365 for Office Add-ins and its uses.
 ms.topic: overview
-ms.date: 06/17/2025
+ms.date: 06/19/2025
 ms.localizationpriority: high
 ---
 

--- a/docs/includes/non-unified-manifest-clients.md
+++ b/docs/includes/non-unified-manifest-clients.md
@@ -1,4 +1,4 @@
 > [!NOTE]
 > Office Add-ins that use the unified manifest for Microsoft 365 are *directly* supported in Office on the web, in [new Outlook on Windows](https://support.microsoft.com/office/656bb8d9-5a60-49b2-a98b-ba7822bc7627), and in Office on Windows connected to a Microsoft 365 subscription, Version 2304 (Build 16320.00000) or later.
 >
-> When the app package that contains the unified manifest is deployed in [AppSource](https://appsource.microsoft.com/) or the [Microsoft 365 Admin Center](../publish/publish.md) then an add-in only manifest is generated from the unified manifest and stored. This add-in only manifest enables the add-in to be installed on platforms that don't directly support the unified manifest, including Office on Mac, Office on mobile, subscription versions of Office on Windows earlier than 2304 (Build 16320.00000), and perpetual versions of Office on Windows.
+> For more information on client and platform support, see [Office Add-ins with the unified app manifest for Microsoft 365](../develop/unified-manifest-overview.md#client-and-platform-support).

--- a/docs/includes/non-unified-manifest-clients.md
+++ b/docs/includes/non-unified-manifest-clients.md
@@ -1,4 +1,2 @@
 > [!NOTE]
-> Office Add-ins that use the unified manifest for Microsoft 365 are *directly* supported in Office on the web, in [new Outlook on Windows](https://support.microsoft.com/office/656bb8d9-5a60-49b2-a98b-ba7822bc7627), and in Office on Windows connected to a Microsoft 365 subscription, Version 2304 (Build 16320.00000) or later.
->
-> For more information on client and platform support, see [Office Add-ins with the unified app manifest for Microsoft 365](../develop/unified-manifest-overview.md#client-and-platform-support).
+> For information on clients and platforms that *directly* support Office Add-ins that use the unified manifest for Microsoft 365, see [Office Add-ins with the unified app manifest for Microsoft 365](../develop/unified-manifest-overview.md#client-and-platform-support).

--- a/docs/outlook/compare-outlook-add-in-support-in-outlook-for-mac.md
+++ b/docs/outlook/compare-outlook-add-in-support-in-outlook-for-mac.md
@@ -1,7 +1,7 @@
 ---
 title: Compare Outlook add-in support in Outlook on Mac
 description: Learn how add-in support in Outlook on Mac compares with other Outlook clients.
-ms.date: 02/29/2024
+ms.date: 06/12/2025
 ms.localizationpriority: medium
 ---
 
@@ -10,8 +10,6 @@ ms.localizationpriority: medium
 You can create and run an Outlook add-in the same way in Outlook on Mac as in the other clients, including Outlook on the web, Windows ([new](https://support.microsoft.com/office/656bb8d9-5a60-49b2-a98b-ba7822bc7627) and classic), iOS, and Android, without customizing the JavaScript for each client. The same calls from the add-in to the Office JavaScript API generally work the same way, except for the areas described in the following table.
 
 For more information, see [Deploy and install Outlook add-ins for testing](testing-and-tips.md).
-
-For information about new UI support, see [Add-in support in Outlook on new Mac UI](#add-in-support-in-outlook-on-new-mac-ui).
 
 | Area | Outlook on the web, Windows (new and classic), and mobile devices | Outlook on Mac |
 |:-----|:-----|:-----|
@@ -39,3 +37,11 @@ You can determine which UI version you're on, as follows:
 **New UI**
 
 ![New UI on Mac.](../images/outlook-on-mac-new.png)
+
+## Support for add-ins with the unified manifest for Microsoft 365
+
+Add-ins that use the [unified manifest for Microsoft 365](../develop/unified-manifest-overview.md) aren't directly supported in Outlook on Mac. To run this type of add-in, it must first be published to [AppSource](https://appsource.microsoft.com/). An add-in only manifest is then generated from the unified manifest, which enables the add-in to be installed in Outlook on Mac.
+
+If you're deploying an add-in that uses the unified manifest in the [Microsoft 365 Admin Center](../publish/publish.md) and require it to run in Outlook on Mac, the add-in must be a published AppSource add-in. Custom add-ins or line-of-business (LOB) add-ins that use the unified manifest can't currently be deployed in the Microsoft 365 Admin Center.
+
+For more information, see the "Client and platform support" section of [Office Add-ins with the unified app manifest for Microsoft 365](../develop/unified-manifest-overview.md#client-and-platform-support).

--- a/docs/outlook/compare-outlook-add-in-support-in-outlook-for-mac.md
+++ b/docs/outlook/compare-outlook-add-in-support-in-outlook-for-mac.md
@@ -1,7 +1,7 @@
 ---
 title: Compare Outlook add-in support in Outlook on Mac
 description: Learn how add-in support in Outlook on Mac compares with other Outlook clients.
-ms.date: 06/17/2025
+ms.date: 06/19/2025
 ms.localizationpriority: medium
 ---
 

--- a/docs/outlook/compare-outlook-add-in-support-in-outlook-for-mac.md
+++ b/docs/outlook/compare-outlook-add-in-support-in-outlook-for-mac.md
@@ -1,7 +1,7 @@
 ---
 title: Compare Outlook add-in support in Outlook on Mac
 description: Learn how add-in support in Outlook on Mac compares with other Outlook clients.
-ms.date: 06/12/2025
+ms.date: 06/17/2025
 ms.localizationpriority: medium
 ---
 

--- a/docs/outlook/outlook-mobile-addins.md
+++ b/docs/outlook/outlook-mobile-addins.md
@@ -1,7 +1,7 @@
 ---
 title: Add-ins for Outlook on mobile devices
 description: Outlook mobile add-ins are supported on all Microsoft 365 business accounts and Outlook.com accounts.
-ms.date: 06/12/2025
+ms.date: 06/17/2025
 ms.localizationpriority: medium
 ---
 

--- a/docs/outlook/outlook-mobile-addins.md
+++ b/docs/outlook/outlook-mobile-addins.md
@@ -1,7 +1,7 @@
 ---
 title: Add-ins for Outlook on mobile devices
 description: Outlook mobile add-ins are supported on all Microsoft 365 business accounts and Outlook.com accounts.
-ms.date: 06/17/2025
+ms.date: 06/19/2025
 ms.localizationpriority: medium
 ---
 

--- a/docs/outlook/outlook-mobile-addins.md
+++ b/docs/outlook/outlook-mobile-addins.md
@@ -1,7 +1,7 @@
 ---
 title: Add-ins for Outlook on mobile devices
 description: Outlook mobile add-ins are supported on all Microsoft 365 business accounts and Outlook.com accounts.
-ms.date: 10/17/2024
+ms.date: 06/12/2025
 ms.localizationpriority: medium
 ---
 
@@ -72,6 +72,14 @@ Here are examples of scenarios that make sense in Outlook mobile.
 **An example user interaction to create a Trello card from an email message on Android**
 
 ![Animated GIF showing user interaction with an add-in in Outlook on Android.](../images/outlook-mobile-addin-interaction-android.gif)
+
+## Support for add-ins with the unified manifest for Microsoft 365
+
+Add-ins that use the [unified manifest for Microsoft 365](../develop/unified-manifest-overview.md) aren't directly supported in Outlook on mobile devices. To run this type of add-in, it must first be published to [AppSource](https://appsource.microsoft.com/). An add-in only manifest is then generated from the unified manifest, which enables the add-in to be installed in Outlook mobile.
+
+If you're deploying an add-in that uses the unified manifest in the [Microsoft 365 Admin Center](../publish/publish.md) and require it to run in Outlook mobile, the add-in must be a published AppSource add-in. Custom add-ins or line-of-business (LOB) add-ins that use the unified manifest can't currently be deployed in the Microsoft 365 Admin Center.
+
+For more information, see the "Client and platform support" section of [Office Add-ins with the unified app manifest for Microsoft 365](../develop/unified-manifest-overview.md#client-and-platform-support).
 
 ## Testing your add-ins on mobile
 


### PR DESCRIPTION
- Clarifies that add-ins that use the unified manifest for Microsoft 365 must be a published AppSource add-in to run on platforms that don't directly support the unified manifest.
- Moves the information about platform support to its own section in [Office Add-ins with the unified app manifest for Microsoft 365](https://learn.microsoft.com/en-us/office/dev/add-ins/develop/unified-manifest-overview).