### PR TITLE
[admin] (Formatting) Standardize XML element formatting

### DIFF
--- a/docs/concepts/browsers-used-by-office-web-add-ins.md
+++ b/docs/concepts/browsers-used-by-office-web-add-ins.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Browsers and webview controls used by Office Add-ins
 description: Specifies how the operating system and Office version determine what webview is used by Office Add-ins.
 ms.topic: concept-article
@@ -79,7 +79,7 @@ To determine whether Office 2016 or Office 2019 is retail or volume-licensed, us
 
 <sup>2</sup> When you use either EdgeHTML or WebView2, the Windows Narrator (sometimes called a "screen reader") reads the `<title>` tag in the page that opens in the task pane. In Trident+, the Narrator reads the title bar of the task pane, which comes from the add-in name that's specified in the add-in's manifest.
 
-<sup>3</sup> If your add-in uses an add-in only manifest and includes the **\<Runtimes\>** element in the manifest or it uses the unified manifest and it includes an "extensions.runtimes.lifetime" property, then it won't use EdgeHTML. If the conditions for using WebView2 are met, then the add-in uses WebView2. Otherwise, it uses Trident+. For more information, see [Runtimes](/javascript/api/manifest/runtimes) and [Activate add-ins with events](../develop/event-based-activation.md).
+<sup>3</sup> If your add-in uses an add-in only manifest and includes the `<Runtimes>` element in the manifest or it uses the unified manifest and it includes an "extensions.runtimes.lifetime" property, then it won't use EdgeHTML. If the conditions for using WebView2 are met, then the add-in uses WebView2. Otherwise, it uses Trident+. For more information, see [Runtimes](/javascript/api/manifest/runtimes) and [Activate add-ins with events](../develop/event-based-activation.md).
 
 ### Microsoft 365 subscription versions of Office on Windows
 
@@ -100,7 +100,7 @@ For subscription Office on Windows, the browser that's used is determined by the
 
 <sup>3</sup> When you use either EdgeHTML or WebView2, the Windows Narrator (sometimes called a "screen reader") reads the `<title>` tag in the page that opens in the task pane. In Trident+, the Narrator reads the title bar of the task pane, which comes from the add-in name that's specified in the add-in's manifest.
 
-<sup>4</sup> If your add-in uses an add-in only manifest and includes the **\<Runtimes\>** element in the manifest or it uses the unified manifest and it includes an "extensions.runtimes.lifetime" property, then it won't use EdgeHTML. If the conditions for using WebView2 are met, then the add-in uses WebView2. Otherwise, it uses Trident+. For more information, see [Runtimes](/javascript/api/manifest/runtimes) and [Activate add-ins with events](../develop/event-based-activation.md).
+<sup>4</sup> If your add-in uses an add-in only manifest and includes the `<Runtimes>` element in the manifest or it uses the unified manifest and it includes an "extensions.runtimes.lifetime" property, then it won't use EdgeHTML. If the conditions for using WebView2 are met, then the add-in uses WebView2. Otherwise, it uses Trident+. For more information, see [Runtimes](/javascript/api/manifest/runtimes) and [Activate add-ins with events](../develop/event-based-activation.md).
 
 ## Working with Trident+ (Internet Explorer 11)
 

--- a/docs/concepts/duplicate-legacy-metaos-add-ins.md
+++ b/docs/concepts/duplicate-legacy-metaos-add-ins.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Manage both a unified manifest and an add-in only manifest version of your Office Add-in
 description: Learn when and how to maintain versions of your add-in for each type of manifest.
 ms.topic: best-practice
@@ -102,7 +102,7 @@ The critical requirement for making two versions available is to be sure that th
 
 - Give the new version a different name from the existing add-in.
 - Create and use different icons for the new version.
-- Be sure that the [`"id"`](/microsoft-365/extensibility/schema/root#id) property of the unified manifest in the new version is a different GUID from the **\<Id\>** element in the add-in only manifest of the existing add-in.
+- Be sure that the [`"id"`](/microsoft-365/extensibility/schema/root#id) property of the unified manifest in the new version is a different GUID from the `<Id>` element in the add-in only manifest of the existing add-in.
 
 > [!NOTE]
 > If you use the same name and icon, the old and new solutions appear indistinguishable in the Outlook UI for add-in installation.

--- a/docs/concepts/privacy-and-security.md
+++ b/docs/concepts/privacy-and-security.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Privacy and security for Office Add-ins
 description: Learn about the privacy and security aspects of the Office Add-ins platform.
 ms.date: 07/24/2025
@@ -301,7 +301,7 @@ Developers should also take note of the following security practices.
 
 - Developers shouldn't use ActiveX controls in Office Add-ins as ActiveX controls don't support the cross-platform nature of the add-in platform.
 
-- Content and task pane add-ins assume the same SSL settings that the browser uses by default, and allows most content to be delivered only by SSL. Outlook add-ins require all content to be delivered by SSL. Developers must specify in the **\<SourceLocation\>** element of the add-in manifest a URL that uses HTTPS, to identify the location of the HTML file for the add-in.
+- Content and task pane add-ins assume the same SSL settings that the browser uses by default, and allows most content to be delivered only by SSL. Outlook add-ins require all content to be delivered by SSL. Developers must specify in the `<SourceLocation>` element of the add-in manifest a URL that uses HTTPS, to identify the location of the HTML file for the add-in.
 
   To make sure add-ins aren't delivering content by using HTTP, when testing add-ins, developers should make sure the following settings are selected in **Internet Options** in **Control Panel** and no security warnings appear in their test scenarios.
 

--- a/docs/design/built-in-button-integration.md
+++ b/docs/design/built-in-button-integration.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Integrate built-in Office buttons into custom control groups and tabs
 description: Learn how to include built-in Office buttons in your custom command groups and tabs on the Office ribbon.
 ms.date: 06/10/2025
@@ -100,7 +100,7 @@ The following example adds the Office Superscript control to a custom group.
 
 ## Insert a built-in control group into a custom tab
 
-To insert a built-in Office control group into a tab, add an [OfficeGroup](/javascript/api/manifest/customtab#officegroup) element as a child element in the parent **\<CustomTab\>** element. The `id` attribute of the of the **\<OfficeGroup\>** element is set to the ID of the built-in group. See [Find the IDs of controls and control groups](#find-the-ids-of-controls-and-control-groups).
+To insert a built-in Office control group into a tab, add an [OfficeGroup](/javascript/api/manifest/customtab#officegroup) element as a child element in the parent `<CustomTab>` element. The `id` attribute of the of the `<OfficeGroup>` element is set to the ID of the built-in group. See [Find the IDs of controls and control groups](#find-the-ids-of-controls-and-control-groups).
 
 The following markup example adds the Office Paragraph control group to a custom tab and positions it to appear just after a custom group.
 
@@ -118,7 +118,7 @@ The following markup example adds the Office Paragraph control group to a custom
 
 ## Insert a built-in control into a custom group
 
-To insert a built-in Office control into a custom group, add an [OfficeControl](/javascript/api/manifest/group#officecontrol) element as a child element in the parent **\<Group\>** element. The `id` attribute of the **\<OfficeControl\>** element is set to the ID of the built-in control. See [Find the IDs of controls and control groups](#find-the-ids-of-controls-and-control-groups).
+To insert a built-in Office control into a custom group, add an [OfficeControl](/javascript/api/manifest/group#officecontrol) element as a child element in the parent `<Group>` element. The `id` attribute of the `<OfficeControl>` element is set to the ID of the built-in control. See [Find the IDs of controls and control groups](#find-the-ids-of-controls-and-control-groups).
 
 The following markup example adds the Office Superscript control to a custom group and positions it to appear just after a custom button.
 

--- a/docs/design/contextual-tabs.md
+++ b/docs/design/contextual-tabs.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Create custom contextual tabs in Office Add-ins
 description: Learn how to add custom contextual tabs to your Office Add-in.
 ms.date: 06/30/2025
@@ -221,7 +221,7 @@ We'll construct an example of a contextual tabs JSON blob step-by-step. The full
 
     - Both the properties are required.
     - The `size` property unit of measure is pixels. Icons are always square, so the number is both the height and the width.
-    - The `sourceLocation` property specifies the full URL to the icon. Its value must match the URL specified in the **\<Image\>** element of the **\<Resources\>** section of your manifest (see [Specify the icons for your contextual tab](#specify-the-icons-for-your-contextual-tab)).
+    - The `sourceLocation` property specifies the full URL to the icon. Its value must match the URL specified in the `<Image>` element of the `<Resources>` section of your manifest (see [Specify the icons for your contextual tab](#specify-the-icons-for-your-contextual-tab)).
 
     > [!IMPORTANT]
     > Just as you typically must change the URLs in the add-in's manifest when you move from development to production, you must also change the URLs in your contextual tabs JSON.
@@ -720,7 +720,7 @@ When a parent menu control is marked with `"overriddenByRibbonApi": true`, then 
 
 # [Add-in only manifest](#tab/xmlmanifest)
 
-Begin by defining a custom core tab (that is, *noncontextual* custom tab) in the manifest that duplicates the ribbon customizations of the custom contextual tabs in your add-in. But add an [OverriddenByRibbonApi](/javascript/api/manifest/overriddenbyribbonapi) element as the first child element of the duplicate [Group](/javascript/api/manifest/group), [Control](/javascript/api/manifest/control), and menu **\<Item\>** elements on the custom core tabs. The effect of doing so is the following:
+Begin by defining a custom core tab (that is, *noncontextual* custom tab) in the manifest that duplicates the ribbon customizations of the custom contextual tabs in your add-in. But add an [OverriddenByRibbonApi](/javascript/api/manifest/overriddenbyribbonapi) element as the first child element of the duplicate [Group](/javascript/api/manifest/group), [Control](/javascript/api/manifest/control), and menu `<Item>` elements on the custom core tabs. The effect of doing so is the following:
 
 - If the add-in runs on an application and platform that support custom contextual tabs, then the custom core groups and controls won't appear on the ribbon. Instead, the custom contextual tab will be created when the add-in calls the `requestCreateControls` method.
 - If the add-in runs on an application or platform that *doesn't* support `requestCreateControls`, then the elements do appear on the custom core tab.
@@ -751,10 +751,10 @@ The following is an example. Note that "MyButton" will appear on the custom core
 
 For more examples, see [OverriddenByRibbonApi](/javascript/api/manifest/overriddenbyribbonapi).
 
-When a parent group, or menu is marked with `<OverriddenByRibbonApi>true</OverriddenByRibbonApi>`, then it isn't visible, and all of its child markup is ignored when custom contextual tabs aren't supported. So, it doesn't matter if any of those child elements have the **\<OverriddenByRibbonApi\>** element or what its value is. The implication of this is that if a menu item or control must be visible in all contexts, then not only should it not be marked with `<OverriddenByRibbonApi>true</OverriddenByRibbonApi>`, but *its ancestor menu and group must also not be marked this way*.
+When a parent group, or menu is marked with `<OverriddenByRibbonApi>true</OverriddenByRibbonApi>`, then it isn't visible, and all of its child markup is ignored when custom contextual tabs aren't supported. So, it doesn't matter if any of those child elements have the `<OverriddenByRibbonApi>` element or what its value is. The implication of this is that if a menu item or control must be visible in all contexts, then not only should it not be marked with `<OverriddenByRibbonApi>true</OverriddenByRibbonApi>`, but *its ancestor menu and group must also not be marked this way*.
 
 > [!IMPORTANT]
-> Don't mark *all* of the child elements of a group or menu with `<OverriddenByRibbonApi>true</OverriddenByRibbonApi>`. This is pointless if the parent element is marked with `<OverriddenByRibbonApi>true</OverriddenByRibbonApi>` for reasons given in the preceding paragraph. Moreover, if you leave out the **\<OverriddenByRibbonApi\>** on the parent (or set it to `false`), then the parent will appear regardless of whether custom contextual tabs are supported, but it will be empty when they are supported. So, if all the child elements shouldn't appear when custom contextual tabs are supported, mark the parent with `<OverriddenByRibbonApi>true</OverriddenByRibbonApi>`.
+> Don't mark *all* of the child elements of a group or menu with `<OverriddenByRibbonApi>true</OverriddenByRibbonApi>`. This is pointless if the parent element is marked with `<OverriddenByRibbonApi>true</OverriddenByRibbonApi>` for reasons given in the preceding paragraph. Moreover, if you leave out the `<OverriddenByRibbonApi>` on the parent (or set it to `false`), then the parent will appear regardless of whether custom contextual tabs are supported, but it will be empty when they are supported. So, if all the child elements shouldn't appear when custom contextual tabs are supported, mark the parent with `<OverriddenByRibbonApi>true</OverriddenByRibbonApi>`.
 
 ---
 

--- a/docs/design/custom-tab-placement.md
+++ b/docs/design/custom-tab-placement.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Position a custom tab on the ribbon
 description: Learn how to control where a custom tab appears on the Office ribbon and whether it has focus by default.
 ms.date: 02/12/2025
@@ -58,7 +58,7 @@ In the following example, the custom tab is configured to appear *just after* th
 
 To position your custom tab, include either an [InsertBefore](/javascript/api/manifest/customtab#insertbefore) (left) or an [InsertAfter](/javascript/api/manifest/customtab#insertafter) (right) element in the [CustomTab](/javascript/api/manifest/customtab) element of your add-in's manifest. (You cannot have both elements.)
 
-In the following example, the custom tab is configured to appear *just after* the **Review** tab. Note that the value of the **\<InsertAfter\>** element is the ID of the built-in Office tab. See [Find the IDs of built-in Office ribbon tabs](../develop/built-in-ui-ids.md).
+In the following example, the custom tab is configured to appear *just after* the **Review** tab. Note that the value of the `<InsertAfter>` element is the ID of the built-in Office tab. See [Find the IDs of built-in Office ribbon tabs](../develop/built-in-ui-ids.md).
 
 ```xml
 <ExtensionPoint xsi:type="ContosoRibbonTab">

--- a/docs/design/disable-add-in-commands.md
+++ b/docs/design/disable-add-in-commands.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Enable and Disable Add-in Commands
 description: Learn how to change the enabled or disabled status of custom ribbon buttons and menu items in your Office Web Add-in.
 ms.date: 03/11/2025
@@ -93,7 +93,7 @@ Just add an [`"enabled"`](/microsoft-365/extensibility/schema/extension-common-c
 
 Just add an [Enabled](/javascript/api/manifest/enabled) element immediately *below* (not inside) the [Action](/javascript/api/manifest/action) element of the control item. Then, set its value to `false`.
 
-The following shows the basic structure of a manifest that configures the **\<Enabled\>** element.
+The following shows the basic structure of a manifest that configures the `<Enabled>` element.
 
 ```xml
 <OfficeApp ...>
@@ -213,7 +213,7 @@ await Office.contextMenu.requestUpdate({
 
 A common scenario in which the state of a ribbon or context menu control should change is when a user-initiated event changes the add-in context. Consider a scenario in which a button should be available when, and only when, a chart is activated. Although the following example uses ribbon controls, a similar implementation can be applied to custom items on a context menu.
 
-1. First, set the **\<Enabled\>** element for the button in the manifest to `false`. For guidance on how to configure this, see [Deactivate ribbon controls at launch](#deactivate-ribbon-controls-at-launch).
+1. First, set the `<Enabled>` element for the button in the manifest to `false`. For guidance on how to configure this, see [Deactivate ribbon controls at launch](#deactivate-ribbon-controls-at-launch).
 1. Then, assign handlers. This is commonly done in the **Office.onReady** function as in the following example. In the example, handlers (created in a later step) are assigned to the **onActivated** and **onDeactivated** events of all the charts in an Excel worksheet.
 
     ```javascript

--- a/docs/design/keyboard-shortcuts.md
+++ b/docs/design/keyboard-shortcuts.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Custom keyboard shortcuts in Office Add-ins
 description: Learn how to add custom keyboard shortcuts, also known as key combinations, to your Office Add-in.
 ms.date: 03/12/2025
@@ -185,7 +185,7 @@ If your add-in uses an add-in only manifest, custom keyboard shortcuts are defin
 ### Link the mapping file to the manifest
 
 1. In your add-in project, open the **manifest.xml** file.
-1. Immediately *below* (not inside) the **\<VersionOverrides\>** element in the manifest, add an [ExtendedOverrides](/javascript/api/manifest/extendedoverrides) element. Set the `Url` attribute to the full URL of the JSON file you created in a previous step.
+1. Immediately *below* (not inside) the `<VersionOverrides>` element in the manifest, add an [ExtendedOverrides](/javascript/api/manifest/extendedoverrides) element. Set the `Url` attribute to the full URL of the JSON file you created in a previous step.
 
 ```xml
     ...
@@ -198,7 +198,7 @@ If your add-in uses an add-in only manifest, custom keyboard shortcuts are defin
 
 ## Map custom actions to their functions
 
-1. In your project, open the JavaScript file loaded by your HTML page in the **\<FunctionFile\>** element.
+1. In your project, open the JavaScript file loaded by your HTML page in the `<FunctionFile>` element.
 1. In the JavaScript file, use the [Office.actions.associate](/javascript/api/office/office.actions#office-office-actions-associate-member) API to map each action you specified in an earlier step to a JavaScript function. Add the following JavaScript to the file. Note the following about the code.
     - The first parameter is the name of an action that you mapped to a keyboard shortcut. The location of the name of the action depends on the type of manifest your add-in uses.
         - **Unified app manifest for Microsoft 365**: The value of the `"extensions.keyboardShortcuts.shortcuts.actionId"` property in the **manifest.json** file.

--- a/docs/develop/authorize-to-microsoft-graph.md
+++ b/docs/develop/authorize-to-microsoft-graph.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Authorize to Microsoft Graph with SSO
 description: Learn how users of an Office Add-in can use single sign-on (SSO) to fetch data from Microsoft Graph.
 ms.date: 06/24/2025
@@ -13,7 +13,7 @@ Users sign in to Office using either their personal Microsoft account or their M
 
 In addition to hosting the pages and JavaScript of the web application, the add-in must also host, at the same [fully qualified domain name](/windows/desktop/DNS/f-gly#_dns_fully_qualified_domain_name_fqdn__gly), one or more web APIs that will get an access token to Microsoft Graph and make requests to it.
 
-The add-in manifest contains a **\<WebApplicationInfo\>** element that provides important Azure app registration information to Office, including the permissions to Microsoft Graph that the add-in requires.
+The add-in manifest contains a `<WebApplicationInfo>` element that provides important Azure app registration information to Office, including the permissions to Microsoft Graph that the add-in requires.
 
 ### How it works at runtime
 

--- a/docs/develop/automatically-open-a-task-pane-with-a-document.md
+++ b/docs/develop/automatically-open-a-task-pane-with-a-document.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Automatically open a task pane with a document
 description: Learn how to configure an Office Add-in to open automatically when a document opens.
 ms.topic: how-to
@@ -89,7 +89,7 @@ The following example shows a `"view"` value set to `"Office.AutoShowTaskpaneWit
 
 To specify the task pane to open automatically, set the [TaskpaneId](/javascript/api/manifest/action#taskpaneid) value to **Office.AutoShowTaskpaneWithDocument**. You can only set this value on one task pane. If you set this value on multiple task panes, the first occurrence of the value will be recognized and the others will be ignored.
 
-The following example shows the **\<TaskPaneId\>** value set to **Office.AutoShowTaskpaneWithDocument**.
+The following example shows the `<TaskPaneId>` value set to **Office.AutoShowTaskpaneWithDocument**.
 
 ```xml
 <Action xsi:type="ShowTaskpane">

--- a/docs/develop/automatically-open-on-installation.md
+++ b/docs/develop/automatically-open-on-installation.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Automatically open a task pane when an add-in is installed
 description: Learn how to configure an Office Add-in to open automatically when it's installed.
 ms.topic: how-to
@@ -62,7 +62,7 @@ The following example shows a `"view"` value set to `"Office.AutoShowTaskpaneWit
 
 # [Add-in only manifest](#tab/xmlmanifest)
 
-To designate a task pane as the default, add a [TaskpaneId](/javascript/api/manifest/action#taskpaneid) element as the first child of the **\<Action\>** element and set its value to **Office.AutoShowTaskpaneWithDocument**. The following is an example.
+To designate a task pane as the default, add a [TaskpaneId](/javascript/api/manifest/action#taskpaneid) element as the first child of the `<Action>` element and set its value to **Office.AutoShowTaskpaneWithDocument**. The following is an example.
 
 ```xml
 <Action xsi:type="ShowTaskpane">

--- a/docs/develop/configure-your-add-in-to-use-a-shared-runtime.md
+++ b/docs/develop/configure-your-add-in-to-use-a-shared-runtime.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Configure your Office Add-in to use a shared runtime
 description: Configure your Office Add-in to use a shared runtime to support additional ribbon, task pane, and custom function features.
 ms.topic: how-to
@@ -81,17 +81,17 @@ Follow these steps to configure a new or existing project to use a shared runtim
     </Requirements>
     ```
 
-1. Find the **\<VersionOverrides\>** section and add the following **\<Runtimes\>** section. Note the following about this markup.
+1. Find the `<VersionOverrides>` section and add the following `<Runtimes>` section. Note the following about this markup.
     - The lifetime needs to be **long** so that your add-in can take advantage of features, such as starting your add-in when the document opens, continuing to run code after the task pane is closed, or using CORS and DOM from custom functions. If you set the lifetime to **short** in this example, your add-in will start when one of your ribbon buttons is pressed, but it may shut down after your ribbon handler is done running. Similarly, your add-in will start when the task pane is opened, but it may shut down when the task pane is closed.
     - The `resid` value is **Taskpane.Url**, which references the **taskpane.html** file location specified in the `<bt:Urls>` section near the bottom of the **manifest.xml** file.
 
         > [!IMPORTANT]
         > The shared runtime won't load if the `resid` uses different values in the manifest. If you change the value to something other than **Taskpane.Url**, be sure to also change the value in all locations shown in the following steps in this article.
 
-    - The **\<Runtimes\>** section must be entered after the **\<Host\>** element in the exact order shown in the following XML.
+    - The `<Runtimes>` section must be entered after the `<Host>` element in the exact order shown in the following XML.
 
         > [!NOTE]
-        > If your add-in includes the **\<Runtimes\>** element in the manifest (required for a shared runtime) and the conditions for using WebView2 (Microsoft Edge Chromium-based) are met, it uses that control. If the conditions are not met, then it uses the Trident (Internet Explorer 11) webview control regardless of the Windows or Microsoft 365 version. For more information, see [Runtimes](/javascript/api/manifest/runtimes) and [Browsers and webview controls used by Office Add-ins](../concepts/browsers-used-by-office-web-add-ins.md).
+        > If your add-in includes the `<Runtimes>` element in the manifest (required for a shared runtime) and the conditions for using WebView2 (Microsoft Edge Chromium-based) are met, it uses that control. If the conditions are not met, then it uses the Trident (Internet Explorer 11) webview control regardless of the Windows or Microsoft 365 version. For more information, see [Runtimes](/javascript/api/manifest/runtimes) and [Browsers and webview controls used by Office Add-ins](../concepts/browsers-used-by-office-web-add-ins.md).
 
     ```xml
     <VersionOverrides ...>
@@ -104,7 +104,7 @@ Follow these steps to configure a new or existing project to use a shared runtim
         </Host>
     ```
 
-1. If you generated an Excel add-in with custom functions, find the **\<Page\>** element. Then change the source location from **Functions.Page.Url** to **Taskpane.Url**.
+1. If you generated an Excel add-in with custom functions, find the `<Page>` element. Then change the source location from **Functions.Page.Url** to **Taskpane.Url**.
 
    ```xml
    <AllFormFactors>
@@ -115,7 +115,7 @@ Follow these steps to configure a new or existing project to use a shared runtim
    ...
    ```
 
-1. Find the **\<FunctionFile\>** tag and change the `resid` from **Commands.Url** to  **Taskpane.Url**. Note that if you don't have action commands, you won't have a **\<FunctionFile\>** entry, and can skip this step.
+1. Find the `<FunctionFile>` tag and change the `resid` from **Commands.Url** to  **Taskpane.Url**. Note that if you don't have action commands, you won't have a `<FunctionFile>` entry, and can skip this step.
 
     ```xml
     </GetStarted>

--- a/docs/develop/convert-xml-to-json-manifest.md
+++ b/docs/develop/convert-xml-to-json-manifest.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Convert an add-in to use the unified manifest for Microsoft 365
 description: Learn the various methods for converting an add-in with an add-in only manifest to the unified manifest for Microsoft 365 and sideload the add-in.
 ms.topic: how-to
@@ -36,7 +36,7 @@ To avoid conflicts with UI control names and other problems, be sure the existin
 
 ### Ensure that you have two special image files
 
-If your add-in only manifest doesn't already have both **\<IconUrl\>** and **\<HighResolutionIconUrl\>** (in that order) elements, then add them just below the **\<Description\>** element. The values of the **DefaultValue** attribute should be the full URLs of image files. The images must be a specified size as shown in the following table.
+If your add-in only manifest doesn't already have both `<IconUrl>` and `<HighResolutionIconUrl>` (in that order) elements, then add them just below the `<Description>` element. The values of the **DefaultValue** attribute should be the full URLs of image files. The images must be a specified size as shown in the following table.
 
 |Office application|\<IconUrl\>|\<HighResolutionIconUrl\>|
 |:---------------|:---------------|:---------------|
@@ -61,7 +61,7 @@ The following markup is an example.
 
 ### Reduce the number of add-in commands as needed
 
-An add-in that uses the unified manifest may not have more than 20 [add-in commands](../design/add-in-commands.md). If the total number of [**\<Action\>** elements](/javascript/api/manifest/action) in the add-in only manifest is greater than 20, you must redesign the add-in to have no more than 20.
+An add-in that uses the unified manifest may not have more than 20 [add-in commands](../design/add-in-commands.md). If the total number of [`<Action>` elements](/javascript/api/manifest/action) in the add-in only manifest is greater than 20, you must redesign the add-in to have no more than 20.
 
 ### Update the add-in ID, version, domain, and function names in the manifest
 
@@ -71,7 +71,7 @@ An add-in that uses the unified manifest may not have more than 20 [add-in comma
 
 1. Be sure that the domain segment of the add-in's URLs in the manifest are pointing to `https://localhost:3000`.
 
-1. If your manifest has any **\<FunctionName\>** elements, make sure their values have fewer than 65 characters.
+1. If your manifest has any `<FunctionName>` elements, make sure their values have fewer than 65 characters.
 
    > [!IMPORTANT]
    > The value of this element must exactly match the name of an action that's mapped to a function in a JavaScript or TypeScript file with the [Office.actions.associate](/javascript/api/office/office.actions#office-office-actions-associate-member(1)) function. If you change it in the manifest, be sure to change it in the `actionId` parameter passed to `associate()` too.
@@ -130,7 +130,7 @@ npx office-addin-manifest-converter convert <relative-path-to-XML-manifest>
 Once you have the unified manifest created, there are two ways to create the zip file and sideload it. For more information, see [Sideload other NodeJS and npm projects](../testing/sideload-add-in-with-unified-manifest.md#sideload-other-nodejs-and-npm-projects).
 
 > [!NOTE]
-> If the original add-in only manifest used any **\<Override\>** elements to localize strings in the manifest, then the conversion process produces JSON string files for each localized language. These files must also be included in the zip file, and they must be at the relative path indicated in the [`"localizationInfo.additionalLanguages.file"`](/microsoft-365/extensibility/schema/root-localization-info-additional-languages#file) property.
+> If the original add-in only manifest used any `<Override>` elements to localize strings in the manifest, then the conversion process produces JSON string files for each localized language. These files must also be included in the zip file, and they must be at the relative path indicated in the [`"localizationInfo.additionalLanguages.file"`](/microsoft-365/extensibility/schema/root-localization-info-additional-languages#file) property.
 
 ## Next steps
 

--- a/docs/develop/create-addin-commands.md
+++ b/docs/develop/create-addin-commands.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Create add-in commands with the add-in only manifest
 description: Configure an add-in only manifest to define add-in commands for Excel, Outlook, PowerPoint, and Word. Use add-in commands to create UI elements, add buttons or menus, and perform actions.
 ms.date: 02/28/2025
@@ -28,9 +28,9 @@ The following steps explain how to add add-in commands to an existing add-in.
 
 ### Step 1: Add VersionOverrides element
 
-The [**\<VersionOverrides\>** element](/javascript/api/manifest/versionoverrides) is the root element that contains the definition of your add-in command. Details on the valid attributes and implications are found in [Version overrides in the manifest](xml-manifest-overview.md?tabs=tabid-1#version-overrides-in-the-manifest).
+The [`<VersionOverrides>` element](/javascript/api/manifest/versionoverrides) is the root element that contains the definition of your add-in command. Details on the valid attributes and implications are found in [Version overrides in the manifest](xml-manifest-overview.md?tabs=tabid-1#version-overrides-in-the-manifest).
 
-The following example shows the **\<VersionOverrides\>** element and its child elements.
+The following example shows the `<VersionOverrides>` element and its child elements.
 
 ```xml
 <OfficeApp>
@@ -54,11 +54,11 @@ The following example shows the **\<VersionOverrides\>** element and its child e
 
 ### Step 2: Add Hosts, Host, and DesktopFormFactor elements
 
-The [**\<Hosts\>** element](/javascript/api/manifest/hosts) contains one or more [**\<Host\>** elements](/javascript/api/manifest/host). A **\<Host\>** element specifies a particular Office application. The **\<Host\>** element contains child elements that specify the add-in commands to display after your add-in is installed in that Office application. To show the same add-in commands in two or more different Office applications, you must duplicate the child elements in each **\<Host\>**.
+The [`<Hosts>` element](/javascript/api/manifest/hosts) contains one or more [`<Host>` elements](/javascript/api/manifest/host). A `<Host>` element specifies a particular Office application. The `<Host>` element contains child elements that specify the add-in commands to display after your add-in is installed in that Office application. To show the same add-in commands in two or more different Office applications, you must duplicate the child elements in each `<Host>`.
 
-The [**\<DesktopFormFactor\>**](/javascript/api/manifest/desktopformfactor) element specifies the settings for an add-in that runs in Office on the web, Windows, and Mac.
+The [`<DesktopFormFactor>`](/javascript/api/manifest/desktopformfactor) element specifies the settings for an add-in that runs in Office on the web, Windows, and Mac.
 
-The following example shows the **\<Hosts\>**, **\<Host\>**, and **\<DesktopFormFactor\>** elements.
+The following example shows the `<Hosts>`, `<Host>`, and `<DesktopFormFactor>` elements.
 
 ```xml
 <OfficeApp>
@@ -82,12 +82,12 @@ The following example shows the **\<Hosts\>**, **\<Host\>**, and **\<DesktopForm
 
 ### Step 3: Add the FunctionFile element
 
-The [**\<FunctionFile\>** element](/javascript/api/manifest/functionfile) specifies a file that contains JavaScript or TypeScript code to run when an add-in command uses the **ExecuteFunction** action. The **\<FunctionFile\>** element's **resid** attribute is set to a HTML file that includes all the JavaScript or TypeScript files your add-in commands require. You can't link directly to a JavaScript or TypeScript file. You can only link to an HTML file. The file name is specified as a [**\<Url\>** element](/javascript/api/manifest/url) in the [**\<Resources\>** element](/javascript/api/manifest/resources).
+The [`<FunctionFile>` element](/javascript/api/manifest/functionfile) specifies a file that contains JavaScript or TypeScript code to run when an add-in command uses the **ExecuteFunction** action. The `<FunctionFile>` element's **resid** attribute is set to a HTML file that includes all the JavaScript or TypeScript files your add-in commands require. You can't link directly to a JavaScript or TypeScript file. You can only link to an HTML file. The file name is specified as a [`<Url>` element](/javascript/api/manifest/url) in the [`<Resources>` element](/javascript/api/manifest/resources).
 
 > [!NOTE]
 > The Yo Office projects use [webpack](https://webpack.js.org/concepts/) to avoid manually adding the JavaScript or TypeScript to the HTML.
 
-The following is an example of the **\<FunctionFile\>** element.
+The following is an example of the `<FunctionFile>` element.
   
 ```xml
 <DesktopFormFactor>
@@ -109,9 +109,9 @@ When an add-in needs to provide status updates, such as progress indicators or e
 
 ### Step 4: Add ExtensionPoint elements
 
-The [**\<ExtensionPoint\>** element](/javascript/api/manifest/extensionpoint) defines where add-in commands should appear in the Office UI.
+The [`<ExtensionPoint>` element](/javascript/api/manifest/extensionpoint) defines where add-in commands should appear in the Office UI.
 
-The following examples show how to use the **\<ExtensionPoint\>** element with **PrimaryCommandSurface** and **ContextMenu** attribute values, and the child elements that should be used with each.
+The following examples show how to use the `<ExtensionPoint>` element with **PrimaryCommandSurface** and **ContextMenu** attribute values, and the child elements that should be used with each.
 
 > [!IMPORTANT]
 > For elements that contain an ID attribute, make sure you provide a unique ID. We recommend that you use your company's name along with your ID. For example, use the following format: `<CustomTab id="mycompanyname.mygroupname">`.
@@ -149,15 +149,15 @@ The following examples show how to use the **\<ExtensionPoint\>** element with *
 
 ### Step 5: Add Control elements
 
-The [**\<Control\>** element](/javascript/api/manifest/control) defines the usable surface of command, such as a button or menu, and the action associated with it.
+The [`<Control>` element](/javascript/api/manifest/control) defines the usable surface of command, such as a button or menu, and the action associated with it.
 
 #### Button controls
 
-A [button control](/javascript/api/manifest/control-button) performs a single action when the user selects it. It can either run a JavaScript or TypeScript function or show a task pane. The following example shows how to define two buttons. The first button runs a JavaScript function without showing a UI, and the second button shows a task pane. In the **\<Control\>** element:
+A [button control](/javascript/api/manifest/control-button) performs a single action when the user selects it. It can either run a JavaScript or TypeScript function or show a task pane. The following example shows how to define two buttons. The first button runs a JavaScript function without showing a UI, and the second button shows a task pane. In the `<Control>` element:
 
 - The **type** attribute is required, and must be set to **Button**.
-- The **id** attribute of the **\<Control\>** element is a string with a maximum of 125 characters.
-- The **xsi:type** attribute of the child [**\<Action\>** element](/javascript/api/manifest/action) must be set to **ExecuteFunction** to run a function or **ShowTaskpane** to display a task pane.
+- The **id** attribute of the `<Control>` element is a string with a maximum of 125 characters.
+- The **xsi:type** attribute of the child [`<Action>` element](/javascript/api/manifest/action) must be set to **ExecuteFunction** to run a function or **ShowTaskpane** to display a task pane.
 
 ```xml
 <!-- Define a control that calls a JavaScript function. -->
@@ -204,7 +204,7 @@ A [menu control](/javascript/api/manifest/control-menu) can be used with either 
 
 When used with **PrimaryCommandSurface**, the root menu item displays as a button on the ribbon. When the button is selected, the submenu displays as a drop-down list. When used with **ContextMenu**, a menu item with a submenu is inserted on the context menu. In both cases, individual submenu items can either run a JavaScript or TypeScript function or show a task pane. Only one level of submenus is supported at this time.
 
-The following example shows how to define a menu item with two submenu items. The first submenu item shows a task pane, and the second submenu item runs a JavaScript function. In the **\<Control\>** element:
+The following example shows how to define a menu item with two submenu items. The first submenu item shows a task pane, and the second submenu item runs a JavaScript function. In the `<Control>` element:
 
 - The **xsi:type** attribute is required, and must be set to **Menu**.
 - The **id** attribute is a string with a maximum of 125 characters.
@@ -259,9 +259,9 @@ The following example shows how to define a menu item with two submenu items. Th
 
 #### Sample code for function commands
 
-The following code shows a function that's invoked by a button or menu item control whose **\<Action\>** element's **xsi:type** is set to **ExecuteFunction**. Note the following about the code.
+The following code shows a function that's invoked by a button or menu item control whose `<Action>` element's **xsi:type** is set to **ExecuteFunction**. Note the following about the code.
 
-- The [Office.actions.associate](/javascript/api/office/office.actions#office-office-actions-associate-member(1)) call tells Office which function to run when a button or menu item is selected. The value passed to its **actionId** parameter must match the value specified in the [**\<FunctionName\>** element](/javascript/api/manifest/action#functionname) of the manifest. You must have an `Office.actions.associate` call for every function command defined in the manifest.
+- The [Office.actions.associate](/javascript/api/office/office.actions#office-office-actions-associate-member(1)) call tells Office which function to run when a button or menu item is selected. The value passed to its **actionId** parameter must match the value specified in the [`<FunctionName>` element](/javascript/api/manifest/action#functionname) of the manifest. You must have an `Office.actions.associate` call for every function command defined in the manifest.
 - The [event.completed](/javascript/api/office/office.addincommands.event#office-office-addincommands-event-completed-member(1)) call signals that you've successfully handled the event. When a function is called multiple times, such as multiple clicks on the same add-in command, all events are automatically queued. The first event runs automatically, while the other events remain on the queue. When your function calls `event.completed`, the next queued call to that function runs. You must implement `event.completed`, otherwise your function won't run.
 
 ```js
@@ -296,9 +296,9 @@ Office.actions.associate("highlightSelection", highlightSelection);
 
 ### Step 6: Add the Resources element
 
-The [**\<Resources\>** element](/javascript/api/manifest/resources) contains resources used by the different child elements of the **\<VersionOverrides\>** element. Resources include icons, strings, and URLs. An element in the manifest can use a resource by referencing the **id** of the resource. Using the **id** helps organize the manifest, especially when there are different versions of the resource for different locales. An **id** has a maximum of 32 characters.
+The [`<Resources>` element](/javascript/api/manifest/resources) contains resources used by the different child elements of the `<VersionOverrides>` element. Resources include icons, strings, and URLs. An element in the manifest can use a resource by referencing the **id** of the resource. Using the **id** helps organize the manifest, especially when there are different versions of the resource for different locales. An **id** has a maximum of 32 characters.
   
-The following shows an example of how to use the **\<Resources\>** element. Each resource can have one or more [**\<Override\>** child elements](/javascript/api/manifest/override) to define a different resource for a specific locale.
+The following shows an example of how to use the `<Resources>` element. Each resource can have one or more [`<Override>` child elements](/javascript/api/manifest/override) to define a different resource for a specific locale.
 
 ```xml
 <Resources>
@@ -332,7 +332,7 @@ The following shows an example of how to use the **\<Resources\>** element. Each
 ```
 
 > [!NOTE]
-> You must use Secure Sockets Layer (SSL) for all URLs in the **\<Image\>** and **\<Url\>** elements.
+> You must use Secure Sockets Layer (SSL) for all URLs in the `<Image>` and `<Url>` elements.
 
 ## Outlook support notes
 

--- a/docs/develop/create-sso-office-add-ins-aspnet.md
+++ b/docs/develop/create-sso-office-add-ins-aspnet.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Create an ASP.NET Office Add-in that uses single sign-on (SSO)
 description: A step-by-step guide for how to create (or convert) an Office Add-in with an ASP.NET backend to use single sign-on (SSO).
 ms.date: 05/20/2023
@@ -69,7 +69,7 @@ Use the following values for placeholders for the subsequent app registration st
 1. Replace the placeholder "Enter_client_ID_here" _in both places_ in the markup with the **Application ID** that you copied when you created the **Office-Add-in-ASPNET-SSO** app registration. This is the same ID you used for the application ID in the appsettings.json file.
 
    > [!NOTE]
-   > The **\<Resource\>** value is the **Application ID URI** you set when you registered the add-in. The **\<Scopes\>** section is used only to generate a consent dialog box if the add-in is sold through AppSource.
+   > The `<Resource>` value is the **Application ID URI** you set when you registered the add-in. The `<Scopes>` section is used only to generate a consent dialog box if the add-in is sold through AppSource.
 
 1. Save and close the manifest file.
 

--- a/docs/develop/create-sso-office-add-ins-nodejs.md
+++ b/docs/develop/create-sso-office-add-ins-nodejs.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Create a Node.js Office Add-in that uses single sign-on
 description: Learn how to create a Node.js-based add-in that uses Office Single Sign-on.
 ms.date: 05/20/2023
@@ -88,7 +88,7 @@ Use the following values for placeholders for the subsequent app registration st
 1. Replace the placeholder "$app-id-guid$" _in both places_ in the markup with the **Application ID** that you copied when you created the **Office-Add-in-NodeJS-SSO** app registration. The "$" symbols are not part of the ID, so don't include them. This is the same ID you used for the CLIENT_ID in the .ENV file.
 
    > [!NOTE]
-   > The **\<Resource\>** value is the **Application ID URI** you set when you registered the add-in. The **\<Scopes\>** section is used only to generate a consent dialog box if the add-in is sold through AppSource.
+   > The `<Resource>` value is the **Application ID URI** you set when you registered the add-in. The `<Scopes>` section is used only to generate a consent dialog box if the add-in is sold through AppSource.
 
 1. Open the `\public\javascripts\fallback-msal\authConfig.js` file. Replace the placeholder "$app-id-guid$" with the application ID that you saved from the **Office-Add-in-NodeJS-SSO** app registration you created previously.
 

--- a/docs/develop/dialog-api-in-office-add-ins.md
+++ b/docs/develop/dialog-api-in-office-add-ins.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Use the Office dialog API in your Office Add-ins
 description: Learn the basics of creating a dialog box in an Office Add-in.
 ms.date: 06/25/2025
@@ -365,7 +365,7 @@ If the message doesn't include sensitive data, you can set the `targetOrigin` to
 dialog.messageChild(messageToDialog, { targetOrigin: "*" });
 ```
 
-The add-in's manifest specifies trusted domains. In the unified manifest for Microsoft 365, this is specified in the "validDomains" property. In the add-in only manifest, this is specified in the **\<AppDomains\>** element.
+The add-in's manifest specifies trusted domains. In the unified manifest for Microsoft 365, this is specified in the "validDomains" property. In the add-in only manifest, this is specified in the `<AppDomains>` element.
 
 [!include[Unified manifest host application support note](../includes/unified-manifest-support-note.md)]
 

--- a/docs/develop/event-based-activation.md
+++ b/docs/develop/event-based-activation.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Activate add-ins with events
 description: Learn how to develop an Office Add-in that implements event-based activation.
 ms.date: 07/17/2025
@@ -114,7 +114,7 @@ When developing an event-based add-in to run on a Windows client, be mindful of 
 
 - Imports aren't supported in the JavaScript file where you implement the handling for event-based activation.
 - Only the JavaScript file referenced in the manifest is supported for event-based activation. You must bundle your event-handling JavaScript code into this single file. The location of the referenced JavaScript file in the manifest varies depending on the type of manifest your add-in uses.
-  - **Add-in only manifest**: **\<Override\>** child element of the **\<Runtime\>** node
+  - **Add-in only manifest**: `<Override>` child element of the `<Runtime>` node
   - **Unified manifest for Microsoft 365**: `"script"` property of the `"code"` object
 
   Note that a large JavaScript bundle may cause issues with the performance of your add-in. We recommend preprocessing heavy operations, so that they're not included in your event-handling code.

--- a/docs/develop/json-manifest-overview.md
+++ b/docs/develop/json-manifest-overview.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Compare the add-in only manifest with the unified manifest for Microsoft 365
 description: Get a comparison of the add-in only manifest with the unified manifest for Microsoft 365.
 ms.topic: overview
@@ -34,7 +34,7 @@ This section describes the unified manifest for readers who are familiar with th
   }
   ```
 
-- There are many places in the add-in only manifest where an element with a plural name has children with the singular version of the same name. For example, the markup to configure a custom menu includes an **\<Items\>** element which can have multiple **\<Item\>** element children. The JSON equivalent of these plural elements is a property with an array as its value. The members of the array are *anonymous* objects, not properties named "item" or "item1", "item2", etc. The following is an example.
+- There are many places in the add-in only manifest where an element with a plural name has children with the singular version of the same name. For example, the markup to configure a custom menu includes an `<Items>` element which can have multiple `<Item>` element children. The JSON equivalent of these plural elements is a property with an array as its value. The members of the array are *anonymous* objects, not properties named "item" or "item1", "item2", etc. The following is an example.
 
   ```json
   "items": [
@@ -49,9 +49,9 @@ This section describes the unified manifest for readers who are familiar with th
 
 ### Top-level structure
 
-The root level of the unified manifest, which roughly corresponds to the **\<OfficeApp\>** element in the add-in only manifest, is an anonymous object.
+The root level of the unified manifest, which roughly corresponds to the `<OfficeApp>` element in the add-in only manifest, is an anonymous object.
 
-The children of **\<OfficeApp\>** are commonly divided into two notional categories. The **\<VersionOverrides\>** element is one category. The other consists of all the other children of **\<OfficeApp\>**, which are collectively referred to as the base manifest. So too, the unified manifest has a similar division. There is a top-level [`"extensions"`](/microsoft-365/extensibility/schema/root#extensions) property that roughly corresponds in its purposes and child properties to the **\<VersionOverrides\>** element. The unified manifest also has over 10 other top-level properties that collectively serve the same purposes as the base manifest of the add-in only manifest. These other properties can be thought of collectively as the base manifest of the unified manifest.
+The children of `<OfficeApp>` are commonly divided into two notional categories. The `<VersionOverrides>` element is one category. The other consists of all the other children of `<OfficeApp>`, which are collectively referred to as the base manifest. So too, the unified manifest has a similar division. There is a top-level [`"extensions"`](/microsoft-365/extensibility/schema/root#extensions) property that roughly corresponds in its purposes and child properties to the `<VersionOverrides>` element. The unified manifest also has over 10 other top-level properties that collectively serve the same purposes as the base manifest of the add-in only manifest. These other properties can be thought of collectively as the base manifest of the unified manifest.
 
 ### Base manifest
 
@@ -59,26 +59,26 @@ The base manifest properties specify characteristics of the add-in that *any* ty
 
 |JSON property|Purpose|XML elements|Comments|
 |:-----|:-----|:-----|:-----|
-|"$schema"| Identifies the manifest schema. | attributes of **\<OfficeApp\>** and **\<VersionOverrides\>** |*None* |
-|[`"id"`](/microsoft-365/extensibility/schema/root#id)| GUID of the add-in. | **\<Id\>**|*None* |
-|[`"version"`](/microsoft-365/extensibility/schema/root#version)| Version of the add-in. | **\<Version\>** |*None* |
-|[`"manifestVersion"`](/microsoft-365/extensibility/schema/root#manifestversion)| Version of the manifest schema. |  attributes of **\<OfficeApp\>** |*None* |
-|[`"name"`](/microsoft-365/extensibility/schema/root#name)| Public name of the add-in. | **\<DisplayName\>** |*None* |
-|[`"description"`](/microsoft-365/extensibility/schema/root#description)| Public description of the add-in.  | **\<Description\>** |*None* |
+|"$schema"| Identifies the manifest schema. | attributes of `<OfficeApp>` and `<VersionOverrides>` |*None* |
+|[`"id"`](/microsoft-365/extensibility/schema/root#id)| GUID of the add-in. | `<Id>`|*None* |
+|[`"version"`](/microsoft-365/extensibility/schema/root#version)| Version of the add-in. | `<Version>` |*None* |
+|[`"manifestVersion"`](/microsoft-365/extensibility/schema/root#manifestversion)| Version of the manifest schema. |  attributes of `<OfficeApp>` |*None* |
+|[`"name"`](/microsoft-365/extensibility/schema/root#name)| Public name of the add-in. | `<DisplayName>` |*None* |
+|[`"description"`](/microsoft-365/extensibility/schema/root#description)| Public description of the add-in.  | `<Description>` |*None* |
 |[`"accentColor"`](/microsoft-365/extensibility/schema/root#accentcolor)|*None* |*None* | This property has no equivalent in the add-in only manifest and isn't used in the unified manifest. But it must be present. |
-|[`"developer"`](/microsoft-365/extensibility/schema/root#developer)| Identifies the developer of the add-in. | **\<ProviderName\>** |*None* |
-|[`"localizationInfo"`](/microsoft-365/extensibility/schema/root#localizationinfo)| Configures the default locale and other supported locales. | **\<DefaultLocale\>** and **\<Override\>** |*None* |
-|[`"webApplicationInfo"`](/microsoft-365/extensibility/schema/root#webApplicationInfo-property)| Identifies the add-in's web app as it is known in Microsoft Entra ID. | **\<WebApplicationInfo\>** | In the add-in only manifest, the **\<WebApplicationInfo\>** element is inside **\<VersionOverrides\>**, not the base manifest. |
-|[`"authorization"`](/microsoft-365/extensibility/schema/root#authorization)| Identifies any Microsoft Graph permissions that the add-in needs. | **\<WebApplicationInfo\>** | In the add-in only manifest, the **\<WebApplicationInfo\>** element is inside **\<VersionOverrides\>**, not the base manifest. |
+|[`"developer"`](/microsoft-365/extensibility/schema/root#developer)| Identifies the developer of the add-in. | `<ProviderName>` |*None* |
+|[`"localizationInfo"`](/microsoft-365/extensibility/schema/root#localizationinfo)| Configures the default locale and other supported locales. | `<DefaultLocale>` and `<Override>` |*None* |
+|[`"webApplicationInfo"`](/microsoft-365/extensibility/schema/root#webApplicationInfo-property)| Identifies the add-in's web app as it is known in Microsoft Entra ID. | `<WebApplicationInfo>` | In the add-in only manifest, the `<WebApplicationInfo>` element is inside `<VersionOverrides>`, not the base manifest. |
+|[`"authorization"`](/microsoft-365/extensibility/schema/root#authorization)| Identifies any Microsoft Graph permissions that the add-in needs. | `<WebApplicationInfo>` | In the add-in only manifest, the `<WebApplicationInfo>` element is inside `<VersionOverrides>`, not the base manifest. |
 
-The **\<Hosts\>**, **\<Requirements\>**, and **\<ExtendedOverrides\>** elements are part of the base manifest in the add-in only manifest. But concepts and purposes associated with these elements are configured inside the `"extensions"` property of the unified manifest.
+The `<Hosts>`, `<Requirements>`, and `<ExtendedOverrides>` elements are part of the base manifest in the add-in only manifest. But concepts and purposes associated with these elements are configured inside the `"extensions"` property of the unified manifest.
 
 ### `"extensions"` property
 
-The `"extensions"` property in the unified manifest primarily represents characteristics of the add-in that wouldn't be relevant to other kinds of Microsoft 365 extensions. For example, the Office applications that the add-in extends (such as, Excel, PowerPoint, Word, and Outlook) are specified inside the `"extensions"` property, as are customizations of the Office application ribbon. The configuration purposes of the `"extensions"` property closely match those of the **\<VersionOverrides\>** element in the add-in only manifest.
+The `"extensions"` property in the unified manifest primarily represents characteristics of the add-in that wouldn't be relevant to other kinds of Microsoft 365 extensions. For example, the Office applications that the add-in extends (such as, Excel, PowerPoint, Word, and Outlook) are specified inside the `"extensions"` property, as are customizations of the Office application ribbon. The configuration purposes of the `"extensions"` property closely match those of the `<VersionOverrides>` element in the add-in only manifest.
 
 > [!NOTE]
-> The **\<VersionOverrides\>** section of the add-in only manifest has a "double jump" system for many string resources. Strings, including URLs, are specified and assigned an ID in the **\<Resources\>** child of **\<VersionOverrides\>**. Elements that require a string have a `resid` attribute that matches the ID of a string in the **\<Resources\>** element. The `"extensions"` property of the unified manifest simplifies things by defining strings directly as property values. There is nothing in the unified manifest that is equivalent to the **\<Resources\>** element.
+> The `<VersionOverrides>` section of the add-in only manifest has a "double jump" system for many string resources. Strings, including URLs, are specified and assigned an ID in the `<Resources>` child of `<VersionOverrides>`. Elements that require a string have a `resid` attribute that matches the ID of a string in the `<Resources>` element. The `"extensions"` property of the unified manifest simplifies things by defining strings directly as property values. There is nothing in the unified manifest that is equivalent to the `<Resources>` element.
 
 The following table shows a mapping of *some* high-level child properties of the `"extensions"` property in the unified manifest to XML elements in the current manifest. Dot notation is used to reference child properties.
 
@@ -87,13 +87,13 @@ The following table shows a mapping of *some* high-level child properties of the
 
 |JSON property|Purpose|XML elements|Comments|
 |:-----|:-----|:-----|:-----|
-| [`"requirements.capabilities"`](/microsoft-365/extensibility/schema/requirements-extension-element-capabilities) | Identifies the [requirement sets](office-versions-and-requirement-sets.md#office-requirement-sets-availability) that the add-in needs to be installable. that the add-in needs to be installable. | **\<Requirements\>** and **\<Sets\>** |*None* |
-| [`"requirements.scopes"`](/microsoft-365/extensibility/schema/requirements-extension-element#scopes) | Identifies the Office applications in which the add-in can be installed. | **\<Hosts\>** |*None* |
-| [`"ribbons"`](/microsoft-365/extensibility/schema/element-extensions#ribbons) | The ribbons that the add-in customizes. | **\<Hosts\>**, **ExtensionPoints**, and various **\*FormFactor** elements | The `"ribbons"` property is an array of anonymous objects that each merge the purposes of the these three elements. See [`"ribbons"` table](#ribbons-table).|
-| [`"alternates"`](/microsoft-365/extensibility/schema/element-extensions#alternates) | Specifies backwards compatibility with an equivalent COM add-in, XLL, or both. | **\<EquivalentAddins\>** | See the [EquivalentAddins - See also](/javascript/api/manifest/equivalentaddins#see-also) for background information. |
-| [`"runtimes"`](/microsoft-365/extensibility/schema/element-extensions#runtimes)  | Configures the [embedded runtimes](../testing/runtimes.md) that the add-in uses, including various kinds of add-ins that have little or no UI, such as custom function-only add-ins and [function commands](../design/add-in-commands.md#types-of-add-in-commands). | **\<Runtimes\>**. **\<FunctionFile\>**, and **\<ExtensionPoint\>** (of type CustomFunctions) |*None.* |
-| [`"autoRunEvents"`](/microsoft-365/extensibility/schema/element-extensions#autorunevents) | Configures an event handler for a specified event. | **\<ExtensionPoint\>** (of type LaunchEvent) |*None.* |
-| [`"keyboardShortcuts"`](/microsoft-365/extensibility/schema/element-extensions#keyboardshortcuts) (developer preview) | Defines custom keyboard shortcuts or key combinations to run specific actions. | **\<ExtendedOverrides\>** | *None.* |
+| [`"requirements.capabilities"`](/microsoft-365/extensibility/schema/requirements-extension-element-capabilities) | Identifies the [requirement sets](office-versions-and-requirement-sets.md#office-requirement-sets-availability) that the add-in needs to be installable. that the add-in needs to be installable. | `<Requirements>` and `<Sets>` |*None* |
+| [`"requirements.scopes"`](/microsoft-365/extensibility/schema/requirements-extension-element#scopes) | Identifies the Office applications in which the add-in can be installed. | `<Hosts>` |*None* |
+| [`"ribbons"`](/microsoft-365/extensibility/schema/element-extensions#ribbons) | The ribbons that the add-in customizes. | `<Hosts>`, **ExtensionPoints**, and various **\*FormFactor** elements | The `"ribbons"` property is an array of anonymous objects that each merge the purposes of the these three elements. See [`"ribbons"` table](#ribbons-table).|
+| [`"alternates"`](/microsoft-365/extensibility/schema/element-extensions#alternates) | Specifies backwards compatibility with an equivalent COM add-in, XLL, or both. | `<EquivalentAddins>` | See the [EquivalentAddins - See also](/javascript/api/manifest/equivalentaddins#see-also) for background information. |
+| [`"runtimes"`](/microsoft-365/extensibility/schema/element-extensions#runtimes)  | Configures the [embedded runtimes](../testing/runtimes.md) that the add-in uses, including various kinds of add-ins that have little or no UI, such as custom function-only add-ins and [function commands](../design/add-in-commands.md#types-of-add-in-commands). | `<Runtimes>`. `<FunctionFile>`, and `<ExtensionPoint>` (of type CustomFunctions) |*None.* |
+| [`"autoRunEvents"`](/microsoft-365/extensibility/schema/element-extensions#autorunevents) | Configures an event handler for a specified event. | `<ExtensionPoint>` (of type LaunchEvent) |*None.* |
+| [`"keyboardShortcuts"`](/microsoft-365/extensibility/schema/element-extensions#keyboardshortcuts) (developer preview) | Defines custom keyboard shortcuts or key combinations to run specific actions. | `<ExtendedOverrides>` | *None.* |
 
 #### `"ribbons"` table
 
@@ -102,9 +102,9 @@ The following table maps the child properties of the anonymous child objects in 
 |JSON property|Purpose|XML elements|Comments|
 |:-----|:-----|:-----|:-----|
 | `"contexts"` | Specifies the command surfaces that the add-in customizes. | Various **\*CommandSurface** elements, such as **PrimaryCommandSurface** and **MessageReadCommandSurface** |*None.* |
-| `"tabs"` | Configures custom ribbon tabs. | **\<CustomTab\>** | The names and hierarchy of the descendant properties of `"tabs"` closely match the descendants of **\<CustomTab\>**. |
-| `"fixedControls"` (developer preview) | Configures and adds the button of an [integrated spam-reporting](../outlook/spam-reporting.md) add-in to the Outlook ribbon. | **\<Control\>** child element of **\<ReportPhishingCustomization\>** | *None.* |
-| `"spamPreProcessingDialog"` (developer preview) | Configures the preprocessing dialog shown after the button of a spam-reporting add-in is selected from the Outlook ribbon. | **\<PreProcessingDialog\>** child element of **\<ReportPhishingCustomization\>** | *None.* |
+| `"tabs"` | Configures custom ribbon tabs. | `<CustomTab>` | The names and hierarchy of the descendant properties of `"tabs"` closely match the descendants of `<CustomTab>`. |
+| `"fixedControls"` (developer preview) | Configures and adds the button of an [integrated spam-reporting](../outlook/spam-reporting.md) add-in to the Outlook ribbon. | `<Control>` child element of `<ReportPhishingCustomization>` | *None.* |
+| `"spamPreProcessingDialog"` (developer preview) | Configures the preprocessing dialog shown after the button of a spam-reporting add-in is selected from the Outlook ribbon. | `<PreProcessingDialog>` child element of `<ReportPhishingCustomization>` | *None.* |
 
 For a full sample unified manifest, see [Sample unified manifest](unified-manifest-overview.md#sample-unified-manifest).
 

--- a/docs/develop/manifest-element-ordering.md
+++ b/docs/develop/manifest-element-ordering.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: How to find the proper order of manifest elements
 description: Learn how to find the correct order in which to place child elements in a parent element.
 ms.date: 06/02/2025
@@ -11,12 +11,12 @@ The XML elements in the manifest of an Office Add-in must be under the proper pa
 
 The required ordering is specified in the XSD files in the [Schemas](/openspecs/office_file_formats/ms-owemxml/c6a06390-34b8-4b42-82eb-b28be12494a8) folder. The XSD files are categorized into subfolders for taskpane, content, and mail add-ins.
 
-For example, in the **\<OfficeApp\>** element, the **\<Id\>**, **\<Version\>**, **\<ProviderName\>** must appear in that order. If an **\<AlternateId\>** element is added, it must be between the **\<Id\>** and **\<Version\>** element. Your manifest will not be valid and your add-in will not load, if any element is in the wrong order.
+For example, in the `<OfficeApp>` element, the `<Id>`, `<Version>`, `<ProviderName>` must appear in that order. If an `<AlternateId>` element is added, it must be between the `<Id>` and `<Version>` element. Your manifest will not be valid and your add-in will not load, if any element is in the wrong order.
 
 > [!NOTE]
 > The [validator within office-addin-manifest](../testing/troubleshoot-manifest.md#validate-your-manifest-with-office-addin-manifest) uses the same error message when an element is out-of-order as it does when an element is under the wrong parent. The error says the child element is not a valid child of the parent element. If you get such an error but the reference documentation for the child element indicates that it *is* valid for the parent, then the problem is likely that the child has been placed in the wrong order.
 
-The following sections show the manifest elements in the order in which they must appear. There are differences depending on whether the `type` attribute of the **\<OfficeApp\>** element is `TaskPaneApp`, `ContentApp`, or `MailApp`. To keep these sections from becoming too unwieldy, the highly complex **\<VersionOverrides\>** element is broken out into separate sections.
+The following sections show the manifest elements in the order in which they must appear. There are differences depending on whether the `type` attribute of the `<OfficeApp>` element is `TaskPaneApp`, `ContentApp`, or `MailApp`. To keep these sections from becoming too unwieldy, the highly complex `<VersionOverrides>` element is broken out into separate sections.
 
 > [!Note]
 > Not all of the elements shown are mandatory. If the `minOccurs` value for a element is **0** in the [schema](/openspecs/office_file_formats/ms-owemxml/4e112d0a-c8ab-46a6-8a6c-2a1c1d1299e3), the element is optional.

--- a/docs/develop/register-sso-add-in-aad-v2.md
+++ b/docs/develop/register-sso-add-in-aad-v2.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Register an Office Add-in that uses SSO with the Microsoft identity platform
 description: Learn how to register an Office Add-in with the Microsoft identity platform to use SSO with Word, Excel, PowerPoint, and Outlook.
 ms.date: 04/18/2023
@@ -15,7 +15,7 @@ The following table itemizes the information that you need to carry out this pro
 |---------|---------|---------|
 |A human readable name for the add-in. (Uniqueness recommended, but not required.)|`Contoso Marketing Excel Add-in (Prod)`| `<add-in-name>` |
 |An application ID which Azure generates for you as part of the registration process.|`c6c1f32b-5e55-4997-881a-753cc1d563b7`|`<app-id>`|
-|The fully qualified domain name (except for protocol) of the add-in. *You must use a domain that you own.* For this reason, you cannot use certain well-known domains such as `azurewebsites.net` or `cloudapp.net`. The domain must be the same, including any subdomains, as is used in the URLs in the **\<Resources\>** section of the add-in's manifest.|`localhost:6789`, `addins.contoso.com`|`<fully-qualified-domain-name>`|
+|The fully qualified domain name (except for protocol) of the add-in. *You must use a domain that you own.* For this reason, you cannot use certain well-known domains such as `azurewebsites.net` or `cloudapp.net`. The domain must be the same, including any subdomains, as is used in the URLs in the `<Resources>` section of the add-in's manifest.|`localhost:6789`, `addins.contoso.com`|`<fully-qualified-domain-name>`|
 |The permissions to the Microsoft identity platform and Microsoft Graph that your add-in needs. (`profile` is always required.)|`profile`, `Files.Read.All`|N/A|
 
 > [!CAUTION]

--- a/docs/develop/show-hide-add-in.md
+++ b/docs/develop/show-hide-add-in.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Show or hide the task pane of your Office Add-in
 description: Learn how to programmatically hide or show the user interface of an add-in while it runs continuously.
 ms.date: 02/12/2025
@@ -42,7 +42,7 @@ When you call `Office.addin.showAsTaskpane()`, Office will display in a task pan
 
    [!include[Unified manifest host application support note](../includes/unified-manifest-support-note.md)]
    
-- **Add-in only manifest**: The URL of the file is assigned as the resource ID (`resid`) value of the task pane. This `resid` value can be assigned or changed by opening your manifest file and locating **\<SourceLocation\>** inside the `<Action xsi:type="ShowTaskpane">` element.
+- **Add-in only manifest**: The URL of the file is assigned as the resource ID (`resid`) value of the task pane. This `resid` value can be assigned or changed by opening your manifest file and locating `<SourceLocation>` inside the `<Action xsi:type="ShowTaskpane">` element.
 
 (See [Configure your Office Add-in to use a shared runtime](configure-your-add-in-to-use-a-shared-runtime.md) for additional details.)
 

--- a/docs/develop/specify-office-hosts-and-api-requirements.md
+++ b/docs/develop/specify-office-hosts-and-api-requirements.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Specify Office hosts and API requirements with the add-in only manifest
 description: Learn how to specify Office applications and API requirements for your add-in to work as expected.
 ms.topic: best-practice
@@ -45,7 +45,7 @@ By default, an add-in is installable in all Office applications supported by the
 
 To ensure that your add-in is installable in only a subset of Office applications, use the [Hosts](/javascript/api/manifest/hosts) and [Host](/javascript/api/manifest/host) elements in the add-in only manifest.
 
-For example, the following **\<Hosts\>** and **\<Host\>** declaration specifies that the add-in can install on any release of Excel, which includes Excel on the web, Windows, and iPad, but can't be installed on any other Office application.
+For example, the following `<Hosts>` and `<Host>` declaration specifies that the add-in can install on any release of Excel, which includes Excel on the web, Windows, and iPad, but can't be installed on any other Office application.
 
 ```xml
 <Hosts>
@@ -53,7 +53,7 @@ For example, the following **\<Hosts\>** and **\<Host\>** declaration specifies 
 </Hosts>
 ```
 
-The **\<Hosts\>** element can contain one or more **\<Host\>** elements. There should be a separate **\<Host\>** element for each Office application on which the add-in should be installable. The `Name` attribute is required and can be set to one of the following values.
+The `<Hosts>` element can contain one or more `<Host>` elements. There should be a separate `<Host>` element for each Office application on which the add-in should be installable. The `Name` attribute is required and can be set to one of the following values.
 
 | Name          | Office client applications                     | Available add-in types |
 |:--------------|:-----------------------------------------------|:-----------------------|
@@ -96,12 +96,12 @@ Requirement set support varies by Office application, the version of the Office 
 
 Use the [Requirements](/javascript/api/manifest/requirements) element and its child element [Sets](/javascript/api/manifest/sets) to specify the minimum requirement sets that must be supported by the Office application to install your add-in.
 
-All APIs in the application specific models are in requirement sets, but some of those in the Common API model are not. Use the [Methods](/javascript/api/manifest/methods) to specify the setless API members that your add-in requires. You can't use the **\<Methods\>** element with Outlook add-ins.
+All APIs in the application specific models are in requirement sets, but some of those in the Common API model are not. Use the [Methods](/javascript/api/manifest/methods) to specify the setless API members that your add-in requires. You can't use the `<Methods>` element with Outlook add-ins.
 
-If the Office application or platform doesn't support the requirement sets or API members specified in the **\<Requirements\>** element, the add-in won't run in that application or platform, and won't display in **My Add-ins**.
+If the Office application or platform doesn't support the requirement sets or API members specified in the `<Requirements>` element, the add-in won't run in that application or platform, and won't display in **My Add-ins**.
 
 > [!NOTE]
-> The **\<Requirements\>** element is optional for all add-ins, except for Outlook add-ins. When the `xsi:type` attribute of the root `OfficeApp` element is `MailApp`, there must be a **\<Requirements\>** element that specifies the minimum version of the Mailbox requirement set that the add-in requires. For more information, see [Outlook JavaScript API requirement sets](/javascript/api/requirement-sets/outlook/outlook-api-requirement-sets).
+> The `<Requirements>` element is optional for all add-ins, except for Outlook add-ins. When the `xsi:type` attribute of the root `OfficeApp` element is `MailApp`, there must be a `<Requirements>` element that specifies the minimum version of the Mailbox requirement set that the add-in requires. For more information, see [Outlook JavaScript API requirement sets](/javascript/api/requirement-sets/outlook/outlook-api-requirement-sets).
 
 The following code example shows how to configure an add-in that is installable in all Office applications that support the following:
 
@@ -127,11 +127,11 @@ The following code example shows how to configure an add-in that is installable 
 
 Note the following about this example.
 
-- The **\<Requirements\>** element contains the **\<Sets\>** and **\<Methods\>** child elements.
-- The **\<Sets\>** element can contain one or more **\<Set\>** elements. `DefaultMinVersion` specifies the default `MinVersion` value of all child **\<Set\>** elements.
-- A [Set](/javascript/api/manifest/set) element specifies a requirement set that the Office application must support to make the add-in installable. The `Name` attribute specifies the name of the requirement set. The `MinVersion` specifies the minimum version of the requirement set. `MinVersion` overrides the value of the `DefaultMinVersion` attribute in the parent **\<Sets\>**.
-- The **\<Methods\>** element can contain one or more [Method](/javascript/api/manifest/method) elements. You can't use the **\<Methods\>** element with Outlook add-ins.
-- The **\<Method\>** element specifies an individual method that the Office application must support to make the add-in installable. The `Name` attribute is required and specifies the name of the method qualified with its parent object.
+- The `<Requirements>` element contains the `<Sets>` and `<Methods>` child elements.
+- The `<Sets>` element can contain one or more `<Set>` elements. `DefaultMinVersion` specifies the default `MinVersion` value of all child `<Set>` elements.
+- A [Set](/javascript/api/manifest/set) element specifies a requirement set that the Office application must support to make the add-in installable. The `Name` attribute specifies the name of the requirement set. The `MinVersion` specifies the minimum version of the requirement set. `MinVersion` overrides the value of the `DefaultMinVersion` attribute in the parent `<Sets>`.
+- The `<Methods>` element can contain one or more [Method](/javascript/api/manifest/method) elements. You can't use the `<Methods>` element with Outlook add-ins.
+- The `<Method>` element specifies an individual method that the Office application must support to make the add-in installable. The `Name` attribute is required and specifies the name of the method qualified with its parent object.
 
 ## Design for alternate experiences
 
@@ -139,24 +139,24 @@ The extensibility features that the Office Add-in platform provides can be usefu
 
 - Extensibility features that are available immediately after the add-in is installed. You can make use of this kind of feature by configuring a [VersionOverrides](/javascript/api/manifest/versionoverrides) element in the manifest. An example of this kind of feature is [Add-in Commands](../design/add-in-commands.md), which are custom ribbon buttons and menus.
 - Extensibility features that are available only when the add-in is running and that are implemented with Office.js JavaScript APIs; for example, [Dialog Boxes](../develop/dialog-api-in-office-add-ins.md).
-- Extensibility features that are available only at runtime but are implemented with a combination of Office.js JavaScript and configuration in a **\<VersionOverrides\>** element. Examples of these are [Excel custom functions](../excel/custom-functions-overview.md), [single sign-on](sso-in-office-add-ins.md), and [custom contextual tabs](../design/contextual-tabs.md).
+- Extensibility features that are available only at runtime but are implemented with a combination of Office.js JavaScript and configuration in a `<VersionOverrides>` element. Examples of these are [Excel custom functions](../excel/custom-functions-overview.md), [single sign-on](sso-in-office-add-ins.md), and [custom contextual tabs](../design/contextual-tabs.md).
 
 If your add-in uses a specific extensibility feature for some of its functionality but has other useful functionality that doesn't require the extensibility feature, you should design the add-in so that it's installable on platform and Office version combinations that don't support the extensibility feature. It can provide a valuable, albeit diminished, experience on those combinations.
 
 You implement this design differently depending on how the extensibility feature is implemented:
 
 - For features implemented entirely with JavaScript, see [Check for API availability at runtime](specify-api-requirements-runtime.md).
-- For features that require you to configure a **\<VersionOverrides\>** element, see [Specifying requirements in a VersionOverrides element](#specify-requirements-in-a-versionoverrides-element).
+- For features that require you to configure a `<VersionOverrides>` element, see [Specifying requirements in a VersionOverrides element](#specify-requirements-in-a-versionoverrides-element).
 
 ### Specify requirements in a VersionOverrides element
 
 The [VersionOverrides](/javascript/api/manifest/versionoverrides) element was added to the manifest schema primarily, but not exclusively, to support features that must be available immediately after an add-in is installed, such as add-in commands (custom ribbon buttons and menus). Office must know about these features when it parses the add-in manifest.
 
-Suppose your add-in uses one of these features, but the add-in is valuable, and should be installable, even on Office versions that don't support the feature. In this scenario, identify the feature using a [Requirements](/javascript/api/manifest/requirements) element (and its child [Sets](/javascript/api/manifest/sets) and [Methods](/javascript/api/manifest/methods) elements) that you include as a child of the **\<VersionOverrides\>** element itself instead of as a child of the base `OfficeApp` element. The effect of doing this is that Office will allow the add-in to be installed, but Office will ignore certain of the child elements of the **\<VersionOverrides\>** element on Office versions where the feature isn't supported.
+Suppose your add-in uses one of these features, but the add-in is valuable, and should be installable, even on Office versions that don't support the feature. In this scenario, identify the feature using a [Requirements](/javascript/api/manifest/requirements) element (and its child [Sets](/javascript/api/manifest/sets) and [Methods](/javascript/api/manifest/methods) elements) that you include as a child of the `<VersionOverrides>` element itself instead of as a child of the base `OfficeApp` element. The effect of doing this is that Office will allow the add-in to be installed, but Office will ignore certain of the child elements of the `<VersionOverrides>` element on Office versions where the feature isn't supported.
 
-Specifically, the child elements of the **\<VersionOverrides\>** that override elements in the base manifest, such as a **\<Hosts\>** element, are ignored and the corresponding elements of the base manifest are used instead. However, there can be child elements in a **\<VersionOverrides\>** that actually implement additional features rather than override settings in the base manifest. Two examples are the `WebApplicationInfo` and `EquivalentAddins`. These parts of the **\<VersionOverrides\>** will *not* be ignored, assuming the platform and version of Office support the corresponding feature.  
+Specifically, the child elements of the `<VersionOverrides>` that override elements in the base manifest, such as a `<Hosts>` element, are ignored and the corresponding elements of the base manifest are used instead. However, there can be child elements in a `<VersionOverrides>` that actually implement additional features rather than override settings in the base manifest. Two examples are the `WebApplicationInfo` and `EquivalentAddins`. These parts of the `<VersionOverrides>` will *not* be ignored, assuming the platform and version of Office support the corresponding feature.  
 
-For information about the descendent elements of the **\<Requirements\>** element, see [Requirements element](#requirements-element) earlier in this article.
+For information about the descendent elements of the `<Requirements>` element, see [Requirements element](#requirements-element) earlier in this article.
 
 The following is an example.
 
@@ -180,10 +180,10 @@ The following is an example.
 ```
 
 > [!WARNING]
-> If your add-in includes [add-in commands](../design/add-in-commands.md), use great care before including a **\<Requirements\>** element in a **\<VersionOverrides\>**. On platform and version combinations that don't support the requirement, *none* of the add-in commands will be installed, *even those that invoke functionality that doesn't need the requirement*. Consider, for example, an add-in that has two custom ribbon buttons. One of them calls Office JavaScript APIs that are available in requirement set **ExcelApi 1.4** (and later). The other calls APIs that are only available in **ExcelApi 1.9** (and later). If you put a requirement for **ExcelApi 1.9** in the **\<VersionOverrides\>**, then when 1.9 isn't supported, *neither* button will appear on the ribbon. A better strategy in this scenario would be to use the technique described in [Check for API availability at runtime](specify-api-requirements-runtime.md). The code invoked by the second button first uses `isSetSupported` to check for support of **ExcelApi 1.9**. If it isn't supported, the code gives the user a message saying that this feature of the add-in isn't available on their version of Office.
+> If your add-in includes [add-in commands](../design/add-in-commands.md), use great care before including a `<Requirements>` element in a `<VersionOverrides>`. On platform and version combinations that don't support the requirement, *none* of the add-in commands will be installed, *even those that invoke functionality that doesn't need the requirement*. Consider, for example, an add-in that has two custom ribbon buttons. One of them calls Office JavaScript APIs that are available in requirement set **ExcelApi 1.4** (and later). The other calls APIs that are only available in **ExcelApi 1.9** (and later). If you put a requirement for **ExcelApi 1.9** in the `<VersionOverrides>`, then when 1.9 isn't supported, *neither* button will appear on the ribbon. A better strategy in this scenario would be to use the technique described in [Check for API availability at runtime](specify-api-requirements-runtime.md). The code invoked by the second button first uses `isSetSupported` to check for support of **ExcelApi 1.9**. If it isn't supported, the code gives the user a message saying that this feature of the add-in isn't available on their version of Office.
 
 > [!TIP]
-> There's no point to repeating a **\<Requirement\>** element in a **\<VersionOverrides\>** that already appears in the base manifest. If the requirement is specified in the base manifest, then the add-in can't install where the requirement isn't supported so Office doesn't even parse the **\<VersionOverrides\>** element.
+> There's no point to repeating a `<Requirement>` element in a `<VersionOverrides>` that already appears in the base manifest. If the requirement is specified in the base manifest, then the add-in can't install where the requirement isn't supported so Office doesn't even parse the `<VersionOverrides>` element.
 
 ## See also
 

--- a/docs/develop/sso-in-office-add-ins.md
+++ b/docs/develop/sso-in-office-add-ins.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Enable single sign-on (SSO) in an Office Add-in
 description: Learn the key steps to enable single sign-on (SSO) for your Office Add-in using common Microsoft personal, work, or education accounts.
 ms.date: 05/06/2024
@@ -83,15 +83,15 @@ There should be a [`"webApplicationInfo"`](/microsoft-365/extensibility/schema/r
 ```
 
 > [!NOTE]
-> Experienced add-in developers should note that, there is no unified manifest property corresponding to the **\<Scopes\>** element in the add-in only manifest. Microsoft Graph and other API permissions are requested at runtime in your code.
+> Experienced add-in developers should note that, there is no unified manifest property corresponding to the `<Scopes>` element in the add-in only manifest. Microsoft Graph and other API permissions are requested at runtime in your code.
 
 # [Add-in only manifest](#tab/xmlmanifest)
 
-- **\<WebApplicationInfo\>** - The parent of the following elements.
-- **\<Id\>** - The application (client) ID you received when you registered the add-in with the Microsoft identity platform. For more information, see [Register an Office Add-in that uses SSO with the Microsoft identity platform](register-sso-add-in-aad-v2.md).
-- **\<Resource\>** - The URI of the add-in. This is the same URI (including the `api:` protocol) that you used when registering the add-in with the Microsoft identity platform. The domain part of this URI must match the domain, including any subdomains, used in the URLs in the **\<Resources\>** section of the add-in's manifest and the URI must end with the client ID specified in the **\<Id\>** element.
-- **\<Scopes\>** - The parent of one or more **\<Scope\>** elements.
-- **\<Scope\>** - Specifies a permission that the add-in needs. The `profile` and `openID` permissions are always needed and may be the only permissions needed. If your add-in needs access to Microsoft Graph or other Microsoft 365 resources, you'll need additional **\<Scope\>** elements. For example, for Microsoft Graph permissions you might request the `User.Read` and `Mail.Read` scopes. Libraries that you use in your code to access Microsoft Graph may need additional permissions. For more information, see [Authorize to Microsoft Graph from an Office Add-in](authorize-to-microsoft-graph.md).
+- `<WebApplicationInfo>` - The parent of the following elements.
+- `<Id>` - The application (client) ID you received when you registered the add-in with the Microsoft identity platform. For more information, see [Register an Office Add-in that uses SSO with the Microsoft identity platform](register-sso-add-in-aad-v2.md).
+- `<Resource>` - The URI of the add-in. This is the same URI (including the `api:` protocol) that you used when registering the add-in with the Microsoft identity platform. The domain part of this URI must match the domain, including any subdomains, used in the URLs in the `<Resources>` section of the add-in's manifest and the URI must end with the client ID specified in the `<Id>` element.
+- `<Scopes>` - The parent of one or more `<Scope>` elements.
+- `<Scope>` - Specifies a permission that the add-in needs. The `profile` and `openID` permissions are always needed and may be the only permissions needed. If your add-in needs access to Microsoft Graph or other Microsoft 365 resources, you'll need additional `<Scope>` elements. For example, for Microsoft Graph permissions you might request the `User.Read` and `Mail.Read` scopes. Libraries that you use in your code to access Microsoft Graph may need additional permissions. For more information, see [Authorize to Microsoft Graph from an Office Add-in](authorize-to-microsoft-graph.md).
 
 For Word, Excel, and PowerPoint add-ins, add the markup to the end of the `<VersionOverrides ... xsi:type="VersionOverridesV1_0">` section. For Outlook add-ins, add the markup to the end of the `<VersionOverrides ... xsi:type="VersionOverridesV1_1">` section.
 

--- a/docs/develop/troubleshoot-sso-in-office-add-ins.md
+++ b/docs/develop/troubleshoot-sso-in-office-add-ins.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Troubleshoot error messages for single sign-on (SSO)
 description: Guidance about how to troubleshoot problems with single sign-on (SSO) in Office Add-ins, and handle special conditions or errors.
 ms.date: 06/24/2025
@@ -60,7 +60,7 @@ User Type not supported. The user isn't signed into Office with a valid Microsof
 
 ### 13004
 
-Invalid Resource. (This error should only be seen in development.) The add-in manifest hasn't been configured correctly. Update the manifest. For more information, see [Validate an Office Add-in's manifest](../testing/troubleshoot-manifest.md). The most common problem is that the **\<Resource\>** element (in the **\<WebApplicationInfo\>** element) has a domain that does not match the domain of the add-in. Although the protocol part of the Resource value should be "api" not "https"; all other parts of the domain name (including port, if any) should be the same as for the add-in.
+Invalid Resource. (This error should only be seen in development.) The add-in manifest hasn't been configured correctly. Update the manifest. For more information, see [Validate an Office Add-in's manifest](../testing/troubleshoot-manifest.md). The most common problem is that the `<Resource>` element (in the `<WebApplicationInfo>` element) has a domain that does not match the domain of the add-in. Although the protocol part of the Resource value should be "api" not "https"; all other parts of the domain name (including port, if any) should be the same as for the add-in.
 
 ### 13005
 

--- a/docs/develop/use-sso-to-get-office-signed-in-user-token.md
+++ b/docs/develop/use-sso-to-get-office-signed-in-user-token.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Use SSO to get the identity of the signed-in user
 description: Call the getAccessToken API to get the ID token with name, email, and additional information about the signed-in user.
 ms.date: 06/24/2025
@@ -44,7 +44,7 @@ To use SSO with Office, you need to create an app registration in the Azure port
 
     When you're finished, the entire ID should have the form `api://localhost:[port]/[app-id-guid]`; for example `api://localhost:44355/c6c1f32b-5e55-4997-881a-753cc1d563b7`.
 
-1. Select the **Add a scope** button. In the panel that opens, enter `access_as_user` as the **\<Scope\>** name.
+1. Select the **Add a scope** button. In the panel that opens, enter `access_as_user` as the `<Scope>` name.
 
 1. Set **Who can consent?** to **Admins and users**.
 
@@ -60,7 +60,7 @@ To use SSO with Office, you need to create an app registration in the Azure port
 1. Select **Add scope** .
 
    > [!NOTE]
-   > The domain part of the **\<Scope\>** name displayed just below the text field should automatically match the Application ID URI that you set earlier, with `/access_as_user` appended to the end; for example, `api://localhost:6789/c6c1f32b-5e55-4997-881a-753cc1d563b7/access_as_user`.
+   > The domain part of the `<Scope>` name displayed just below the text field should automatically match the Application ID URI that you set earlier, with `/access_as_user` appended to the end; for example, `api://localhost:6789/c6c1f32b-5e55-4997-881a-753cc1d563b7/access_as_user`.
 
 1. In the **Authorized client applications** section, enter the following ID to pre-authorize all Microsoft Office application endpoints.
 
@@ -150,11 +150,11 @@ In Visual Studio Code, open the **manifest.xml** file.
 
 The XML you inserted contains the following elements and information.
 
-- **\<WebApplicationInfo\>** - The parent of the following elements.
-- **\<Id\>** - The client ID of the add-in This is an application ID that you obtain as part of registering the add-in. See [Register an Office Add-in that uses single sign-on (SSO) with the Microsoft identity platform](register-sso-add-in-aad-v2.md).
-- **\<Resource\>** - The URL of the add-in. This is the same URI (including the `api:` protocol) that you used when registering the add-in in Microsoft Entra ID. The domain part of this URI must match the domain, including any subdomains, used in the URLs in the **\<Resources\>** section of the add-in's manifest and the URI must end with the client ID in the **\<Id\>**.
-- **\<Scopes\>** - The parent of one or more **\<Scope\>** elements.
-- **\<Scope\>** - Specifies a permission that the add-in needs. The `profile` and `openID` permissions are always needed and may be the only permissions needed, if your add-in doesn't access Microsoft Graph. If it does, you also need **\<Scope\>** elements for the required Microsoft Graph permissions; for example, `User.Read`, `Mail.Read`. Libraries that you use in your code to access Microsoft Graph may need additional permissions. For example, Microsoft Authentication Library (MSAL) for .NET requires the `offline_access` permission. For more information, see [Authorize to Microsoft Graph from an Office Add-in](authorize-to-microsoft-graph.md).
+- `<WebApplicationInfo>` - The parent of the following elements.
+- `<Id>` - The client ID of the add-in This is an application ID that you obtain as part of registering the add-in. See [Register an Office Add-in that uses single sign-on (SSO) with the Microsoft identity platform](register-sso-add-in-aad-v2.md).
+- `<Resource>` - The URL of the add-in. This is the same URI (including the `api:` protocol) that you used when registering the add-in in Microsoft Entra ID. The domain part of this URI must match the domain, including any subdomains, used in the URLs in the `<Resources>` section of the add-in's manifest and the URI must end with the client ID in the `<Id>`.
+- `<Scopes>` - The parent of one or more `<Scope>` elements.
+- `<Scope>` - Specifies a permission that the add-in needs. The `profile` and `openID` permissions are always needed and may be the only permissions needed, if your add-in doesn't access Microsoft Graph. If it does, you also need `<Scope>` elements for the required Microsoft Graph permissions; for example, `User.Read`, `Mail.Read`. Libraries that you use in your code to access Microsoft Graph may need additional permissions. For example, Microsoft Authentication Library (MSAL) for .NET requires the `offline_access` permission. For more information, see [Authorize to Microsoft Graph from an Office Add-in](authorize-to-microsoft-graph.md).
 
 ## Add the jwt-decode package
 

--- a/docs/develop/xml-manifest-overview.md
+++ b/docs/develop/xml-manifest-overview.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Office Add-ins with the add-in only manifest
 description: Get an overview of the add-in only manifest for Office add-ins and its uses.
 ms.topic: overview
@@ -17,7 +17,7 @@ This article introduces the XML-formatted add-in only manifest for Office Add-in
 
 Not all Office clients support the latest features, and some Office users will have an older version of Office. Having schema versions lets developers build add-ins that are backwards compatible, using the newest features where they are available but still functioning on older versions.
 
-The **\<VersionOverrides\>** element in the manifest is an example of this. All elements defined inside **\<VersionOverrides\>** will override the same element in the other part of the manifest. This means that, whenever possible, Office will use what is in the **\<VersionOverrides\>** section to set up the add-in. However, if the version of Office doesn't support a certain version of **\<VersionOverrides\>**, Office will ignore it and depend on the information in the rest of the manifest.
+The `<VersionOverrides>` element in the manifest is an example of this. All elements defined inside `<VersionOverrides>` will override the same element in the other part of the manifest. This means that, whenever possible, Office will use what is in the `<VersionOverrides>` section to set up the add-in. However, if the version of Office doesn't support a certain version of `<VersionOverrides>`, Office will ignore it and depend on the information in the rest of the manifest.
 
 This approach means that developers don't have to create multiple individual manifests, but rather keep everything defined in one file.
 
@@ -26,11 +26,11 @@ The current versions of the schema are:
 |Version|Description|
 |:-----|:-----|
 |v1.0|Supports version 1.0 of the Office JavaScript API. For example, in Outlook add-ins, this supports the read form. |
-|v1.1|Supports version 1.1 of the Office JavaScript API and **\<VersionOverrides\>**. For example, in Outlook add-ins, this adds support for the compose form.|
-|**\<VersionOverrides\>** 1.0|Supports later versions of the Office JavaScript API. This supports add-in commands.|
-|**\<VersionOverrides\>** 1.1|Supported by Outlook only. This version of **\<VersionOverrides\>** adds support for newer features, such as [pinnable task panes](../outlook/pinnable-taskpane.md) and mobile add-ins.|
+|v1.1|Supports version 1.1 of the Office JavaScript API and `<VersionOverrides>`. For example, in Outlook add-ins, this adds support for the compose form.|
+|`<VersionOverrides>` 1.0|Supports later versions of the Office JavaScript API. This supports add-in commands.|
+|`<VersionOverrides>` 1.1|Supported by Outlook only. This version of `<VersionOverrides>` adds support for newer features, such as [pinnable task panes](../outlook/pinnable-taskpane.md) and mobile add-ins.|
 
-Even if your add-in manifest uses the **\<VersionOverrides\>** element, it is still important to include the v1.1 manifest elements to allow your add-in to work with older clients that do not support **\<VersionOverrides\>**.
+Even if your add-in manifest uses the `<VersionOverrides>` element, it is still important to include the v1.1 manifest elements to allow your add-in to work with older clients that do not support `<VersionOverrides>`.
 
 > [!NOTE]
 > Office uses a schema to validate manifests. The schema requires that elements in the manifest appear in a specific order. If you include elements out of the required order, you may get errors when sideloading your add-in. See [How to find the proper order of manifest elements](../develop/manifest-element-ordering.md) elements in the required order.
@@ -99,7 +99,7 @@ _\*\* SupportUrl is only required for add-ins that are distributed through AppSo
 
 ## Root element
 
-The root element for the Office Add-in manifest is **\<OfficeApp\>**. This element also declares the default namespace, schema version and the type of add-in. Place all other elements in the manifest within its open and close tags. The following is an example of the root element.
+The root element for the Office Add-in manifest is `<OfficeApp>`. This element also declares the default namespace, schema version and the type of add-in. Place all other elements in the manifest within its open and close tags. The following is an example of the root element.
 
 ```XML
 <OfficeApp
@@ -122,7 +122,7 @@ If the add-in's requested permissions change, users will be prompted to upgrade 
 
 ## Hosts
 
-Office add-ins specify the **\<Hosts\>** element like the following:
+Office add-ins specify the `<Hosts>` element like the following:
 
 ```XML
 <OfficeApp>
@@ -134,13 +134,13 @@ Office add-ins specify the **\<Hosts\>** element like the following:
 </OfficeApp>
 ```
 
-This is separate from the **\<Hosts\>** element inside the **\<VersionOverrides\>** element, which is discussed in [Create add-in commands with the add-in only manifest](../develop/create-addin-commands.md).
+This is separate from the `<Hosts>` element inside the `<VersionOverrides>` element, which is discussed in [Create add-in commands with the add-in only manifest](../develop/create-addin-commands.md).
 
 ## Specify safe domains with the AppDomains element
 
 There is an [AppDomains](/javascript/api/manifest/appdomains) element of the add-in only manifest file that is used to tell Office which domains your add-in should be allowed to navigate to. As noted in [Specify domains you want to open in the add-in window](add-in-manifests.md#specify-domains-you-want-to-open-in-the-add-in-window), when running in Office on the web, your task pane can be navigated to any URL. However, in desktop platforms, if your add-in tries to go to a URL in a domain other than the domain that hosts the start page (as specified in the [SourceLocation](/javascript/api/manifest/sourcelocation) element), that URL opens in a new browser window outside the add-in pane of the Office application.
 
-To override this (desktop Office) behavior, add each domain you want to open in the add-in window in the list of domains specified in the **\<AppDomains\>** element. If the add-in tries to go to a URL in a domain that is in the list, then it opens in the task pane in both Office on the web and desktop. If it tries to go to a URL that isn't in the list, then in desktop Office that URL opens in a new browser window (outside the add-in pane).
+To override this (desktop Office) behavior, add each domain you want to open in the add-in window in the list of domains specified in the `<AppDomains>` element. If the add-in tries to go to a URL in a domain that is in the list, then it opens in the task pane in both Office on the web and desktop. If it tries to go to a URL that isn't in the list, then in desktop Office that URL opens in a new browser window (outside the add-in pane).
 
 The following table describes browser behavior when your add-in attempts to navigate to a URL outside of the add-in's default domain.
 
@@ -150,7 +150,7 @@ The following table describes browser behavior when your add-in attempts to navi
 |Office 2016 on Windows (volume-licensed perpetual)|No|Link opens in Internet Explorer 11.|
 |Other clients|No|Link opens in user's default browser.|
 
-The following add-in only manifest example hosts its main add-in page in the `https://www.contoso.com` domain as specified in the **\<SourceLocation\>** element. It also specifies the `https://www.northwindtraders.com` domain in an [AppDomain](/javascript/api/manifest/appdomain) element within the **\<AppDomains\>** element list. If the add-in goes to a page in the `www.northwindtraders.com` domain, that page opens in the add-in pane, even in Office desktop.
+The following add-in only manifest example hosts its main add-in page in the `https://www.contoso.com` domain as specified in the `<SourceLocation>` element. It also specifies the `https://www.northwindtraders.com` domain in an [AppDomain](/javascript/api/manifest/appdomain) element within the `<AppDomains>` element list. If the add-in goes to a page in the `www.northwindtraders.com` domain, that page opens in the add-in pane, even in Office desktop.
 
 ```XML
 <?xml version="1.0" encoding="UTF-8"?>
@@ -226,11 +226,11 @@ For an example of a manifest that includes a `VersionOverrides` element, see [Ma
 
 ## Requirements
 
-The **\<Requirements\>** element specifies the set of APIs available to the add-in. For detailed information about requirement sets, see [Office requirement sets availability](office-versions-and-requirement-sets.md#office-requirement-sets-availability). For example, in an Outlook add-in, the requirement set must be Mailbox and a value of 1.1 or above.
+The `<Requirements>` element specifies the set of APIs available to the add-in. For detailed information about requirement sets, see [Office requirement sets availability](office-versions-and-requirement-sets.md#office-requirement-sets-availability). For example, in an Outlook add-in, the requirement set must be Mailbox and a value of 1.1 or above.
 
-The **\<Requirements\>** element can also appear in the **\<VersionOverrides\>** element, allowing the add-in to specify a different requirement when loaded in clients that support **\<VersionOverrides\>**.
+The `<Requirements>` element can also appear in the `<VersionOverrides>` element, allowing the add-in to specify a different requirement when loaded in clients that support `<VersionOverrides>`.
 
-The following example uses the **DefaultMinVersion** attribute of the **\<Sets\>** element to require office.js version 1.1 or higher, and the **MinVersion** attribute of the **\<Set\>** element to require the Mailbox requirement set version 1.1.
+The following example uses the **DefaultMinVersion** attribute of the `<Sets>` element to require office.js version 1.1 or higher, and the **MinVersion** attribute of the `<Set>` element to require the Mailbox requirement set version 1.1.
 
 ```XML
 <OfficeApp>
@@ -246,7 +246,7 @@ The following example uses the **DefaultMinVersion** attribute of the **\<Sets\>
 
 ## Localization
 
-Some aspects of the add-in need to be localized for different locales, such as the name, description and the URL that's loaded. These elements can easily be localized by specifying the default value and then locale overrides in the **\<Resources\>** element within the **\<VersionOverrides\>** element. The following shows how to override an image, a URL, and a string.
+Some aspects of the add-in need to be localized for different locales, such as the name, description and the URL that's loaded. These elements can easily be localized by specifying the default value and then locale overrides in the `<Resources>` element within the `<VersionOverrides>` element. The following shows how to override an image, a URL, and a string.
 
 ```XML
 <Resources>

--- a/docs/excel/custom-functions-json.md
+++ b/docs/excel/custom-functions-json.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Manually create JSON metadata for custom functions in Excel
 description: Define JSON metadata for custom functions in Excel and associate your function ID and name properties.
 ms.date: 07/10/2025
@@ -24,13 +24,13 @@ The following image explains the differences between using `yo office` scaffold 
 ![Image of differences between using the Yeoman generator for Office Add-ins and writing your own JSON.](../images/custom-functions-json.png)
 
 > [!NOTE]
-> Remember to connect your manifest to the JSON file you create, through the **\<Resources\>** section in your add-in only manifest file if you do not use the [Yeoman generator for Office Add-ins](../develop/yeoman-generator-overview.md).
+> Remember to connect your manifest to the JSON file you create, through the `<Resources>` section in your add-in only manifest file if you do not use the [Yeoman generator for Office Add-ins](../develop/yeoman-generator-overview.md).
 
 ## Authoring metadata and connecting to the manifest
 
 Create a JSON file in your project and provide all the details about your functions in it, such as the function's parameters. See the [following metadata example](#json-metadata-example) and [the metadata reference](#metadata-reference) for a complete list of function properties.
 
-Ensure your add-in only manifest file references your JSON file in the **\<Resources\>** section, similar to the following example.
+Ensure your add-in only manifest file references your JSON file in the `<Resources>` section, similar to the following example.
 
 ```json
 <Resources>

--- a/docs/excel/custom-functions-overview.md
+++ b/docs/excel/custom-functions-overview.md
@@ -1,4 +1,4 @@
----
+﻿---
 description: Create an Excel custom function for your Office Add-in.
 title: Create custom functions in Excel
 ms.date: 11/11/2024
@@ -74,7 +74,7 @@ function add(first, second){
 The add-in only manifest file for an add-in that defines custom functions (**./manifest.xml** in the project that the [Yeoman generator for Office Add-ins](../develop/yeoman-generator-overview.md) creates) does several things.
 
 - Defines the namespace for your custom functions. A namespace prepends itself to your custom functions to help customers identify your functions as part of your add-in.
-- Uses **\<ExtensionPoint\>** and **\<Resources\>** elements that are unique to a custom functions manifest. These elements contain the information about the locations of the JavaScript, JSON, and HTML files.
+- Uses `<ExtensionPoint>` and `<Resources>` elements that are unique to a custom functions manifest. These elements contain the information about the locations of the JavaScript, JSON, and HTML files.
 - Specifies which runtime to use for your custom function. We recommend always using a shared runtime unless you have a specific need for another runtime, because a shared runtime allows for the sharing of data between functions and the task pane.
 
 To see a full working manifest from a sample add-in, see the manifest in the [one of our Office Add-in samples Github repositories](https://github.com/OfficeDev/Office-Add-in-samples/blob/main/Samples/excel-shared-runtime-global-state/manifest.xml).

--- a/docs/excludes/outlook-quickstart-json-manifest-typescript.md
+++ b/docs/excludes/outlook-quickstart-json-manifest-typescript.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Build an Outlook add-in with the unified manifest for Microsoft 365
 description: Learn how to build a simple Outlook task pane add-in with the unified manifest for Microsoft 365.
 ms.date: 05/19/2025
@@ -70,7 +70,7 @@ The add-in project that you've created with the Yeoman generator contains sample
     > [!TIP]
     > On Windows, you can navigate to the root directory of the project via the command line and then enter `code .` to open that folder in VS Code.
 
-1. Open the file **./src/taskpane/taskpane.html** and replace the entire **\<main\>** element (within the **\<body\>** element) with the following markup. This new markup adds a label where the script in **./src/taskpane/taskpane.ts** will write data.
+1. Open the file **./src/taskpane/taskpane.html** and replace the entire `<main>` element (within the `<body>` element) with the following markup. This new markup adds a label where the script in **./src/taskpane/taskpane.ts** will write data.
 
     ```html
     <main id="app-body" class="ms-welcome__main" style="display: none;">

--- a/docs/outlook/add-mobile-support.md
+++ b/docs/outlook/add-mobile-support.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Add support for add-in commands in Outlook on mobile devices
 description: Learn how to add support for Outlook on mobile devices including how to update the add-in manifest and change your code for mobile scenarios, if necessary.
 ms.date: 01/31/2025
@@ -127,13 +127,13 @@ The first step to enabling add-in commands in Outlook mobile is to define them i
 
 # [Add-in only manifest](#tab/xmlmanifest)
 
-The [VersionOverrides](/javascript/api/manifest/versionoverrides) v1.1 schema defines a new form factor for mobile, [MobileFormFactor](/javascript/api/manifest/mobileformfactor). The **\<MobileFormFactor\>** element contains all of the information for loading the add-in in mobile clients. This way, you can define completely different UI elements and JavaScript files for the mobile experience.
+The [VersionOverrides](/javascript/api/manifest/versionoverrides) v1.1 schema defines a new form factor for mobile, [MobileFormFactor](/javascript/api/manifest/mobileformfactor). The `<MobileFormFactor>` element contains all of the information for loading the add-in in mobile clients. This way, you can define completely different UI elements and JavaScript files for the mobile experience.
 
-The following example shows a single task pane button in a **\<MobileFormFactor\>** element. This is very similar to the elements that appear in a [DesktopFormFactor](/javascript/api/manifest/desktopformfactor) element, with some notable differences.
+The following example shows a single task pane button in a `<MobileFormFactor>` element. This is very similar to the elements that appear in a [DesktopFormFactor](/javascript/api/manifest/desktopformfactor) element, with some notable differences.
 
 - The [OfficeTab](/javascript/api/manifest/officetab) element isn't used.
-- The [ExtensionPoint](/javascript/api/manifest/extensionpoint) element must have only one child element. If your add-in implements the [MobileOnlineMeetingCommandSurface](/javascript/api/manifest/extensionpoint#mobileonlinemeetingcommandsurface) or [MobileLogEventAppointmentAttendee](/javascript/api/manifest/extensionpoint#mobilelogeventappointmentattendee) extension point, you must include a [Control](/javascript/api/manifest/control) child element. If your add-in implements the [MobileMessageReadCommandSurface](/javascript/api/manifest/extensionpoint#mobilemessagereadcommandsurface) extension point, you must include a [Group](/javascript/api/manifest/group) child element that contains multiple **\<Control\>** elements.
-- There is no `Menu` type equivalent for the **\<Control\>** element.
+- The [ExtensionPoint](/javascript/api/manifest/extensionpoint) element must have only one child element. If your add-in implements the [MobileOnlineMeetingCommandSurface](/javascript/api/manifest/extensionpoint#mobileonlinemeetingcommandsurface) or [MobileLogEventAppointmentAttendee](/javascript/api/manifest/extensionpoint#mobilelogeventappointmentattendee) extension point, you must include a [Control](/javascript/api/manifest/control) child element. If your add-in implements the [MobileMessageReadCommandSurface](/javascript/api/manifest/extensionpoint#mobilemessagereadcommandsurface) extension point, you must include a [Group](/javascript/api/manifest/group) child element that contains multiple `<Control>` elements.
+- There is no `Menu` type equivalent for the `<Control>` element.
 - The [Supertip](/javascript/api/manifest/supertip) element isn't used.
 - The required icon sizes are different. Mobile add-ins minimally must support 25x25, 32x32 and 48x48 pixel icons. For more information, see [Additional requirements for mobile form factors](/javascript/api/manifest/icon#additional-requirements-for-mobile-form-factors).
 

--- a/docs/outlook/apis.md
+++ b/docs/outlook/apis.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Outlook add-in APIs
 description: Learn how to reference the Outlook add-in APIs and declare permissions in your Outlook add-in.
 ms.date: 01/07/2025
@@ -46,7 +46,7 @@ if (item.somePropertyOrFunction) {
 
 Specify the minimum requirement set that supports the critical set of APIs for your scenario, without which features of your add-in won't work. You specify the requirement set in the manifest. The markup varies depending on the manifest that you are using.
 
-- **Add-in only manifest**:  Use the **\<Requirements\>** element. Note that the **\<Methods\>** child element of **\<Requirements\>** isn't supported in Outlook add-ins, so you can't declare support for specific methods.
+- **Add-in only manifest**:  Use the `<Requirements>` element. Note that the `<Methods>` child element of `<Requirements>` isn't supported in Outlook add-ins, so you can't declare support for specific methods.
 - **Unified manifest for Microsoft 365**: Use the `"extensions.capabilities"` property.
 
 For more information, see [Office Add-in manifests](../develop/add-in-manifests.md), and [Understanding Outlook API requirement sets](/javascript/api/requirement-sets/outlook/outlook-api-requirement-sets).

--- a/docs/outlook/append-on-send.md
+++ b/docs/outlook/append-on-send.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Prepend or append content to a message or appointment body on send
 description: Learn how to prepend or append content to a message or appointment body when the mail item is sent.
 ms.date: 07/18/2024
@@ -182,7 +182,7 @@ To enable the prepend-on-send and append-on-send features in your add-in, you mu
 
 1. Open the **manifest.xml** file located at the root of your project.
 
-1. Select the entire **\<VersionOverrides\>** node (including open and close tags) and replace it with the following XML.
+1. Select the entire `<VersionOverrides>` node (including open and close tags) and replace it with the following XML.
 
     ```XML
     <VersionOverrides xmlns="http://schemas.microsoft.com/office/mailappversionoverrides" xsi:type="VersionOverridesV1_0">
@@ -395,7 +395,7 @@ In this section, you'll implement the JavaScript code to append a sample company
 
 1. In the same **commands.js** file, insert the following after the `appendDisclaimerOnSend` function. These calls map the function name specified in the manifest to its JavaScript counterpart. The location of the function name in the manifest varies depending on the type of manifest your add-in uses.
 
-- **Add-in only manifest**: The function name specified in the **\<FunctionName\>** element.
+- **Add-in only manifest**: The function name specified in the `<FunctionName>` element.
 - **Unified manifest for Microsoft 365**: The function name specified in the `"id"` property of the objects in the `"extensions.runtimes.actions"` array.
 
     ```javascript

--- a/docs/outlook/categories.md
+++ b/docs/outlook/categories.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Get and set categories
 description: How to manage categories on mailbox and item.
 ms.date: 04/12/2024
@@ -20,7 +20,7 @@ Only categories in the master list on your mailbox are available for you to appl
 > [!IMPORTANT]
 > For the add-in to manage the categories master list, it must request the **read/write mailbox** permission in the manifest. The markup varies depending on the type of manifest.
 >
-> - **Add-in only manifest**: Set the **\<Permissions\>** element to **ReadWriteMailbox**.
+> - **Add-in only manifest**: Set the `<Permissions>` element to **ReadWriteMailbox**.
 > - **Unified manifest for Microsoft 365**: Set the `"name"` property of an object in the [`"authorization.permissions.resourceSpecific"`](/microsoft-365/extensibility/schema/root-authorization-permissions#resourcespecific) array to `"Mailbox.ReadWrite.User"`.
 
 ### Add master categories

--- a/docs/outlook/contextless.md
+++ b/docs/outlook/contextless.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Activate your Outlook add-in without the Reading Pane enabled or a message selected
 description: Learn how to activate your Outlook add-in without enabling the Reading Pane or first selecting a message.
 ms.date: 04/12/2024
@@ -77,17 +77,17 @@ The steps to configure the manifest vary depending on which type of manifest you
 
 # [Add-in only manifest](#tab/xmlmanifest)
 
-To activate your add-in with the Reading Pane turned off or without a message selected, you must add the [SupportsNoItemContext](/javascript/api/manifest/action#supportsnoitemcontext) child element to the **\<Action\>** element and set its value to `true`. As this feature can only be implemented with a task pane in Message Read mode, the following elements must also be configured.
+To activate your add-in with the Reading Pane turned off or without a message selected, you must add the [SupportsNoItemContext](/javascript/api/manifest/action#supportsnoitemcontext) child element to the `<Action>` element and set its value to `true`. As this feature can only be implemented with a task pane in Message Read mode, the following elements must also be configured.
 
 - The [VersionOverrides 1.1 Mail](/javascript/api/manifest/versionoverrides-1-1-mail) schema must be specified.
-- The `xsi:type` attribute value of the **\<ExtensionPoint\>** element must be set to `MessageReadCommandSurface`.
-- The `xsi:type` attribute value of the **\<Action\>** element must be set to `ShowTaskpane`.
+- The `xsi:type` attribute value of the `<ExtensionPoint>` element must be set to `MessageReadCommandSurface`.
+- The `xsi:type` attribute value of the `<Action>` element must be set to `ShowTaskpane`.
 
 1. In your preferred code editor, open the Outlook quick start project you created.
 
 1. Open the **manifest.xml** file located at the root of the project.
 
-1. Select the entire **\<VersionOverrides\>** node and replace it with the following XML.
+1. Select the entire `<VersionOverrides>` node and replace it with the following XML.
 
     ```xml
     <VersionOverrides xmlns="http://schemas.microsoft.com/office/mailappversionoverrides" xsi:type="VersionOverridesV1_0">
@@ -156,7 +156,7 @@ To activate your add-in with the Reading Pane turned off or without a message se
 ## Configure the task pane
 
 1. In your project, navigate to the **taskpane** folder, then open **taskpane.html**.
-1. Replace the entire **\<body\>** element with the following markup.
+1. Replace the entire `<body>` element with the following markup.
 
     ```html
     <body class="ms-font-m ms-welcome ms-Fabric">

--- a/docs/outlook/contextual-outlook-add-ins.md
+++ b/docs/outlook/contextual-outlook-add-ins.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Contextual Outlook add-ins
 description: Initiate tasks related to a message without leaving the message itself to result in an easier and richer user experience.
 ms.date: 07/18/2024
@@ -18,7 +18,7 @@ You can specify regular expression rules to activate a contextual add-in when a 
 
 [!INCLUDE [Unified manifest for Microsoft 365 does not support contextual add-ins](../includes/json-manifest-outlook-contextual-not-supported.md)]
 
-A contextual add-in's manifest must include an [ExtensionPoint](/javascript/api/manifest/extensionpoint#detectedentity) element with its `xsi:type` attribute set to `DetectedEntity`. Within the **\<ExtensionPoint\>** element, the add-in must then specify a regular expression rule using the [Rule](/javascript/api/manifest/rule) element with its `xsi:type` attribute set to [ItemHasRegularExpressionMatch](/javascript/api/manifest/rule#itemhasregularexpressionmatch-rule).
+A contextual add-in's manifest must include an [ExtensionPoint](/javascript/api/manifest/extensionpoint#detectedentity) element with its `xsi:type` attribute set to `DetectedEntity`. Within the `<ExtensionPoint>` element, the add-in must then specify a regular expression rule using the [Rule](/javascript/api/manifest/rule) element with its `xsi:type` attribute set to [ItemHasRegularExpressionMatch](/javascript/api/manifest/rule#itemhasregularexpressionmatch-rule).
 
 The following example activates an add-in whenever a stock symbol is included in the body of the current mail item.
 

--- a/docs/outlook/debug-ui-less.md
+++ b/docs/outlook/debug-ui-less.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Debug function commands in Outlook add-ins
 description: Learn how to debug function commands in Outlook add-ins.
 ms.date: 07/11/2022
@@ -21,7 +21,7 @@ If you used the [Yeoman generator for Office Add-ins](../develop/yeoman-generato
 
 Otherwise, if you used another tool to create your add-in, perform the following steps.
 
-1. Navigate to the `HKEY_CURRENT_USER\SOFTWARE\Microsoft\Office\16.0\WEF\Developer\[Add-in ID]` registry key. Replace `[Add-in ID]` with the **\<Id\>** from your add-in's manifest.
+1. Navigate to the `HKEY_CURRENT_USER\SOFTWARE\Microsoft\Office\16.0\WEF\Developer\[Add-in ID]` registry key. Replace `[Add-in ID]` with the `<Id>` from your add-in's manifest.
 
     [!include[Developer registry key](../includes/developer-registry-key.md)]
 

--- a/docs/outlook/delegate-access.md
+++ b/docs/outlook/delegate-access.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Implement shared folders and shared mailbox scenarios in an Outlook add-in
 description: Discusses how to configure Outlook add-in support for shared folders (also known as delegate access) and shared mailboxes.
 ms.date: 07/22/2025
@@ -126,7 +126,7 @@ Add an additional object to the [`"authorization.permissions.resourceSpecific"`]
 
 # [Add-in only manifest](#tab/xmlmanifest)
 
-Under the parent **\<DesktopFormFactor\>** element, set the [SupportsSharedFolders](/javascript/api/manifest/supportssharedfolders) element to `true`. At present, other form factors aren't supported.
+Under the parent `<DesktopFormFactor>` element, set the [SupportsSharedFolders](/javascript/api/manifest/supportssharedfolders) element to `true`. At present, other form factors aren't supported.
 
 ```XML
 ...

--- a/docs/outlook/inside-the-identity-token.md
+++ b/docs/outlook/inside-the-identity-token.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Inside the Exchange identity token in an Outlook add-in
 description: Learn about the contents of an Exchange user identity token generated from an Outlook add-in.
 ms.date: 04/12/2024
@@ -63,7 +63,7 @@ The following table lists the parts of the identity token payload.
 
 | Claim | Description |
 |:-----|:-----|
-| `aud` | The URL of the add-in that requested the token. A token is only valid if it is sent from the add-in that is running in the client's webview control. The URL of the add-in is specified in the manifest. The markup depends on the type of manifest.</br></br>**Add-in only manifest:** If the add-in uses the Office Add-ins manifests schema v1.1, this URL is the URL specified in the first **\<SourceLocation\>** element, under the form type `ItemRead` or `ItemEdit`, whichever occurs first as part of the [FormSettings](/javascript/api/manifest/formsettings) element in the add-in manifest.</br></br>**Unified manifest for Microsoft 365:** The URL is specified in the `"extensions.audienceClaimUrl"` property. |
+| `aud` | The URL of the add-in that requested the token. A token is only valid if it is sent from the add-in that is running in the client's webview control. The URL of the add-in is specified in the manifest. The markup depends on the type of manifest.</br></br>**Add-in only manifest:** If the add-in uses the Office Add-ins manifests schema v1.1, this URL is the URL specified in the first `<SourceLocation>` element, under the form type `ItemRead` or `ItemEdit`, whichever occurs first as part of the [FormSettings](/javascript/api/manifest/formsettings) element in the add-in manifest.</br></br>**Unified manifest for Microsoft 365:** The URL is specified in the `"extensions.audienceClaimUrl"` property. |
 | `iss` | A unique identifier for the Exchange server that issued the token. All tokens issued by this Exchange server will have the same identifier. |
 | `nbf` | The date and time that the token is valid starting from. The value is the number of seconds since January 1, 1970. |
 | `exp` | The date and time that the token is valid until. The value is the number of seconds since January 1, 1970. |

--- a/docs/outlook/item-multi-select.md
+++ b/docs/outlook/item-multi-select.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Activate your Outlook add-in on multiple messages
 description: Learn how to activate your Outlook add-in when multiple messages are selected.
 ms.date: 07/15/2025
@@ -93,19 +93,19 @@ Complete the [Outlook quick start](../quickstarts/outlook-quickstart-yo.md) to c
 
 # [Add-in only manifest](#tab/xmlmanifest)
 
-To enable your add-in to activate on multiple selected messages, you must add the [SupportsMultiSelect](/javascript/api/manifest/action#supportsmultiselect) child element to the **\<Action\>** element and set its value to `true`. As item multi-select only supports messages at this time, the **\<ExtensionPoint\>** element's `xsi:type` attribute value must be set to `MessageReadCommandSurface` or `MessageComposeCommandSurface`.
+To enable your add-in to activate on multiple selected messages, you must add the [SupportsMultiSelect](/javascript/api/manifest/action#supportsmultiselect) child element to the `<Action>` element and set its value to `true`. As item multi-select only supports messages at this time, the `<ExtensionPoint>` element's `xsi:type` attribute value must be set to `MessageReadCommandSurface` or `MessageComposeCommandSurface`.
 
 1. In your preferred code editor, open the Outlook quick start project you created.
 
 1. Open the **manifest.xml** file located at the root of the project.
 
-1. Assign the **\<Permissions\>** element the `ReadWriteMailbox` value.
+1. Assign the `<Permissions>` element the `ReadWriteMailbox` value.
 
     ```xml
     <Permissions>ReadWriteMailbox</Permissions>
     ```
 
-1. Select the entire **\<VersionOverrides\>** node and replace it with the following XML.
+1. Select the entire `<VersionOverrides>` node and replace it with the following XML.
 
     ```xml
     <VersionOverrides xmlns="http://schemas.microsoft.com/office/mailappversionoverrides" xsi:type="VersionOverridesV1_0">
@@ -182,7 +182,7 @@ Item multi-select relies on the [SelectedItemsChanged](/javascript/api/office/of
 
 1. From the **./src/taskpane** folder, open **taskpane.html**.
 
-1. In the **\<body\>** element, replace the entire **\<main\>** element with the following markup.
+1. In the `<body>` element, replace the entire `<main>` element with the following markup.
 
     ```html
     <main id="app-body" class="ms-welcome__main">

--- a/docs/outlook/mobile-event-based.md
+++ b/docs/outlook/mobile-event-based.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Implement event-based activation in Outlook mobile add-ins
 description: Learn how to develop an Outlook mobile add-in that implements event-based activation.
 ms.date: 06/12/2025
@@ -105,7 +105,7 @@ To enable an event-based add-in on Outlook mobile, you must configure the follow
 
 1. In your code editor, open the quick start project you created.
 1. Open the **manifest.xml** file located at the root of your project.
-1. Select the entire **\<VersionOverrides\>** node (including the open and close tags) and replace it with the following XML.
+1. Select the entire `<VersionOverrides>` node (including the open and close tags) and replace it with the following XML.
 
     ```xml
     <VersionOverrides xmlns="http://schemas.microsoft.com/office/mailappversionoverrides" xsi:type="VersionOverridesV1_0">

--- a/docs/outlook/on-new-compose-events-walkthrough.md
+++ b/docs/outlook/on-new-compose-events-walkthrough.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Automatically set the subject of a new message or appointment
 description: Learn how to implement an event-based add-in that automatically sets the subject of a new message or appointment.
 ms.date: 06/12/2025
@@ -130,13 +130,13 @@ To configure the manifest, select the tab for the type of manifest you're using.
 
 To enable event-based activation of your add-in, you must configure the [Runtimes](/javascript/api/manifest/runtimes) element and [LaunchEvent](/javascript/api/manifest/extensionpoint#launchevent) extension point in the `VersionOverridesV1_1` node of the manifest.
 
-In event-based add-ins, classic Outlook on Windows uses a JavaScript file, while Outlook on the web and on the new Mac UI, and [new Outlook on Windows](https://support.microsoft.com/office/656bb8d9-5a60-49b2-a98b-ba7822bc7627) use an HTML file that can reference the same JavaScript file. You must provide references to both these files in the `Resources` node of the manifest as the Outlook platform ultimately determines whether to use HTML or JavaScript based on the Outlook client. As such, to configure event handling, provide the location of the HTML in the **\<Runtime\>** element, then in its `Override` child element provide the location of the JavaScript file inlined or referenced by the HTML.
+In event-based add-ins, classic Outlook on Windows uses a JavaScript file, while Outlook on the web and on the new Mac UI, and [new Outlook on Windows](https://support.microsoft.com/office/656bb8d9-5a60-49b2-a98b-ba7822bc7627) use an HTML file that can reference the same JavaScript file. You must provide references to both these files in the `Resources` node of the manifest as the Outlook platform ultimately determines whether to use HTML or JavaScript based on the Outlook client. As such, to configure event handling, provide the location of the HTML in the `<Runtime>` element, then in its `Override` child element provide the location of the JavaScript file inlined or referenced by the HTML.
 
 1. In your code editor, open the quick start project.
 
 1. Open the **manifest.xml** file located at the root of your project.
 
-1. Select the entire **\<VersionOverrides\>** node (including open and close tags) and replace it with the following XML, then save your changes.
+1. Select the entire `<VersionOverrides>` node (including open and close tags) and replace it with the following XML, then save your changes.
 
 ```XML
 <VersionOverrides xmlns="http://schemas.microsoft.com/office/mailappversionoverrides" xsi:type="VersionOverridesV1_0">

--- a/docs/outlook/online-meeting.md
+++ b/docs/outlook/online-meeting.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Create an Outlook add-in for an online-meeting provider
 description: Discusses how to set up an Outlook add-in for an online-meeting service provider.
 ms.date: 12/16/2024
@@ -256,7 +256,7 @@ The steps for configuring the manifest depend on which type of manifest you sele
 
 1. Open the **manifest.xml** file located at the root of your project.
 
-1. Select the entire **\<VersionOverrides\>** node (including open and close tags) and replace it with the following XML.
+1. Select the entire `<VersionOverrides>` node (including open and close tags) and replace it with the following XML.
 
 ```xml
 <VersionOverrides xmlns="http://schemas.microsoft.com/office/mailappversionoverrides" xsi:type="VersionOverridesV1_0">
@@ -322,13 +322,13 @@ The steps for configuring the manifest depend on which type of manifest you sele
 
 ### Add mobile support
 
-To allow users to create an online meeting from their mobile device, the [MobileOnlineMeetingCommandSurface extension point](/javascript/api/manifest/extensionpoint#mobileonlinemeetingcommandsurface) is configured in the manifest under the parent element **\<MobileFormFactor\>**. This extension point isn't supported in other form factors.
+To allow users to create an online meeting from their mobile device, the [MobileOnlineMeetingCommandSurface extension point](/javascript/api/manifest/extensionpoint#mobileonlinemeetingcommandsurface) is configured in the manifest under the parent element `<MobileFormFactor>`. This extension point isn't supported in other form factors.
 
 1. In your code editor, open the Outlook quick start project you created.
 
 1. Open the **manifest.xml** file located at the root of your project.
 
-1. Add the following markup as the second child of the **\<Host xsi:type="MailHost"\>** element. It should be a peer of the **\<DesktopFormFactor\>** element.
+1. Add the following markup as the second child of the **\<Host xsi:type="MailHost"\>** element. It should be a peer of the `<DesktopFormFactor>` element.
 
 ```xml
 <MobileFormFactor>

--- a/docs/outlook/onmessagefromchanged-onappointmentfromchanged-events.md
+++ b/docs/outlook/onmessagefromchanged-onappointmentfromchanged-events.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Automatically update your signature when switching between Exchange accounts
 description: Learn how to automatically update your signature when switching between Exchange accounts through the OnMessageFromChanged and OnAppointmentFromChanged events in your event-based activation Outlook add-in.
 ms.date: 07/22/2025
@@ -166,7 +166,7 @@ In addition to the `OnMessageFromChanged` event, the `OnNewMessageCompose` event
 
 1. Open the **manifest.xml** file located at the root of your project.
 
-1. Select the entire **\<VersionOverrides\>** node (including open and close tags), replace it with the following XML, then save your changes.
+1. Select the entire `<VersionOverrides>` node (including open and close tags), replace it with the following XML, then save your changes.
 
    ```xml
    <VersionOverrides xmlns="http://schemas.microsoft.com/office/mailappversionoverrides" xsi:type="VersionOverridesV1_0">

--- a/docs/outlook/outlook-mobile-addins.md
+++ b/docs/outlook/outlook-mobile-addins.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Add-ins for Outlook on mobile devices
 description: Outlook mobile add-ins are supported on all Microsoft 365 business accounts and Outlook.com accounts.
 ms.date: 07/01/2025
@@ -51,7 +51,7 @@ Outlook mobile add-ins are supported on all Microsoft 365 business accounts and 
 
 - Your manifest needs to declare mobile support including special mobile controls and icon sizes.
   - **Unified manifest for Microsoft 365**: Include the string `"mobile"` in the [`"extensions.ribbons.requirements.formFactors"`](/microsoft-365/extensibility/schema/requirements-extension-element#formfactors) array, and include a `"customMobileRibbonGroups"` array in the tab object of the [`"extensions.ribbons.tabs"`](/microsoft-365/extensibility/schema/extension-ribbons-array#tabs) array. The object in this array must include a `"controls.type"` of `"mobileButton"` and a `"controls.icons"` array.
-  - **Add-in only manifest**: Include a **\<MobileFormFactor\>**, and include the correct types of [controls](/javascript/api/manifest/control) and [icon sizes](/javascript/api/manifest/icon).
+  - **Add-in only manifest**: Include a `<MobileFormFactor>`, and include the correct types of [controls](/javascript/api/manifest/control) and [icon sizes](/javascript/api/manifest/icon).
   
   To learn more, see [Add support for add-in commands in Outlook on mobile devices](add-mobile-support.md).
 

--- a/docs/outlook/outlook-on-send-addins.md
+++ b/docs/outlook/outlook-on-send-addins.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: On-send feature for Outlook add-ins
 description: Provides a way to handle an item or block users from certain actions, and allows an add-in to set certain properties on send.
 ms.date: 07/22/2025
@@ -349,7 +349,7 @@ The following are the supported and unsupported scenarios for add-ins that use t
 
 ### Event handlers are dynamically defined
 
-Your add-in's event handlers must be defined by the time `Office.initialize` or `Office.onReady()` is called (for further information, see [Startup of an Outlook add-in](../develop/loading-the-dom-and-runtime-environment.md#startup-of-an-outlook-add-in) and [Initialize your Office Add-in](../develop/initialize-add-in.md)). If your handler code is dynamically defined by certain circumstances during initialization, you must create a stub function to call the handler once it's completely defined. The stub function must be referenced in the **\<Event\>** element's `FunctionName` attribute of your manifest. This workaround ensures that your handler is defined and ready to be referenced once `Office.initialize` or `Office.onReady()` runs.
+Your add-in's event handlers must be defined by the time `Office.initialize` or `Office.onReady()` is called (for further information, see [Startup of an Outlook add-in](../develop/loading-the-dom-and-runtime-environment.md#startup-of-an-outlook-add-in) and [Initialize your Office Add-in](../develop/initialize-add-in.md)). If your handler code is dynamically defined by certain circumstances during initialization, you must create a stub function to call the handler once it's completely defined. The stub function must be referenced in the `<Event>` element's `FunctionName` attribute of your manifest. This workaround ensures that your handler is defined and ready to be referenced once `Office.initialize` or `Office.onReady()` runs.
 
 If your handler isn't defined once your add-in is initialized, the sender will be notified that "The callback function is unreachable" through an information bar in the mail item.
 

--- a/docs/outlook/pinnable-taskpane.md
+++ b/docs/outlook/pinnable-taskpane.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Implement a pinnable task pane in an Outlook add-in
 description: The task pane UX shape for add-in commands opens a vertical task pane to the right of an open message or meeting request, allowing the add-in to provide UI for more detailed interactions.
 ms.date: 07/15/2025
@@ -52,7 +52,7 @@ Add a `"pinnable"` property, set to `true`, to the object in the [`"actions"`](/
 
 # [Add-in only manifest](#tab/xmlmanifest)
 
-Add the [SupportsPinning](/javascript/api/manifest/action#supportspinning) element to the **\<Action\>** element that describes the task pane button. The following is an example.
+Add the [SupportsPinning](/javascript/api/manifest/action#supportspinning) element to the `<Action>` element that describes the task pane button. The following is an example.
 
 ```xml
 <!-- Task pane button. -->
@@ -74,7 +74,7 @@ Add the [SupportsPinning](/javascript/api/manifest/action#supportspinning) eleme
 </Control>
 ```
 
-The **\<SupportsPinning\>** element is defined in the VersionOverrides v1.1 schema, so you will need to include a [VersionOverrides](/javascript/api/manifest/versionoverrides) element both for v1.0 and v1.1.
+The `<SupportsPinning>` element is defined in the VersionOverrides v1.1 schema, so you will need to include a [VersionOverrides](/javascript/api/manifest/versionoverrides) element both for v1.0 and v1.1.
 
 ---
 

--- a/docs/outlook/smart-alerts-onmessagesend-walkthrough.md
+++ b/docs/outlook/smart-alerts-onmessagesend-walkthrough.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Automatically check for an attachment before a message is sent
 description: Learn how to implement an event-based add-in that implements Smart Alerts to automatically check a message for an attachment before it's sent.
 ms.date: 06/18/2025
@@ -111,7 +111,7 @@ To configure the manifest, select the tab for the type of manifest you are using
 
 1. Open the **manifest.xml** file located at the root of your project.
 
-1. Select the entire **\<VersionOverrides\>** node (including open and close tags) and replace it with the following XML.
+1. Select the entire `<VersionOverrides>` node (including open and close tags) and replace it with the following XML.
 
     ```XML
     <VersionOverrides xmlns="http://schemas.microsoft.com/office/mailappversionoverrides" xsi:type="VersionOverridesV1_0">
@@ -351,7 +351,7 @@ To modify the text of the dialog button or assign it a task pane or function, yo
 
 - The [cancelLabel](/javascript/api/outlook/office.smartalertseventcompletedoptions#outlook-office-smartalertseventcompletedoptions-cancellabel-member) option customizes the text of the applicable button. Custom text must be a maximum of 20 characters.
 - The [commandId](/javascript/api/outlook/office.smartalertseventcompletedoptions#outlook-office-smartalertseventcompletedoptions-commandid-member) option specifies the ID of the task pane or function that runs when the applicable button is selected. The value must match the task pane or function command ID in the manifest of your add-in. The markup depends on the type of manifest your add-in uses.
-  - **Add-in only manifest**: The `id` attribute of the **\<Control\>** element representing the task pane or function command.
+  - **Add-in only manifest**: The `id` attribute of the `<Control>` element representing the task pane or function command.
   - **Unified manifest for Microsoft 365**: The "id" property of the task pane or function command in the "controls" array.
 
   In supported Outlook clients and versions, when the `commandId` option is specified, the **Take Action** button appears in the Smart Alerts dialog.
@@ -467,7 +467,7 @@ If you implemented the optional steps to customize a dialog button or override t
 > In classic Outlook on Windows starting in Version 2412 (Build 18324.20000), you must implement a task pane or function command to customize the **Take Action** button. This is because the **Take Action** button only appears in the Smart Alerts dialog when a task pane or function command is implemented in the add-in.
 
 1. Navigate to the **./src/taskpane** folder, then open **taskpane.html**.
-1. Select the entire **\<body\>** node (including its open and close tags) and replace it with the following code.
+1. Select the entire `<body>` node (including its open and close tags) and replace it with the following code.
 
     ```html
     <body class="ms-welcome ms-Fabric">

--- a/docs/outlook/spam-reporting.md
+++ b/docs/outlook/spam-reporting.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Implement an integrated spam-reporting add-in
 description: Learn how to implement an integrated spam-reporting add-in in Outlook.
 ms.date: 06/18/2025
@@ -174,24 +174,24 @@ Select the tab for the type of manifest you're using.
 Configure the [VersionOverridesV1_1](/javascript/api/manifest/versionoverrides-1-1-mail) node of your add-in only manifest accordingly.
 
 - To run a spam-reporting add-in in Outlook on the web and on Mac and in the new Outlook on Windows, you must specify the HTML file that references or contains the code to handle the spam-reporting event in the `resid` attribute of the [Runtime](/javascript/api/manifest/runtime) element.
-- To run a spam-reporting add-in in classic Outlook on Windows, you must specify the JavaScript file that contains the code to handle the spam-reporting event in the [Override](/javascript/api/manifest/override) child element of the **\<Runtime\>** element.
-- To activate the add-in in the Outlook ribbon and prevent it from appearing at the end of the ribbon or in the overflow section, set the `xsi:type` attribute of the **\<ExtensionPoint\>** element to [ReportPhishingCommandSurface](/javascript/api/manifest/extensionpoint#reportphishingcommandsurface).
+- To run a spam-reporting add-in in classic Outlook on Windows, you must specify the JavaScript file that contains the code to handle the spam-reporting event in the [Override](/javascript/api/manifest/override) child element of the `<Runtime>` element.
+- To activate the add-in in the Outlook ribbon and prevent it from appearing at the end of the ribbon or in the overflow section, set the `xsi:type` attribute of the `<ExtensionPoint>` element to [ReportPhishingCommandSurface](/javascript/api/manifest/extensionpoint#reportphishingcommandsurface).
 - To customize the ribbon button and preprocessing dialog, you must define the [ReportPhishingCustomization](/javascript/api/manifest/reportphishingcustomization) node.
-  - To configure the ribbon button, set the `xsi:type` attribute of the [Control](/javascript/api/manifest/control-button) element to `Button`. Then, set the `xsi:type` attribute of the [Action](/javascript/api/manifest/action) child element to `ExecuteFunction` and specify the name of the spam-reporting event handler in its **\<FunctionName\>** child element.
+  - To configure the ribbon button, set the `xsi:type` attribute of the [Control](/javascript/api/manifest/control-button) element to `Button`. Then, set the `xsi:type` attribute of the [Action](/javascript/api/manifest/action) child element to `ExecuteFunction` and specify the name of the spam-reporting event handler in its `<FunctionName>` child element.
   - To customize the preprocessing dialog, configure the [PreProcessingDialog](/javascript/api/manifest/preprocessingdialog) element of your manifest. While the dialog must have a title and description, you can optionally include the following elements.
     - A list of choices to help a user identify the type of message they're reporting. You can configure these options as radio buttons or checkboxes. To learn more, see [ReportingOptions element](/javascript/api/manifest/reportingoptions).
     - A text box for the user to provide additional information about the message they're reporting. To learn how to implement a text box, see [FreeTextLabel element](/javascript/api/manifest/preprocessingdialog#child-elements).
     - Custom text and URL to provide informational resources to the user. To learn how to personalize these elements, see [MoreInfo element](/javascript/api/manifest/moreinfo).
 
       > [!NOTE]
-      > Depending on the Outlook client, the custom text specified in the **\<MoreInfoText\>** element appears before the URL that's provided in the **\<MoreInfoUrl\>** element or as link text for the URL. For more information, see [MoreInfoText](/javascript/api/manifest/moreinfo#moreinfotext).
+      > Depending on the Outlook client, the custom text specified in the `<MoreInfoText>` element appears before the URL that's provided in the `<MoreInfoUrl>` element or as link text for the URL. For more information, see [MoreInfoText](/javascript/api/manifest/moreinfo#moreinfotext).
     - A "Don't show me this message again" checkbox to prevent the preprocessing dialog from appearing again. To learn how to implement this option, see [Suppress the preprocessing dialog](#suppress-the-preprocessing-dialog).
 
-The following is an example of a **\<VersionOverrides\>** node configured for spam reporting.
+The following is an example of a `<VersionOverrides>` node configured for spam reporting.
 
 1. In your preferred code editor, open the add-in project you created.
 1. Open the **manifest.xml** file located at the root of your project.
-1. Select the entire **\<VersionOverrides\>** node (including the open and close tags) and replace it with the following code.
+1. Select the entire `<VersionOverrides>` node (including the open and close tags) and replace it with the following code.
 
     ```xml
     <VersionOverrides xmlns="http://schemas.microsoft.com/office/mailappversionoverrides" xsi:type="VersionOverridesV1_0">

--- a/docs/outlook/understanding-outlook-add-in-permissions.md
+++ b/docs/outlook/understanding-outlook-add-in-permissions.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Understanding Outlook add-in permissions
 description: Outlook add-ins specify the required permission level in their manifest, which include restricted, read item, read/write item, or read/write mailbox. 
 ms.date: 10/17/2024
@@ -18,7 +18,7 @@ Outlook add-ins specify the required permission level in their manifest. There a
 
 Permissions are declared in the manifest. The markup varies depending on the type of manifest.
 
-- **Add-in only manifest**:  Use the **\<Permissions\>** element.
+- **Add-in only manifest**:  Use the `<Permissions>` element.
 - **Unified manifest for Microsoft 365**: Use the `"name"` property of an object in the [`"authorization.permissions.resourceSpecific"`](/microsoft-365/extensibility/schema/root-authorization-permissions#resourcespecific) array.
 
 > [!NOTE]

--- a/docs/outlook/web-services.md
+++ b/docs/outlook/web-services.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Use Exchange Web Services (EWS) from an Outlook add-in
 description: Provides an example that shows how an Outlook add-in in an Exchange on-premises environment can request information from Exchange Web Services.
 ms.date: 10/17/2024
@@ -187,7 +187,7 @@ When you use the `makeEwsRequestAsync` method, the request is authenticated by u
 
 To use the `makeEwsRequestAsync` method, your add-in must request the **read/write mailbox** permission in the manifest. The markup varies depending on the type of manifest.
 
-- **Add-in only manifest**: Set the **\<Permissions\>** element to **ReadWriteMailbox**.
+- **Add-in only manifest**: Set the `<Permissions>` element to **ReadWriteMailbox**.
 - **Unified manifest for Microsoft 365**: Set the `"name"` property of an object in the [`"authorization.permissions.resourceSpecific"`](/microsoft-365/extensibility/schema/root-authorization-permissions#resourcespecific) array to `"Mailbox.ReadWrite.User"`.
 
 For information about using the **read/write mailbox** permission, see [read/write mailbox permission](understanding-outlook-add-in-permissions.md#readwrite-mailbox-permission).

--- a/docs/project/create-a-project-add-in-that-uses-rest-with-an-on-premises-odata-service.md
+++ b/docs/project/create-a-project-add-in-that-uses-rest-with-an-on-premises-odata-service.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Create a Project add-in that uses REST with an on-premises Project Server OData service
 description: Learn how to build a task pane add-in for Project Professional that compares cost and work data in the active project with the averages for all projects in the current Project Web App instance.
 ms.date: 07/16/2025
@@ -102,7 +102,7 @@ For more information about the manifest, see [Office Add-ins manifest](../develo
 
 1. In Visual Studio, open the HelloProjectOData.xml file.
 
-1. The default display name is the name of the Visual Studio project ("HelloProjectOData"). For example, change the default value of the **\<DisplayName\>** element to"Hello ProjectData".
+1. The default display name is the name of the Visual Studio project ("HelloProjectOData"). For example, change the default value of the `<DisplayName>` element to"Hello ProjectData".
 
 1. The default description is also "HelloProjectOData". For example, change the default value of the Description element to "Test REST queries of the ProjectData service".
 
@@ -116,7 +116,7 @@ The following steps show how to add an icon file to the Visual Studio solution.
 
     ![Icon for the HelloProjectOData app.](../images/pj15-hello-project-data-new-icon.jpg)
 
-1. In the HelloProjectOData.xml, add an **\<IconUrl\>** element below the **\<Description\>** element, where the value of the icon URL is the relative path to the 32x32 icon file. For example, add the following line: `<IconUrl DefaultValue="~remoteAppUrl/Images/NewIcon.png" />`. The HelloProjectOData.xml file now contains the following (your **\<Id\>** value will be different):
+1. In the HelloProjectOData.xml, add an `<IconUrl>` element below the `<Description>` element, where the value of the icon URL is the relative path to the 32x32 icon file. For example, add the following line: `<IconUrl DefaultValue="~remoteAppUrl/Images/NewIcon.png" />`. The HelloProjectOData.xml file now contains the following (your `<Id>` value will be different):
 
     ```XML
     <?xml version="1.0" encoding="UTF-8"?>
@@ -145,7 +145,7 @@ The following steps show how to add an icon file to the Visual Studio solution.
 
 The **HelloProjectOData** add-in is a sample that includes debugging and error output; it isn't intended for production use. Before you start coding the HTML content, design the UI and user experience for the add-in, and outline the JavaScript functions that interact with the HTML code. For more information, see [Design guidelines for Office Add-ins](../design/add-in-design.md).
 
-The task pane shows the add-in display name at the top, which is the value of the **\<DisplayName\>** element in the manifest. The **body** element in the HelloProjectOData.html file contains the other UI elements, as follows:
+The task pane shows the add-in display name at the top, which is the value of the `<DisplayName>` element in the manifest. The **body** element in the HelloProjectOData.html file contains the other UI elements, as follows:
 
 - A subtitle indicates the general functionality or type of operation, for example, **ODATA REST QUERY**.
 

--- a/docs/publish/publish.md
+++ b/docs/publish/publish.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Deploy and publish Office Add-ins
 description: Methods and options to deploy your Office Add-in for testing or distribution to users.
 ms.date: 06/23/2025
@@ -57,7 +57,7 @@ The following table summarizes publication methods that are available *only when
 |Method|Use|Support limitations|
 |:---------|:------------|:------------|
 |[Network share](../testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins.md)|As part of your development process, to test your add-in running on Windows computers other than your development computer after you have published the add-in to a server other than localhost.|<ul><li>Not supported for production add-ins.</li><li>Not supported for Outlook add-ins.</li><li>Not supported for testing on iPad, Mac, or the web.</li></ul>|
-|[SharePoint catalog](#sharepoint-app-catalog-deployment)|In an on-premises environment, to distribute your add-in to users in your organization.|<ul><li>Not supported for Outlook add-ins.</li><li>Not supported for Office on Mac.</li><li>Not supported for add-ins with any feature that requires a **\<VersionOverrides\>** element in the add-in only manifest.</li></ul>|
+|[SharePoint catalog](#sharepoint-app-catalog-deployment)|In an on-premises environment, to distribute your add-in to users in your organization.|<ul><li>Not supported for Outlook add-ins.</li><li>Not supported for Office on Mac.</li><li>Not supported for add-ins with any feature that requires a `<VersionOverrides>` element in the add-in only manifest.</li></ul>|
 |[Exchange server](#outlook-add-in-exchange-server-deployment)|In an on-premises or online environment, to distribute Outlook add-ins to users.|Only supported for Outlook add-ins.|
 
 ### SharePoint app catalog deployment

--- a/docs/quickstarts/outlook-quickstart-vs.md
+++ b/docs/quickstarts/outlook-quickstart-vs.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Build your first Outlook add-in with Visual Studio
 description: Learn how to build a simple Outlook task pane add-in by using the Office JS API and a Visual Studio template.
 ms.date: 08/24/2024
@@ -40,7 +40,7 @@ When you've completed the wizard, Visual Studio creates a solution that contains
 
 ## Update the code
 
-1. **MessageRead.html** specifies the HTML that will be rendered in the add-in's task pane. In **MessageRead.html**, replace the **\<body\>** element with the following markup and save the file.
+1. **MessageRead.html** specifies the HTML that will be rendered in the add-in's task pane. In **MessageRead.html**, replace the `<body>` element with the following markup and save the file.
 
     ```HTML
     <body class="ms-font-m ms-welcome">
@@ -125,11 +125,11 @@ When you've completed the wizard, Visual Studio creates a solution that contains
 
 1. Open the manifest file in the Add-in project. This file defines the add-in's settings and capabilities.
 
-1. The **\<ProviderName\>** element has a placeholder value. Replace it with your name.
+1. The `<ProviderName>` element has a placeholder value. Replace it with your name.
 
-1. The **DefaultValue** attribute of the **\<DisplayName\>** element has a placeholder. Replace it with `My Office Add-in`.
+1. The **DefaultValue** attribute of the `<DisplayName>` element has a placeholder. Replace it with `My Office Add-in`.
 
-1. The **DefaultValue** attribute of the **\<Description\>** element has a placeholder. Replace it with `My First Outlook add-in`.
+1. The **DefaultValue** attribute of the `<Description>` element has a placeholder. Replace it with `My First Outlook add-in`.
 
 1. Save the file.
 

--- a/docs/resources/resources-glossary.md
+++ b/docs/resources/resources-glossary.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Office Add-ins glossary of terms
 description: A glossary of terms commonly used throughout the Office Add-ins documentation.
 ms.date: 02/12/2025
@@ -90,7 +90,7 @@ See also: [add-in commands](#add-in-commands).
 
 ## host
 
-**\<Host\>** typically refers to an Office application. The Office applications, or hosts, that support Office Add-ins are Excel, OneNote, Outlook, PowerPoint, Project, and Word.
+`<Host>` typically refers to an Office application. The Office applications, or hosts, that support Office Add-ins are Excel, OneNote, Outlook, PowerPoint, Project, and Word.
 
 See also: [application](#application), [client](#client), [Office application, Office client](#office-application-office-client).
 

--- a/docs/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins.md
+++ b/docs/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Sideload Office Add-ins for testing from a network share
 description: Learn how to sideload an Office Add-in for testing from a network share.
 ms.date: 05/21/2025
@@ -117,7 +117,7 @@ There are two options for how you specify this trust. Follow the instructions fo
 
 ## Sideload your add-in
 
-1. Put the manifest XML file of any add-in that you're testing into the shared folder catalog. Note that you deploy the web application itself to a web server. Be sure to specify the URL in the **\<SourceLocation\>** element of the manifest file.
+1. Put the manifest XML file of any add-in that you're testing into the shared folder catalog. Note that you deploy the web application itself to a web server. Be sure to specify the URL in the `<SourceLocation>` element of the manifest file.
 
     > [!IMPORTANT]
     > [!include[HTTPS guidance](../includes/https-guidance.md)]

--- a/docs/testing/debug-autolaunch.md
+++ b/docs/testing/debug-autolaunch.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Debug event-based or spam-reporting add-ins
 description: Learn how to debug your Office Add-ins that implement event-based activation or integrated spam reporting.
 ms.date: 07/15/2025
@@ -34,7 +34,7 @@ If you used the [Yeoman generator for Office Add-ins](../develop/yeoman-generato
 
 1. Get your add-in's ID from the manifest.
 
-    - **Add-in only manifest**: Use the value of the **\<Id\>** element child of the root **\<OfficeApp\>** element.
+    - **Add-in only manifest**: Use the value of the `<Id>` element child of the root `<OfficeApp>` element.
     - **Unified manifest for Microsoft 365**: Use the value of the `"id"` property of the root anonymous `{ ... }` object.
 
 1. In the registry, mark your add-in for debugging.

--- a/docs/testing/troubleshoot-development-errors.md
+++ b/docs/testing/troubleshoot-development-errors.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Troubleshoot development errors with Office Add-ins
 description: Learn how to troubleshoot development errors in Office Add-ins.
 ms.topic: troubleshooting-problem-resolution
@@ -83,8 +83,8 @@ The following are some of the causes of this error. If you discover additional c
 - If the add-in only manifest is being used, one of the following may apply.
 
   - The value of the [ID](/javascript/api/manifest/id) element in the manifest has been changed directly in the deployed copy. If for any reason, you want to change this ID, first remove the add-in from the Office host, then replace the original manifest with the changed manifest. You many need to clear the Office cache to remove all traces of the original. See the [Clear the Office cache](clear-cache.md) article for instructions on clearing the cache for your operating system.
-  - The add-in's manifest has a `resid` that isn't defined anywhere in the [Resources](/javascript/api/manifest/resources) section of the manifest, or there is a mismatch in the spelling of the `resid` between where it is used and where it is defined in the **\<Resources\>** section.
-  - There is a `resid` attribute somewhere in the manifest with more than 32 characters. A `resid` attribute, and the `id` attribute of the corresponding resource in the **\<Resources\>** section, cannot be more than 32 characters.
+  - The add-in's manifest has a `resid` that isn't defined anywhere in the [Resources](/javascript/api/manifest/resources) section of the manifest, or there is a mismatch in the spelling of the `resid` between where it is used and where it is defined in the `<Resources>` section.
+  - There is a `resid` attribute somewhere in the manifest with more than 32 characters. A `resid` attribute, and the `id` attribute of the corresponding resource in the `<Resources>` section, cannot be more than 32 characters.
 
 - The add-in has a custom Add-in Command but you are trying to run it on a platform that doesn't support them. For more information, see [Add-in commands requirement sets](/javascript/api/requirement-sets/common/add-in-commands-requirement-sets).
 
@@ -102,7 +102,7 @@ See [Troubleshoot Word add-ins](../word/word-add-ins-troubleshooting.md) for pos
 
 ## Add-in only manifest schema validation errors in Visual Studio projects
 
-If you're using newer features that require changes to the add-in only manifest file, you may get validation errors in Visual Studio. For example, when adding the **\<Runtimes\>** element to implement the [shared runtime](runtimes.md#shared-runtime), you may see the following validation error.
+If you're using newer features that require changes to the add-in only manifest file, you may get validation errors in Visual Studio. For example, when adding the `<Runtimes>` element to implement the [shared runtime](runtimes.md#shared-runtime), you may see the following validation error.
 
 **The element 'Host' in namespace 'http://schemas.microsoft.com/office/taskpaneappversionoverrides' has invalid child element 'Runtimes' in namespace 'http://schemas.microsoft.com/office/taskpaneappversionoverrides'**
 

--- a/docs/testing/troubleshoot-event-based-and-spam-reporting-add-ins.md
+++ b/docs/testing/troubleshoot-event-based-and-spam-reporting-add-ins.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Troubleshoot event-based and spam-reporting add-ins
 description: Learn how to troubleshoot development errors in Office Add-ins that implement event-based activation or integrated spam reporting.
 ms.date: 07/15/2025
@@ -25,7 +25,7 @@ As you develop your [event-based](../develop/event-based-activation.md) or [spam
 - Ensure that the following conditions are met in your add-in's manifest.
 
   - Verify that your add-in's source file location URL is publicly available and isn't blocked by a firewall. This URL is specified in the [SourceLocation element](/javascript/api/manifest/sourcelocation) of the add-in only manifest or the [`"extensions.runtimes.code.page"`](/microsoft-365/extensibility/schema/extension-runtime-code#page) property of the unified manifest for Microsoft 365.
-  - Verify that the **\<Runtimes\>** element (add-in only manifest) or `"extensions.runtimes.code"` property (unified manifest) correctly references the HTML or JavaScript file containing the event handlers. Classic Outlook on Windows and other Windows-based Office applications use the JavaScript file during runtime, while Office on the web, the new Outlook Mac UI, and [new Outlook on Windows](https://support.microsoft.com/office/656bb8d9-5a60-49b2-a98b-ba7822bc7627) use the HTML file. For an example of how this is configured in the manifest, see the "Configure the manifest" section of [Automatically set the subject of a new message or appointment](../outlook/on-new-compose-events-walkthrough.md#configure-the-manifest).
+  - Verify that the `<Runtimes>` element (add-in only manifest) or `"extensions.runtimes.code"` property (unified manifest) correctly references the HTML or JavaScript file containing the event handlers. Classic Outlook on Windows and other Windows-based Office applications use the JavaScript file during runtime, while Office on the web, the new Outlook Mac UI, and [new Outlook on Windows](https://support.microsoft.com/office/656bb8d9-5a60-49b2-a98b-ba7822bc7627) use the HTML file. For an example of how this is configured in the manifest, see the "Configure the manifest" section of [Automatically set the subject of a new message or appointment](../outlook/on-new-compose-events-walkthrough.md#configure-the-manifest).
   
     For Windows clients (except for new Outlook on Windows), you must bundle all your event-handling JavaScript code into this JavaScript file referenced in the manifest. Note that a large JavaScript bundle may cause issues with the performance of your add-in. We recommend preprocessing heavy operations, so that they're not included in your event-handling code.
 - Verify that your event-handling JavaScript file calls `Office.actions.associate`. This ensures that the event handler name specified in the manifest is mapped to its JavaScript counterpart. The following code is an example.

--- a/docs/tutorials/excel-tutorial.md
+++ b/docs/tutorials/excel-tutorial.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Excel add-in tutorial
 description: Build an Excel add-in that creates, populates, filters, and sorts a table, creates a chart, freezes a table header, protects a worksheet, and opens a dialog.
 ms.date: 02/12/2025
@@ -593,7 +593,7 @@ The steps vary depending on the type of manifest.
 
 1. Open the manifest file **./manifest.xml**.
 
-1. Locate the **\<Control\>** element. This element defines the **Show Taskpane** button on the **Home** ribbon you have been using to launch the add-in. We're going to add a second button to the same group on the **Home** ribbon. In between the closing **\</Control\>** tag and the closing **\</Group\>** tag, add the following markup.
+1. Locate the `<Control>` element. This element defines the **Show Taskpane** button on the **Home** ribbon you have been using to launch the add-in. We're going to add a second button to the same group on the **Home** ribbon. In between the closing **\</Control\>** tag and the closing **\</Group\>** tag, add the following markup.
 
     ```xml
     <Control xsi:type="Button" id="<!--TODO1: Unique (in manifest) name for button -->">

--- a/docs/tutorials/outlook-tutorial.md
+++ b/docs/tutorials/outlook-tutorial.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: 'Tutorial: Build a message compose Outlook add-in'
 description: In this tutorial, you will build an Outlook add-in that inserts GitHub gists into the body of a new message.
 ms.date: 01/07/2025
@@ -175,13 +175,13 @@ Make the following updates in the manifest file to specify some basic informatio
 
 # [Add-in only manifest](#tab/xmlmanifest)
 
-1. Locate the **\<ProviderName\>** element and replace the default value with your company name.
+1. Locate the `<ProviderName>` element and replace the default value with your company name.
 
     ```xml
     <ProviderName>Contoso</ProviderName>
     ```
 
-1. Locate the **\<Description\>** element, replace the default value with a description of the add-in, and save the file.
+1. Locate the `<Description>` element, replace the default value with a description of the add-in, and save the file.
 
     ```xml
     <Description DefaultValue="Allows users to access their GitHub gists."/>
@@ -375,7 +375,7 @@ Take the following steps:
 
 1. Open the **manifest.xml** file.
 
-1. Locate the **\<ExtensionPoint\>** element with type **MessageReadCommandSurface** and delete it (including its closing tag). This removes the add-in buttons from the read message window.
+1. Locate the `<ExtensionPoint>` element with type **MessageReadCommandSurface** and delete it (including its closing tag). This removes the add-in buttons from the read message window.
 
 ### Add the MessageComposeCommandSurface extension point
 
@@ -383,15 +383,15 @@ Take the following steps:
 
 1. Immediately before this line, insert the following XML markup. Note the following about this markup.
 
-    - The **\<ExtensionPoint\>** with `xsi:type="MessageComposeCommandSurface"` indicates that you're defining buttons to add to the compose message window.
+    - The `<ExtensionPoint>` with `xsi:type="MessageComposeCommandSurface"` indicates that you're defining buttons to add to the compose message window.
 
-    - By using an **\<OfficeTab\>** element with `id="TabDefault"`, you're indicating you want to add the buttons to the default tab on the ribbon.
+    - By using an `<OfficeTab>` element with `id="TabDefault"`, you're indicating you want to add the buttons to the default tab on the ribbon.
 
-    - The **\<Group\>** element defines the grouping for the new buttons, with a label set by the **groupLabel** resource.
+    - The `<Group>` element defines the grouping for the new buttons, with a label set by the **groupLabel** resource.
 
-    - The first **\<Control\>** element contains an **\<Action\>** element with `xsi:type="ShowTaskPane"`, so this button opens a task pane.
+    - The first `<Control>` element contains an `<Action>` element with `xsi:type="ShowTaskPane"`, so this button opens a task pane.
 
-    - The second **\<Control\>** element contains an **\<Action\>** element with `xsi:type="ExecuteFunction"`, so this button invokes a JavaScript function contained in the function file.
+    - The second `<Control>` element contains an `<Action>` element with `xsi:type="ExecuteFunction"`, so this button invokes a JavaScript function contained in the function file.
 
     ```xml
     <!-- Message Compose -->
@@ -436,11 +436,11 @@ Take the following steps:
 
 ### Update resources in the manifest
 
-The previous code references labels, tooltips, and URLs that you need to define before the manifest will be valid. You'll specify this information in the **\<Resources\>** section of the manifest.
+The previous code references labels, tooltips, and URLs that you need to define before the manifest will be valid. You'll specify this information in the `<Resources>` section of the manifest.
 
-1. In **manifest.xml**, locate the **\<Resources\>** element in the manifest file and delete the entire element (including its closing tag).
+1. In **manifest.xml**, locate the `<Resources>` element in the manifest file and delete the entire element (including its closing tag).
 
-1. In that same location, add the following markup to replace the **\<Resources\>** element you just removed.
+1. In that same location, add the following markup to replace the `<Resources>` element you just removed.
 
     ```xml
     <Resources>
@@ -963,7 +963,7 @@ This add-in's **Insert default gist** button is a UI-less button that invokes a 
 
 ### Update the function file (HTML)
 
-A function that's invoked by a UI-less button must be defined in the file that's specified by the **\<FunctionFile\>** element in the manifest for the corresponding form factor. This add-in's manifest specifies `https://localhost:3000/commands.html` as the function file.
+A function that's invoked by a UI-less button must be defined in the file that's specified by the `<FunctionFile>` element in the manifest for the corresponding form factor. This add-in's manifest specifies `https://localhost:3000/commands.html` as the function file.
 
 1. Open the **./src/commands/commands.html** and replace the entire contents with the following markup.
 

--- a/docs/tutorials/powerpoint-tutorial-vs.md
+++ b/docs/tutorials/powerpoint-tutorial-vs.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: PowerPoint add-in tutorial using Visual Studio
 description: "In this tutorial, you'll use Visual Studio to build a PowerPoint add-in that inserts an image, inserts text, gets slide metadata, and navigates between slides."
 ms.date: 01/16/2025
@@ -333,7 +333,7 @@ Complete the following steps to add code that retrieves the [Bing](https://www.b
     > If you get an error "Could not find file [...]\bin\roslyn\csc.exe", then do the following:
     >
     > 1. Open the **.\Web.config** file.
-    > 1. Find the **\<compiler\>** node for the .cs `extension`, then remove the `type` attribute and its value.
+    > 1. Find the `<compiler>` node for the .cs `extension`, then remove the `type` attribute and its value.
     > 1. Save the file.
 
 1. In Visual Studio, stop the add-in by pressing <kbd>Shift</kbd>+<kbd>F5</kbd> or choosing the **Stop** button. PowerPoint will automatically close when the add-in is stopped.

--- a/docs/word/add-headers-on-document-open.md
+++ b/docs/word/add-headers-on-document-open.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Add headers when a document opens
 description: Learn how to develop a Word add-in that implements event-based activation to add headers when a document is opened.
 ms.date: 07/02/2025
@@ -33,7 +33,7 @@ Use the following sample manifest code to update your project.
 
 1. In your code editor, open the quick start project you created.
 1. Open the **manifest.xml** file located at the root of your project.
-1. Select the entire **\<VersionOverrides\>** node (including the open and close tags) and replace it with the following XML.
+1. Select the entire `<VersionOverrides>` node (including the open and close tags) and replace it with the following XML.
 
     ```xml
       <VersionOverrides xmlns="http://schemas.microsoft.com/office/taskpaneappversionoverrides" xsi:type="VersionOverridesV1_0">

--- a/docs/word/dictionary-task-pane-add-ins.md
+++ b/docs/word/dictionary-task-pane-add-ins.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Create a dictionary task pane add-in
 description: Learn how to create a dictionary task pane add-in.
 ms.date: 02/12/2025
@@ -96,7 +96,7 @@ The following code shows sample XSD for the OfficeDefinitions XML schema example
 </xs:schema>
 ```
 
-Returned XML consists of a root **\<Result\>** element that contains a **\<Definitions\>** element with zero to three **\<Definition\>** child elements. Each child element contains definitions that are at most 400 characters in length. Additionally, the URL to the full page on the dictionary site must be provided in the **\<SeeMoreURL\>** element. The following example shows the structure of returned XML that conforms to the OfficeDefinitions schema.
+Returned XML consists of a root `<Result>` element that contains a `<Definitions>` element with zero to three `<Definition>` child elements. Each child element contains definitions that are at most 400 characters in length. Additionally, the URL to the full page on the dictionary site must be provided in the `<SeeMoreURL>` element. The following example shows the structure of returned XML that conforms to the OfficeDefinitions schema.
 
 ```XML
 <?xml version="1.0" encoding="utf-8"?>
@@ -295,7 +295,7 @@ The following is an example manifest file for a dictionary add-in.
 </OfficeApp>
 ```
 
-The **\<Dictionary\>** element and its child elements specific to creating a dictionary add-in's manifest file are described in the following sections. For information about the other elements in the manifest file, see [Office Add-ins with the add-in only manifest](../develop/xml-manifest-overview.md).
+The `<Dictionary>` element and its child elements specific to creating a dictionary add-in's manifest file are described in the following sections. For information about the other elements in the manifest file, see [Office Add-ins with the add-in only manifest](../develop/xml-manifest-overview.md).
 
 ### Dictionary element
 
@@ -303,15 +303,15 @@ Specifies settings for dictionary add-ins.
 
 **Parent element**
 
-**\<OfficeApp\>**
+`<OfficeApp>`
 
 **Child elements**
 
-**\<TargetDialects\>**, **\<QueryUri\>**, **\<CitationText\>**, **\<Name\>**, **\<DictionaryHomePage\>**
+`<TargetDialects>`, `<QueryUri>`, `<CitationText>`, `<Name>`, `<DictionaryHomePage>`
 
 **Remarks**
 
-The **\<Dictionary\>** element and its child elements are added to the manifest of a task pane add-in when you create a dictionary add-in.
+The `<Dictionary>` element and its child elements are added to the manifest of a task pane add-in when you create a dictionary add-in.
 
 #### TargetDialects element
 
@@ -319,15 +319,15 @@ Specifies the regional languages that this dictionary supports. Required for dic
 
 **Parent element**
 
-**\<Dictionary\>**
+`<Dictionary>`
 
 **Child element**
 
-**\<TargetDialect\>**
+`<TargetDialect>`
 
 **Remarks**
 
-The **\<TargetDialects\>** element and its child elements specify the set of regional languages your dictionary contains. For example, if your dictionary applies to both Spanish (Mexico) and Spanish (Peru), but not Spanish (Spain), you can specify that in this element. Do not specify more than one language (e.g., Spanish and English) in this manifest. Publish separate languages as separate dictionaries.
+The `<TargetDialects>` element and its child elements specify the set of regional languages your dictionary contains. For example, if your dictionary applies to both Spanish (Mexico) and Spanish (Peru), but not Spanish (Spain), you can specify that in this element. Do not specify more than one language (e.g., Spanish and English) in this manifest. Publish separate languages as separate dictionaries.
 
 **Example**
 
@@ -360,7 +360,7 @@ Specifies a regional language that this dictionary supports. Required for dictio
 
 **Parent element**
 
-**\<TargetDialects\>**
+`<TargetDialects>`
 
 **Remarks**
 
@@ -378,7 +378,7 @@ Specifies the endpoint for the dictionary query service. Required for dictionary
 
 **Parent element**
 
-**\<Dictionary\>**
+`<Dictionary>`
 
 **Remarks**
 
@@ -396,13 +396,13 @@ Specifies the text to use in citations. Required for dictionary add-ins.
 
 **Parent element**
 
-**\<Dictionary\>**
+`<Dictionary>`
 
 **Remarks**
 
 This element specifies the beginning of the citation text that will be displayed on a line below the content that is returned from the web service (for example, "Results by: " or "Powered by: ").
 
-For this element, you can specify values for additional locales by using the **\<Override\>** element. For example, if a user is running the Spanish SKU of Office, but using an English dictionary, this allows the citation line to read "Resultados por: Bing" rather than "Results by: Bing". For more information about how to specify values for additional locales, see [Localization](../develop/xml-manifest-overview.md#localization).
+For this element, you can specify values for additional locales by using the `<Override>` element. For example, if a user is running the Spanish SKU of Office, but using an English dictionary, this allows the citation line to read "Resultados por: Bing" rather than "Results by: Bing". For more information about how to specify values for additional locales, see [Localization](../develop/xml-manifest-overview.md#localization).
 
 **Example**
 
@@ -416,7 +416,7 @@ Specifies the name of this dictionary. Required for dictionary add-ins.
 
 **Parent element**
 
-**\<Dictionary\>**
+`<Dictionary>`
 
 **Remarks**
 
@@ -436,7 +436,7 @@ Specifies the URL of the home page for the dictionary. Required for dictionary a
 
 **Parent element**
 
-**\<Dictionary\>**
+`<Dictionary>`
 
 **Remarks**
 
@@ -453,10 +453,10 @@ For this element, you can specify values for additional locales.
 ### Update your dictionary add-in's manifest file
 
 1. Open the manifest file in the add-in project.
-1. Update the value of the **\<ProviderName\>** element with your name.
-1. Replace the value of the **\<DisplayName\>** element's **\<DefaultValue\>** attribute with an appropriate name, for example, "Microsoft Office Demo Dictionary".
-1. Replace the value of the **\<Description\>** element's **\<DefaultValue\>** attribute with an appropriate description, for example, "The Microsoft Office Demo Dictionary is an example built to demonstrate how a publisher could create a dictionary that integrates with Office. It doesn't return real definitions.".
-1. Add the following code after the **\<Permissions\>** node, replacing "contoso" references with your own company name, then save your changes.
+1. Update the value of the `<ProviderName>` element with your name.
+1. Replace the value of the `<DisplayName>` element's `<DefaultValue>` attribute with an appropriate name, for example, "Microsoft Office Demo Dictionary".
+1. Replace the value of the `<Description>` element's `<DefaultValue>` attribute with an appropriate description, for example, "The Microsoft Office Demo Dictionary is an example built to demonstrate how a publisher could create a dictionary that integrates with Office. It doesn't return real definitions.".
+1. Add the following code after the `<Permissions>` node, replacing "contoso" references with your own company name, then save your changes.
 
     ```XML
     <Dictionary>


### PR DESCRIPTION
Based on internal work item [10231168](https://office.visualstudio.com/OC/_workitems/edit/10231168).

This PR standardizes the way we format XML elements across the documentation. The markdown should use code ticks (`<Example>`) instead of bold (**<Example>**).

Reviewers, please make sure something unintended didn't get caught in the regex. 