### PR TITLE
Update pinnable-taskpane.md

### DIFF
--- a/docs/outlook/pinnable-taskpane.md
+++ b/docs/outlook/pinnable-taskpane.md
@@ -1,7 +1,7 @@
 ---
 title: Implement a pinnable task pane in an Outlook add-in
 description: The task pane UX shape for add-in commands opens a vertical task pane to the right of an open message or meeting request, allowing the add-in to provide UI for more detailed interactions.
-ms.date: 10/01/2024
+ms.date: 07/15/2025
 ms.topic: how-to
 ms.localizationpriority: medium
 ---

--- a/docs/outlook/pinnable-taskpane.md
+++ b/docs/outlook/pinnable-taskpane.md
@@ -125,9 +125,9 @@ Office.onReady(() => {
 
 ## Task pane pinning in multi-select
 
-In Outlook on the web and new Outlook on Windows, when the task pane of an add-in that implements the [item multi-select](item-multi-select.md) feature is opened, it's automatically pinned to the Outlook client. It remains pinned even when a user switches to a different mail item or selects the **pin** icon from the task pane. The task pane can only be closed by selecting the **Close** button from the task pane.
+In Outlook on the web and new Outlook on Windows and Mac, when the task pane of an add-in that implements the [item multi-select](item-multi-select.md) feature is opened, it's automatically pinned to the Outlook client. It remains pinned even when a user switches to a different mail item or selects the **pin** icon from the task pane. The task pane can only be closed by selecting the **Close** button from the task pane.
 
-Conversely, in classic Outlook on Windows and Outlook on Mac, the task pane of a multi-select add-in isn't automatically pinned and closes when a user switches to a different mail item.
+Conversely, in classic Outlook on Windows, the task pane of a multi-select add-in isn't automatically pinned and closes when a user switches to a different mail item.
 
 ## Deploy to users
 

--- a/docs/outlook/pinnable-taskpane.md
+++ b/docs/outlook/pinnable-taskpane.md
@@ -125,7 +125,7 @@ Office.onReady(() => {
 
 ## Task pane pinning in multi-select
 
-In Outlook on the web and new Outlook on Windows and Mac, when the task pane of an add-in that implements the [item multi-select](item-multi-select.md) feature is opened, it's automatically pinned to the Outlook client. It remains pinned even when a user switches to a different mail item or selects the **pin** icon from the task pane. The task pane can only be closed by selecting the **Close** button from the task pane.
+In Outlook on the web, on Mac, and in the new Outlook on Windows, when the task pane of an add-in that implements the [item multi-select](item-multi-select.md) feature is opened, it's automatically pinned to the Outlook client. It remains pinned even when a user switches to a different mail item or selects the **pin** icon from the task pane. The task pane can only be closed by selecting the **Close** button from the task pane.
 
 Conversely, in classic Outlook on Windows, the task pane of a multi-select add-in isn't automatically pinned and closes when a user switches to a different mail item.
 


### PR DESCRIPTION
Behavior for macOS client no longer seems to match what's described here.
The task pane in macOS replicates the Outlook on the web behavior, i.e. it **remains visible** even if it isn't manually pinned by the end user.