### PR TITLE
[all hosts] (Identity) Rebrand AAD to Entra

### DIFF
--- a/docs/design/authentication-patterns.md
+++ b/docs/design/authentication-patterns.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication design guidelines for Office Add-ins
-ms.date: 08/14/2023
+ms.date: 06/24/2025
 ms.topic: best-practice
 description: Learn how to visually design a sign-on or sign-up page in an Office Add-in.
 
@@ -32,7 +32,7 @@ Add-ins may require users to sign-in or sign-up in order to access features and 
 
     ![The Identity Provider Choices dialog in an Office application.](../images/add-in-auth-choices-dialog.png)
 
-1. Identity Provider Sign-in - The identity provider will have their own UI. Microsoft Azure Active Directory allows customization of sign-in and access panel pages for consistent look and feel with your service. [Learn More](/azure/active-directory/fundamentals/customize-branding).
+1. Identity Provider Sign-in - The identity provider will have their own UI. Microsoft Entra allows customization of sign-in and access panel pages for consistent look and feel with your service. For more information, see [Configure your company branding](/entra/fundamentals/how-to-customize-branding).
 
     ![The Identity Provider Sign-in dialog in an Office application.](../images/add-in-auth-identity-sign-in.png)
 

--- a/docs/develop/authorize-to-microsoft-graph.md
+++ b/docs/develop/authorize-to-microsoft-graph.md
@@ -1,7 +1,7 @@
 ---
 title: Authorize to Microsoft Graph with SSO
 description: Learn how users of an Office Add-in can use single sign-on (SSO) to fetch data from Microsoft Graph.
-ms.date: 01/22/2024
+ms.date: 06/24/2025
 ms.localizationpriority: medium
 ---
 
@@ -61,7 +61,7 @@ When a Microsoft 365 admin acquires an add-in from [AppSource](https://appsource
 If your code passes the `allowConsentPrompt` option in the call of `getAccessToken`, like `OfficeRuntime.auth.getAccessToken( { allowConsentPrompt: true } );`, then Office can prompt the user for consent if the Microsoft identity platform reports to Office that consent has not yet been granted to the add-in. However, for security reasons, Office can only prompt the user to consent to the Microsoft Graph `profile` scope. *Office cannot prompt for consent to other Microsoft Graph scopes*, not even `User.Read`. This means that if the user grants consent on the prompt, Office returns an access token. But the attempt to exchange the access token for a new access token with additional Microsoft Graph scopes fails with error AADSTS65001, which means consent (to Microsoft Graph scopes) has not been granted.
 
 > [!NOTE]
-> The request for consent with `{ allowConsentPrompt: true }` could still fail even for the `profile` scope if the administrator has turned off end-user consent. For more information, see [Configure how end-users consent to applications using Azure Active Directory](/azure/active-directory/manage-apps/configure-user-consent).
+> The request for consent with `{ allowConsentPrompt: true }` could still fail even for the `profile` scope if the administrator has turned off end-user consent. For more information, see [Configure how end-users consent to applications](/entra/identity/enterprise-apps/configure-user-consent).
 
 Your code can, and should, handle this error by falling back to an alternate system of authentication, which prompts the user for consent to Microsoft Graph scopes. For code examples, see [Create a Node.js Office Add-in that uses single sign-on](create-sso-office-add-ins-nodejs.md) and [Create an ASP.NET Office Add-in that uses single sign-on](create-sso-office-add-ins-aspnet.md) and the samples they link to. The entire process requires multiple round trips to the Microsoft identity platform. To avoid this performance penalty, include the `forMSGraphAccess` option in the call of `getAccessToken`; for example, `OfficeRuntime.auth.getAccessToken( { forMSGraphAccess: true } )`. This signals to Office that your add-in needs Microsoft Graph scopes. Office will ask the Microsoft identity platform to verify that consent to Microsoft Graph scopes has already been granted to the add-in. If it has, the access token is returned. If it hasn't, then the call of `getAccessToken` returns error 13012. Your code can handle this error by falling back to an alternate system of authentication immediately, without making a doomed attempt to exchange tokens with the Microsoft identity platform.
 

--- a/docs/develop/debug-office-add-ins-in-visual-studio.md
+++ b/docs/develop/debug-office-add-ins-in-visual-studio.md
@@ -142,7 +142,7 @@ This section describes how to start and debug an add-in in desktop Office on the
 Start the project by choosing **Debug** > **Start Debugging** from the menu bar or press the <kbd>F5</kbd> button. Visual Studio automatically builds the solution and launches the Office application host page of your Microsoft 365 tenancy.
 
 > [!NOTE]
-> When you're debugging an add-in on the web, you may get an AADSTS50011 error similar to the following: 
+> When you're debugging an add-in on the web, you may get an AADSTS50011 error similar to the following:
 >
 >    "The redirect URI `{Full absolute URL to add-in home page}` specified in the request doesn't match the redirect URIs configured for the application  ... "
 >

--- a/docs/develop/enable-nested-app-authentication-in-your-add-in.md
+++ b/docs/develop/enable-nested-app-authentication-in-your-add-in.md
@@ -1,7 +1,7 @@
 ---
 title: Enable single sign-on in an Office Add-in with nested app authentication
 description: Learn how to enable SSO in an Office Add-in with nested app authentication.
-ms.date: 12/23/2024
+ms.date: 06/24/2025
 ms.topic: how-to
 ms.localizationpriority: high
 ---
@@ -17,7 +17,7 @@ You can use the MSAL.js library with nested app authentication to use single sig
 
 ## NAA supported accounts and hosts
 
-NAA supports both Microsoft Accounts and Microsoft Entra ID (work/school) identities. It doesn't support Azure Active Directory B2C for business-to-consumer identity management scenarios. The following table explains the current support by platform. Platforms listed as generally available (GA) are ready for production usage in your add-in.
+NAA supports both Microsoft Accounts and Microsoft Entra ID (work/school) identities. It doesn't support [Azure Active Directory B2C](/azure/active-directory-b2c/overview) for business-to-consumer identity management scenarios. The following table explains the current support by platform. Platforms listed as generally available (GA) are ready for production usage in your add-in.
 
 | Application | Web        | Windows                                              | Mac        | iOS/iPad           | Android        |
 |-------------|------------|------------------------------------------------------|------------|--------------------|----------------|

--- a/docs/develop/json-manifest-overview.md
+++ b/docs/develop/json-manifest-overview.md
@@ -2,7 +2,7 @@
 title: Compare the add-in only manifest with the unified manifest for Microsoft 365
 description: Get a comparison of the add-in only manifest with the unified manifest for Microsoft 365.
 ms.topic: overview
-ms.date: 02/12/2025
+ms.date: 06/24/2025
 ms.localizationpriority: high
 ---
 
@@ -68,7 +68,7 @@ The base manifest properties specify characteristics of the add-in that *any* ty
 |[`"accentColor"`](/microsoft-365/extensibility/schema/root#accentcolor)|*None* |*None* | This property has no equivalent in the add-in only manifest and isn't used in the unified manifest. But it must be present. |
 |[`"developer"`](/microsoft-365/extensibility/schema/root#developer)| Identifies the developer of the add-in. | **\<ProviderName\>** |*None* |
 |[`"localizationInfo"`](/microsoft-365/extensibility/schema/root#localizationinfo)| Configures the default locale and other supported locales. | **\<DefaultLocale\>** and **\<Override\>** |*None* |
-|[`"webApplicationInfo"`](/microsoft-365/extensibility/schema/root#webApplicationInfo-property)| Identifies the add-in's web app as it is known in Azure Active Directory. | **\<WebApplicationInfo\>** | In the add-in only manifest, the **\<WebApplicationInfo\>** element is inside **\<VersionOverrides\>**, not the base manifest. |
+|[`"webApplicationInfo"`](/microsoft-365/extensibility/schema/root#webApplicationInfo-property)| Identifies the add-in's web app as it is known in Microsoft Entra. | **\<WebApplicationInfo\>** | In the add-in only manifest, the **\<WebApplicationInfo\>** element is inside **\<VersionOverrides\>**, not the base manifest. |
 |[`"authorization"`](/microsoft-365/extensibility/schema/root#authorization)| Identifies any Microsoft Graph permissions that the add-in needs. | **\<WebApplicationInfo\>** | In the add-in only manifest, the **\<WebApplicationInfo\>** element is inside **\<VersionOverrides\>**, not the base manifest. |
 
 The **\<Hosts\>**, **\<Requirements\>**, and **\<ExtendedOverrides\>** elements are part of the base manifest in the add-in only manifest. But concepts and purposes associated with these elements are configured inside the `"extensions"` property of the unified manifest.

--- a/docs/develop/overview-authn-authz.md
+++ b/docs/develop/overview-authn-authz.md
@@ -37,7 +37,7 @@ Before you begin implementing user authentication with SSO, be sure that you're 
 
 ### Access your Web APIs through SSO
 
-If your add-in has server-side APIs that require an authorized user, call the [getAccessToken](/javascript/api/office-runtime/officeruntime.auth#office-runtime-officeruntime-auth-getaccesstoken-member(1)) method to get an access token. The access token provides access to your own web server (configured through a [Microsoft Azure app registration](register-sso-add-in-aad-v2.md)). When you call APIs on your web server, you also pass the access token to authorize the user.
+If your add-in has server-side APIs that require an authorized user, call the [getAccessToken](/javascript/api/office-runtime/officeruntime.auth#office-runtime-officeruntime-auth-getaccesstoken-member(1)) method to get an access token. The access token provides access to your own web server (configured through a [Microsoft Entra app registration](register-sso-add-in-aad-v2.md)). When you call APIs on your web server, you also pass the access token to authorize the user.
 
 The following code shows how to construct an HTTPS GET request to the add-in's web server API to get some data. The code runs on the client side, such as in a task pane. It first gets the access token by calling `getAccessToken`. Then it constructs an AJAX call with the correct authorization header and URL for the server API.
 

--- a/docs/develop/troubleshoot-sso-in-office-add-ins.md
+++ b/docs/develop/troubleshoot-sso-in-office-add-ins.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshoot error messages for single sign-on (SSO)
 description: Guidance about how to troubleshoot problems with single sign-on (SSO) in Office Add-ins, and handle special conditions or errors.
-ms.date: 02/07/2024
+ms.date: 06/24/2025
 ms.localizationpriority: medium
 ---
 
@@ -43,7 +43,7 @@ The user isn't signed into Office. In most scenarios, you should prevent this er
 
 But there may be exceptions. For example, you want the add-in to open with features that require a logged in user; but *only if* the user is *already* logged into Office. If the user isn't logged in, you want the add-in to open with an alternate set of features that do not require that the user is signed in. In this case, logic which runs when the add-in launches calls `getAccessToken` without `allowSignInPrompt: true`. Use the 13001 error as the flag to tell the add-in to present the alternate set of features.
 
-Another option is to respond to 13001 by falling back to an alternate system of user authentication. This will sign the user into AAD, but not sign the user into Office.
+Another option is to respond to 13001 by falling back to an alternate system of user authentication. This will sign the user into Microsoft Entra, but not sign the user into Office.
 
 This error doesn't typically occur in Office on the web. If the user's cookie expires, Office on the web returns [error 13006](#13006). However, if a user accesses Outlook on the web from Firefox with Enhanced Tracking Protection turned on, they'll encounter error 13001.
 
@@ -80,8 +80,8 @@ The Office application was unable to get an access token to the add-in's web ser
 - In production, an account mismatch could cause this error. For example, if the user attempts to sign in with a personal Microsoft account (MSA) when a Work or school account was expected. For these cases, your code should fall back to an alternate system of user authentication. For more information on account types, see [Identity and account types for single- and multi-tenant apps](/security/zero-trust/develop/identity-supported-account-types).
 - Make sure your application is enabled for users to sign-in for your organization.
     1. Sign in to the [Microsoft Azure portal](https://portal.azure.com/).
-    2. Go to your add-in's app registration.
-    3. On the **Overview** page,  select **Managed application in local directory**.
+    1. Go to your add-in's app registration.
+    1. On the **Overview** page,  select **Managed application in local directory**.
         :::image type="content" source="../images/azure-portal-managed-application.png" alt-text="The Managed application in local directory option in the App Registration Overview window.":::
     1. Select **Manage** > **Properties**, and ensure that the value of **Enabled for users to sign-in?** is **Yes**.
         :::image type="content" source="../images/azure-portal-enable-sign-in.png" alt-text="The option to allow users in the organization to sign-in to an application in the Properties window.":::
@@ -100,7 +100,7 @@ There are several possible causes.
 
 - The add-in is running on a platform that does not support the `getAccessToken` API. For example, it isn't supported on iPad. See also [Identity API requirement sets](/javascript/api/requirement-sets/common/identity-api-requirement-sets).
 - The Office document was opened from the **Files** tab of a Teams channel using the **Edit in Teams** option on the **Open** dropdown menu. The `getAccessToken` API isn't supported in this scenario.
-- The `forMSGraphAccess` option was passed in the call to `getAccessToken` and the user obtained the add-in from AppSource. In this scenario, the tenant admin has not granted consent to the add-in for the Microsoft Graph scopes (permissions) that it needs. Recalling `getAccessToken` with the `allowConsentPrompt` will not solve the problem because Office is allowed to prompt the user for consent to only the AAD `profile` scope.
+- The `forMSGraphAccess` option was passed in the call to `getAccessToken` and the user obtained the add-in from AppSource. In this scenario, the tenant admin has not granted consent to the add-in for the Microsoft Graph scopes (permissions) that it needs. Recalling `getAccessToken` with the `allowConsentPrompt` will not solve the problem because Office is allowed to prompt the user for consent to only the Entra `profile` scope.
 
 Your code should fall back to an alternate system of user authentication.
 
@@ -116,7 +116,7 @@ This error (which isn't specific to `getAccessToken`) may indicate that the brow
 
 In a production add-in, the add-in should respond to this error by falling back to an alternate system of user authentication. For more information, see [Requirements and Best Practices](../develop/sso-in-office-add-ins.md#requirements-and-best-practices).
 
-## Errors on the server-side from Azure Active Directory
+## Errors on the server-side from Microsoft Entra
 
 For samples of the error-handling described in this section, see:
 
@@ -125,15 +125,15 @@ For samples of the error-handling described in this section, see:
 
 ### Conditional access / Multifactor authentication errors
 
-In certain configurations of identity in AAD and Microsoft 365, it is possible for some resources that are accessible with Microsoft Graph to require multifactor authentication (MFA), even when the user's Microsoft 365 tenancy does not. When AAD receives a request for a token to the MFA-protected resource, via the on-behalf-of flow, it returns to your add-in's web service a JSON message that contains a `claims` property. The claims property has information about what further authentication factors are needed.
+In certain configurations of identity in Entra and Microsoft 365, it is possible for some resources that are accessible with Microsoft Graph to require multifactor authentication (MFA), even when the user's Microsoft 365 tenancy does not. When Entra receives a request for a token to the MFA-protected resource, via the on-behalf-of flow, it returns to your add-in's web service a JSON message that contains a `claims` property. The claims property has information about what further authentication factors are needed.
 
 Your code should test for this `claims` property. Depending on your add-in's architecture, you may test for it on the client-side, or you may test for it on the server-side and relay it to the client. You need this information in the client because Office handles authentication for SSO add-ins. If you relay it from the server-side, the message to the client can be either an error (such as `500 Server Error` or `401 Unauthorized`) or in the body of a success response (such as `200 OK`). In either case, the (failure or success) callback of your code's client-side AJAX call to your add-in's web API should test for this response.
 
-Regardless of your architecture, if the claims value has been sent from AAD, your code should recall `getAccessToken` and pass the option `authChallenge: CLAIMS-STRING-HERE` in the `options` parameter. When AAD sees this string, it prompts the user for the additional factors and then returns a new access token which will be accepted in the on-behalf-of flow.
+Regardless of your architecture, if the claims value has been sent from Entra, your code should recall `getAccessToken` and pass the option `authChallenge: CLAIMS-STRING-HERE` in the `options` parameter. When Entra sees this string, it prompts the user for the additional factors and then returns a new access token which will be accepted in the on-behalf-of flow.
 
 ### Consent missing errors
 
-If AAD has no record that consent (to the Microsoft Graph resource) was granted to the add-in by the user (or tenant administrator), AAD will send an error message to your web service. Your code must tell the client (in the body of a `403 Forbidden` response, for example).
+If Entra has no record that consent (to the Microsoft Graph resource) was granted to the add-in by the user (or tenant administrator), Entra will send an error message to your web service. Your code must tell the client (in the body of a `403 Forbidden` response, for example).
 
 If the add-in needs Microsoft Graph scopes that can only be consented to by an admin, your code should throw an error. If the only scopes that are needed can be consented to by the user, then your code should fall back to an alternate system of user authentication.
 

--- a/docs/develop/unified-manifest-overview.md
+++ b/docs/develop/unified-manifest-overview.md
@@ -2,7 +2,7 @@
 title: Office Add-ins with the unified app manifest for Microsoft 365
 description: Get an overview of the unified app manifest for Microsoft 365 for Office Add-ins and its uses.
 ms.topic: overview
-ms.date: 06/19/2025
+ms.date: 06/24/2025
 ms.localizationpriority: high
 ---
 
@@ -45,7 +45,7 @@ Each of the base properties listed in the following table has more extensive doc
 |[`"developer"`](/microsoft-365/extensibility/schema/root#developer)| Information about the developer of the Teams app/add-in. |
 |[`"localizationInfo"`](/microsoft-365/extensibility/schema/root#localizationinfo)| Configures the default locale and other supported locales. |
 |[`"validDomains"`](/microsoft-365/extensibility/schema/root#validdomains) | See [Specify safe domains](#specify-safe-domains). |
-|[`"webApplicationInfo"`](/microsoft-365/extensibility/schema/root#webApplicationInfo-property)| Identifies the Teams app/add-in's web app as it is known in Azure Active Directory. |
+|[`"webApplicationInfo"`](/microsoft-365/extensibility/schema/root#webApplicationInfo-property)| Identifies the Teams app/add-in's web app as it is known in Microsoft Entra. |
 |[`"authorization"`](/microsoft-365/extensibility/schema/root#authorization)| Identifies any Microsoft Graph permissions that the add-in needs. |
 
 ### `"extensions"` property

--- a/docs/develop/use-sso-to-get-office-signed-in-user-token.md
+++ b/docs/develop/use-sso-to-get-office-signed-in-user-token.md
@@ -1,7 +1,7 @@
 ---
 title: Use SSO to get the identity of the signed-in user
 description: Call the getAccessToken API to get the ID token with name, email, and additional information about the signed-in user.
-ms.date: 06/23/2023
+ms.date: 06/24/2025
 ms.localizationpriority: medium
 ---
 
@@ -151,10 +151,10 @@ In Visual Studio Code, open the **manifest.xml** file.
 The XML you inserted contains the following elements and information.
 
 - **\<WebApplicationInfo\>** - The parent of the following elements.
-- **\<Id\>** - The client ID of the add-in This is an application ID that you obtain as part of registering the add-in. See [Register an Office Add-in that uses SSO with the Azure AD v2.0 endpoint](register-sso-add-in-aad-v2.md).
-- **\<Resource\>** - The URL of the add-in. This is the same URI (including the `api:` protocol) that you used when registering the add-in in AAD. The domain part of this URI must match the domain, including any subdomains, used in the URLs in the **\<Resources\>** section of the add-in's manifest and the URI must end with the client ID in the **\<Id\>**.
+- **\<Id\>** - The client ID of the add-in This is an application ID that you obtain as part of registering the add-in. See [Register an Office Add-in that uses single sign-on (SSO) with the Microsoft identity platform](register-sso-add-in-aad-v2.md).
+- **\<Resource\>** - The URL of the add-in. This is the same URI (including the `api:` protocol) that you used when registering the add-in in Microsft Entra. The domain part of this URI must match the domain, including any subdomains, used in the URLs in the **\<Resources\>** section of the add-in's manifest and the URI must end with the client ID in the **\<Id\>**.
 - **\<Scopes\>** - The parent of one or more **\<Scope\>** elements.
-- **\<Scope\>** - Specifies a permission that the add-in needs to AAD. The `profile` and `openID` permissions are always needed and may be the only permissions needed, if your add-in doesn't access Microsoft Graph. If it does, you also need **\<Scope\>** elements for the required Microsoft Graph permissions; for example, `User.Read`, `Mail.Read`. Libraries that you use in your code to access Microsoft Graph may need additional permissions. For example, Microsoft Authentication Library (MSAL) for .NET requires the `offline_access` permission. For more information, see [Authorize to Microsoft Graph from an Office Add-in](authorize-to-microsoft-graph.md).
+- **\<Scope\>** - Specifies a permission that the add-in needs to Entra. The `profile` and `openID` permissions are always needed and may be the only permissions needed, if your add-in doesn't access Microsoft Graph. If it does, you also need **\<Scope\>** elements for the required Microsoft Graph permissions; for example, `User.Read`, `Mail.Read`. Libraries that you use in your code to access Microsoft Graph may need additional permissions. For example, Microsoft Authentication Library (MSAL) for .NET requires the `offline_access` permission. For more information, see [Authorize to Microsoft Graph from an Office Add-in](authorize-to-microsoft-graph.md).
 
 ## Add the jwt-decode package
 

--- a/docs/develop/xml-manifest-overview.md
+++ b/docs/develop/xml-manifest-overview.md
@@ -2,13 +2,13 @@
 title: Office Add-ins with the add-in only manifest
 description: Get an overview of the add-in only manifest for Office add-ins and its uses.
 ms.topic: overview
-ms.date: 04/12/2024
+ms.date: 06/24/2025
 ms.localizationpriority: high
 ---
 
 # Office Add-ins with the add-in only manifest
 
-This article introduces the XML-formatted add-in only manifest for Office Add-ins. It assumes that you're familiar with the [Office Add-ins manifest](add-in-manifests.md). 
+This article introduces the XML-formatted add-in only manifest for Office Add-ins. It assumes that you're familiar with the [Office Add-ins manifest](add-in-manifests.md).
 
 > [!TIP]
 > For an overview of the unified manifest for Microsoft 365, see [Office Add-ins with the unified manifest for Microsoft 365](unified-manifest-overview.md).
@@ -179,7 +179,7 @@ The optional [VersionOverrides](/javascript/api/manifest/versionoverrides) eleme
 
 - Customizing the Office ribbon and menus.
 - Customizing how Office works with the embedded runtimes in which add-ins run.
-- Configuring how the add-in interacts with Azure Active Directory and Microsoft Graph for Single Sign-on.
+- Configuring how the add-in interacts with Microsoft Entra and Microsoft Graph for Single Sign-on.
 
 Some descendant elements of `VersionOverrides` have values that override values of the parent `OfficeApp` element. For example, the `Hosts` element in `VersionOverrides` overrides the `Hosts` element in `OfficeApp`.
 

--- a/docs/includes/register-sso-add-in-aad-v2-include.md
+++ b/docs/includes/register-sso-add-in-aad-v2-include.md
@@ -79,7 +79,7 @@ Sometimes called an _application password_, a client secret is a string value yo
     For additional application ID URI details, see [Application manifest identifierUris attribute](/azure/active-directory/develop/reference-app-manifest#identifieruris-attribute).
 
     > [!NOTE]
-    > If you get an error saying that the domain is already owned but you own it, follow the procedure at [Quickstart: Add a custom domain name to Azure Active Directory](/azure/active-directory/add-custom-domain) to register it, and then repeat this step. (This error can also occur if you are not signed in with credentials of an admin in the Microsoft 365 tenancy. See step 2. Sign out and sign in again with admin credentials and repeat the process from step 3.)
+    > If you get an error saying that the domain is already owned but you own it, follow the procedure at [Add your custom domain name to your tenant](/entra/fundamentals/add-custom-domain) to register it, and then repeat this step. (This error can also occur if you are not signed in with credentials of an admin in the Microsoft 365 tenancy. See step 2. Sign out and sign in again with admin credentials and repeat the process from step 3.)
 
 ## Add a scope
 
@@ -126,8 +126,6 @@ Sometimes called an _application password_, a client secret is a string value yo
     > - `93d53678-613d-4013-afc1-62e9e444a0a5` (Office on the web)
     > - `bc59ab01-8403-45c6-8796-ac3ef710b3e3` (Outlook on the web)
 
-
-
 1. In **Authorized scopes**, select the `api://<fully-qualified-domain-name>/<app-id>/access_as_user` checkbox.
 
 1. Select **Add application**.
@@ -169,7 +167,7 @@ Sometimes called an _application password_, a client secret is a string value yo
 
 ## Configure access token version
 
-You must define the access token version that is acceptable for your app. This configuration is made in the Azure Active Directory application manifest.
+You must define the access token version that is acceptable for your app. This configuration is made in the Microsoft Entra application manifest.
 
 ### Define the access token version
 
@@ -179,7 +177,7 @@ The access token version can change if you chose an account type other than **Ac
 
     :::image type="content" source="../images/azure-portal-manifest.png" alt-text="Select Azure manifest.":::
 
-    The Azure Active Directory application manifest appears.
+    The Microsoft Entra application manifest appears.
 
 1. Enter **2** as the value for the `requestedAccessTokenVersion` property (in the `api` object).
 

--- a/docs/outlook/authenticate-a-user-with-an-sso-token.md
+++ b/docs/outlook/authenticate-a-user-with-an-sso-token.md
@@ -1,12 +1,13 @@
 ---
 title: Authenticate a user with a single-sign-on token
 description: Learn about using the single-sign-on token provided by an Outlook add-in to implement SSO with your service.
-ms.date: 07/24/2024
+ms.date: 06/24/2025
 ms.topic: how-to
 ms.localizationpriority: medium
 ---
 
 # Authenticate a user with a single-sign-on token in an Outlook add-in
+
 [!INCLUDE [legacy-exchange-token-deprecation](../includes/legacy-exchange-token-deprecation.md)]
 
 Single sign-on (SSO) provides a seamless way for your add-in to authenticate users (and optionally to obtain access tokens to call the [Microsoft Graph API](/graph/overview)).
@@ -24,7 +25,7 @@ To use SSO with an Outlook add-in, you must enable Modern Authentication for the
 
 ## Register your add-in
 
-To use SSO, your Outlook add-in will need to have a server-side web API that is registered with Azure Active Directory (AAD) v2.0. For more information, see [Register an Office Add-in that uses SSO with the Azure AD v2.0 endpoint](../develop/register-sso-add-in-aad-v2.md).
+To use SSO, your Outlook add-in will need to have a server-side web API that is registered with Microsoft Entra. For more information, see [Register an Office Add-in that uses SSO with the Microsoft identity platform](../develop/register-sso-add-in-aad-v2.md).
 
 ### Provide consent when sideloading an add-in
 

--- a/docs/outlook/authentication.md
+++ b/docs/outlook/authentication.md
@@ -1,7 +1,7 @@
 ---
 title: Authentication options in Outlook add-ins
 description: Outlook add-ins provide a number of different methods to authenticate, depending on your specific scenario.
-ms.date: 10/29/2024
+ms.date: 06/24/2025
 ms.topic: overview
 ms.localizationpriority: high
 ---
@@ -25,7 +25,7 @@ Consider using SSO access tokens if your add-in:
   - Microsoft services that are exposed as part of Microsoft Graph
   - A non-Microsoft service that you control
 
-The SSO authentication method uses the [OAuth2 On-Behalf-Of flow provided by Azure Active Directory](/azure/active-directory/develop/active-directory-v2-protocols-oauth-on-behalf-of). It requires that the add-in register in the [Application Registration Portal](https://apps.dev.microsoft.com/) and specify any required Microsoft Graph scopes in the add-in manifest, if the add-in only manifest is being used. If the add-in is using the [unified manifest for Microsoft 365](../develop/json-manifest-overview.md), there is some manifest configuration, but Microsoft Graph scopes aren't specified. Instead, the needed scopes are specified at runtime in a call to fetch a token to Microsoft Graph.
+The SSO authentication method uses the [Microsoft identity platform and OAuth 2.0 On-Behalf-Of flow](/entra/identity-platform/v2-oauth2-on-behalf-of-flow). It requires that the add-in register in the [Application Registration Portal](https://apps.dev.microsoft.com/) and specify any required Microsoft Graph scopes in the add-in manifest, if the add-in only manifest is being used. If the add-in is using the [unified manifest for Microsoft 365](../develop/json-manifest-overview.md), there is some manifest configuration, but Microsoft Graph scopes aren't specified. Instead, the needed scopes are specified at runtime in a call to fetch a token to Microsoft Graph.
 
 Using this method, your add-in can obtain an access token scoped to your server back-end API. The add-in uses this as a bearer token in the `Authorization` header to authenticate a call back to your API. At that point your server can:
 

--- a/docs/publish/publish-add-in-vs-code.md
+++ b/docs/publish/publish-add-in-vs-code.md
@@ -1,6 +1,6 @@
 ---
 title: Publish an add-in using Visual Studio Code and Azure
-description: How to publish an add-in using Visual Studio Code and Azure Active Directory
+description: How to publish an add-in using Visual Studio Code and Microsoft Entra
 ms.date: 05/19/2025
 ms.custom: vscode-azure-extension-update-completed
 ms.localizationpriority: medium


### PR DESCRIPTION
Azure Active Directory was rebranded to Microsoft Entra. This PR updates our docs to reflect that change.