### PR TITLE
[excel] (Performance) Clarify the 5MB limit is for Excel on the web only

### DIFF
--- a/docs/concepts/correlated-objects-pattern.md
+++ b/docs/concepts/correlated-objects-pattern.md
@@ -2,7 +2,7 @@
 title: Avoid using the context.sync method in loops
 description: Learn how to use the split loop and correlated objects patterns to avoid calling context.sync in a loop.
 ms.topic: best-practice
-ms.date: 01/31/2025
+ms.date: 09/03/2025
 ms.localizationpriority: medium
 ---
 
@@ -225,4 +225,4 @@ One further caveat: sometimes it takes more than one loop just to create the arr
 
 ## When should you *not* use the patterns in this article?
 
-Excel can't read more than 5MB of data in a given call of `context.sync`. If this limit is exceeded, an error is thrown. (See the "Excel add-ins section" of [Resource limits and performance optimization for Office Add-ins](resource-limits-and-performance-optimization.md#excel-add-ins) for more information.) It's very rare that this limit is approached, but if there's a chance that this will happen with your add-in, then your code should *not* load all the data in a single loop and follow the loop with a `context.sync`. But you still should avoid having a `context.sync` in every iteration of a loop over a collection object. Instead, define subsets of the items in the collection and loop over each subset in turn, with a `context.sync` between the loops. You could structure this with an outer loop that iterates over the subsets and contains the `context.sync` in each of these outer iterations.
+**Excel on the web** can't read more than **5MB** of data in a given call of `context.sync`. If this limit is exceeded, an error is thrown. (See the "Excel add-ins section" of [Resource limits and performance optimization for Office Add-ins](resource-limits-and-performance-optimization.md#excel-add-ins) for more information.) It's very rare that this limit is approached, but if there's a chance that this will happen with your add-in, then your code should *not* load all the data in a single loop and follow the loop with a `context.sync`. But you still should avoid having a `context.sync` in every iteration of a loop over a collection object. Instead, define subsets of the items in the collection and loop over each subset in turn, with a `context.sync` between the loops. You could structure this with an outer loop that iterates over the subsets and contains the `context.sync` in each of these outer iterations.

--- a/docs/concepts/resource-limits-and-performance-optimization.md
+++ b/docs/concepts/resource-limits-and-performance-optimization.md
@@ -1,7 +1,7 @@
 ---
 title: Resource limits and performance optimization for Office Add-ins
 description: Learn about the resource limits of the Office Add-in platform, including CPU and memory.
-ms.date: 07/14/2025
+ms.date: 09/03/2025
 ms.localizationpriority: medium
 ---
 
@@ -61,8 +61,8 @@ Outlook add-ins that use regular expressions and run in Outlook on Windows (clas
 
 Excel add-ins have important data transfer limits when interacting with the workbook.
 
-- Excel on the web has a payload size limit for requests and responses of 5MB. `RichAPI.Error` will be thrown if that limit is exceeded.
-- A range is limited to 5,000,000 cells for read operations.
+- Excel on the web has a payload size limit for requests and responses of **5MB**. `RichAPI.Error` will be thrown if that limit is exceeded.
+- A range is limited to **5,000,000** cells for read operations.
 
 If you expect user input will exceed these limits, check the data before calling `context.sync()`. Split the operation into smaller pieces as needed. Call `context.sync()` for each sub-operation to avoid those operations getting batched together again.
 

--- a/docs/excel/performance.md
+++ b/docs/excel/performance.md
@@ -1,7 +1,7 @@
 ---
 title: Excel JavaScript API performance optimization
 description: Optimize Excel add-in performance using the JavaScript API.
-ms.date: 02/17/2022
+ms.date: 09/03/2025
 ms.topic: best-practice
 ms.localizationpriority: medium
 ---
@@ -107,7 +107,7 @@ await Excel.run(async (context) => {
 
 ## Payload size limit best practices
 
-The Excel JavaScript API has size limitations for API calls. Excel on the web has a payload size limit for requests and responses of 5MB, and an API returns a `RichAPI.Error` error if this limit is exceeded. On all platforms, a range is limited to five million cells for get operations. Large ranges typically exceed both of these limitations.
+The Excel JavaScript API has size limitations for API calls. **Excel on the web** has a payload size limit for requests and responses of **5MB**, and an API returns a `RichAPI.Error` error if this limit is exceeded. On all platforms, a range is limited to five million cells for get operations. Large ranges typically exceed both of these limitations.
 
 The payload size of a request is a combination of the following three components.
 


### PR DESCRIPTION
There was a recent comment through the docs that expressed confusion about whether this 5mb limit applied to other hosts. After some internal discussion, I confirmed that this limit is only for Excel on the web. This PR clarifies that fact with the help of some formatting.