### PR TITLE
[Outlook] (mobile) Update supported Office.Recipients methods

### DIFF
--- a/docs/outlook/outlook-mobile-apis.md
+++ b/docs/outlook/outlook-mobile-apis.md
@@ -1,7 +1,7 @@
 ---
 title: Outlook JavaScript APIs supported in Outlook on mobile devices
 description: Learn which Outlook JavaScript APIs are supported in Outlook on mobile devices.
-ms.date: 06/12/2025
+ms.date: 07/17/2025
 ms.localizationpriority: medium
 ---
 
@@ -62,8 +62,6 @@ Although Outlook mobile supports up to requirement set 1.5, there are some APIs 
 |[Office.context.mailbox.item.getRegexMatches](/javascript/api/requirement-sets/outlook/preview-requirement-set/office.context.mailbox.item#methods)|Mailbox 1.1|<ul><li>Message Read</li><li>Appointment Attendee</li></ul>|
 |[Office.context.mailbox.item.getRegexMatchesByName](/javascript/api/requirement-sets/outlook/preview-requirement-set/office.context.mailbox.item#methods)|Mailbox 1.1|<ul><li>Message Read</li><li>Appointment Attendee</li></ul>|
 |[Office.context.mailbox.item.notificationMessages](/javascript/api/requirement-sets/outlook/preview-requirement-set/office.context.mailbox.item#methods)|Mailbox 1.3|<ul><li>Appointment Attendee</li><li>Appointment Organizer</li></ul>|
-|[Office.context.mailbox.item.bcc.addAsync](/javascript/api/outlook/office.recipients#outlook-office-recipients-addasync-member(1))<br><br>[Office.context.mailbox.item.cc.addAsync](/javascript/api/outlook/office.recipients#outlook-office-recipients-addasync-member(1))<br><br>[Office.context.mailbox.item.to.addAsync](/javascript/api/outlook/office.recipients#outlook-office-recipients-addasync-member(1))|Mailbox 1.1|<ul><li>Message Compose</li></ul>|
-|[Office.context.mailbox.item.bcc.setAsync](/javascript/api/outlook/office.recipients#outlook-office-recipients-setasync-member(1))<br><br>[Office.context.mailbox.item.cc.setAsync](/javascript/api/outlook/office.recipients#outlook-office-recipients-setasync-member(1))<br><br>[Office.context.mailbox.item.to.setAsync](/javascript/api/outlook/office.recipients#outlook-office-recipients-setasync-member(1))|Mailbox 1.1|<ul><li>Message Compose</li></ul>|
 |[Office.context.mailbox.item.body.getTypeAsync](/javascript/api/outlook/office.body#outlook-office-body-gettypeasync-member(1))|Mailbox 1.1|<ul><li>Message Compose</li></ul>|
 |[Office.context.mailbox.item.body.prependAsync](/javascript/api/outlook/office.body#outlook-office-body-prependasync-member(1))|Mailbox 1.1|<ul><li>Message Compose</li></ul>|
 |[Office.context.mailbox.item.body.setAsync](/javascript/api/outlook/office.body#outlook-office-body-setasync-member(1))|Mailbox 1.1|<ul><li>Message Compose</li></ul>|


### PR DESCRIPTION
The `addAsync` and `setAsync` methods of Office.Recipients is now supported on the Message Compose surface in Outlook on mobile devices.