### PR TITLE
[all hosts] (TOC) Move VS quick starts and tutorials

### DIFF
--- a/docs/quickstarts/powerpoint-quickstart-vs.md
+++ b/docs/quickstarts/powerpoint-quickstart-vs.md
@@ -1,7 +1,7 @@
 ---
 title: Build your first PowerPoint task pane add-in with Visual Studio
 description: Learn how to build a simple PowerPoint task pane add-in by using the Office JS API and a Visual Studio template.
-ms.date: 08/20/2024
+ms.date: 06/20/2025
 ms.service: powerpoint
 ms.localizationpriority: high
 ---

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -319,6 +319,33 @@ items:
           href: develop/get-javascript-intellisense-in-visual-studio.md
         - name: Convert JavaScript projects to TypeScript
           href: develop/convert-javascript-to-typescript.md
+        - name: Quick starts
+          items:
+          - name: Excel
+            items:
+            - name: Task pane
+              href: quickstarts/excel-quickstart-vs.md
+              displayName: Excel, Visual Studio
+            - name: Content
+              href: quickstarts/excel-quickstart-content.md
+              displayName: Excel, Visual Studio
+          - name: Outlook
+            href: quickstarts/outlook-quickstart-vs.md
+            displayName: Outlook, Visual Studio
+          - name: PowerPoint 
+            items:
+            - name: Task pane
+              href: quickstarts/powerpoint-quickstart-vs.md
+              displayName: PowerPoint, Visual Studio
+            - name: Content
+              href: quickstarts/powerpoint-quickstart-content.md
+              displayName: PowerPoint, Visual Studio
+          - name: Word
+            href: quickstarts/word-quickstart-vs.md
+            displayName: Word, Visual Studio
+        - name: PowerPoint presentation tutorial
+          href: tutorials/powerpoint-tutorial-vs.md
+          displayName: Visual Studio
       - name: Copy Script Lab snippet to Yo Office
         href: overview/create-an-office-add-in-from-script-lab.md
         displayName: 'code samples'
@@ -1037,32 +1064,6 @@ items:
   items: 
   - name: VSTO add-in developers' guide to Office Add-ins
     href: overview/learning-path-transition.md
-  - name: Quick starts
-    items:
-    - name: Excel
-      items:
-      - name: Task pane
-        href: quickstarts/excel-quickstart-vs.md
-        displayName: Excel
-      - name: Content
-        href: quickstarts/excel-quickstart-content.md
-        displayName: Excel
-    - name: Outlook
-      href: quickstarts/outlook-quickstart-vs.md
-      displayName: Outlook
-    - name: PowerPoint 
-      items:
-      - name: Task pane
-        href: quickstarts/powerpoint-quickstart-vs.md
-        displayName: PowerPoint
-      - name: Content
-        href: quickstarts/powerpoint-quickstart-content.md
-        displayName: PowerPoint
-    - name: Word
-      href: quickstarts/word-quickstart-vs.md
-      displayName: Word
-  - name: Work with a PowerPoint presentation
-    href: tutorials/powerpoint-tutorial-vs.md
   - name: Share code from VSTO Add-in to Office Add-in
     href: tutorials/migrate-vsto-to-office-add-in-shared-code-library-tutorial.md
   - name: Make your Office Add-in compatible with an existing COM add-in

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -310,15 +310,11 @@ items:
         href: develop/import-teams-toolkit.md
       - name: Develop add-ins with Visual Studio Code
         href: develop/develop-add-ins-vscode.md
-      - name: Create and Develop add-ins with Visual Studio
+      - name: Create and develop add-ins with Visual Studio
         items:
         - name: Overview
           href: develop/develop-add-ins-visual-studio.md
           displayName: Visual Studio
-        - name: Get JavaScript IntelliSense in Visual Studio
-          href: develop/get-javascript-intellisense-in-visual-studio.md
-        - name: Convert JavaScript projects to TypeScript
-          href: develop/convert-javascript-to-typescript.md
         - name: Quick starts
           items:
           - name: Excel
@@ -346,6 +342,10 @@ items:
         - name: PowerPoint presentation tutorial
           href: tutorials/powerpoint-tutorial-vs.md
           displayName: Visual Studio
+        - name: Get JavaScript IntelliSense in Visual Studio
+          href: develop/get-javascript-intellisense-in-visual-studio.md
+        - name: Convert JavaScript projects to TypeScript
+          href: develop/convert-javascript-to-typescript.md
       - name: Copy Script Lab snippet to Yo Office
         href: overview/create-an-office-add-in-from-script-lab.md
         displayName: 'code samples'


### PR DESCRIPTION
- Work with low engagement article: Confirmed that PowerPoint VS quick start is in a good state so updated ms.date
- Moved the VS quick starts and tutorial from the VSTO/COM transition section: Hoping to improve engagement by placing in VS section of TOC