### PR TITLE
[all hosts] (Trust Prompts) Add information about suppressing the trust prompt for non-installed add-ins

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -9,6 +9,10 @@
             "redirect_url": "/entra/identity-platform/quickstart-configure-app-access-web-apis#more-on-api-permissions-and-admin-consent"
         },	
         {
+            "source_path": "docs/publish/custom-protocol-handler.md",
+            "redirect_url": "/office/dev/add-ins/publish/manage-trust-options"
+        },
+        {
             "source_path": "docs/testing/debug-with-vs-extension.md",
             "redirect_url": "/office/dev/add-ins/testing/debug-add-ins-overview"
         },			

--- a/docs/develop/automatically-open-a-task-pane-with-a-document.md
+++ b/docs/develop/automatically-open-a-task-pane-with-a-document.md
@@ -2,7 +2,7 @@
 title: Automatically open a task pane with a document
 description: Learn how to configure an Office Add-in to open automatically when a document opens.
 ms.topic: how-to
-ms.date: 02/12/2025
+ms.date: 09/22/2025
 ms.localizationpriority: medium
 ---
 
@@ -57,7 +57,6 @@ Apply the following best practices when you use the autoopen feature.
 ### Step 1: Specify the task pane to open
 
 Configure the manifest to specify the task pane page that should open automatically. The process depends on what type of manifest the add-in uses.
-
 
 # [Unified manifest for Microsoft 365](#tab/jsonmanifest)
 
@@ -195,3 +194,4 @@ You can test the previous example by using your Microsoft 365 subscription to tr
 - For a sample that shows you how to use the autoopen feature, see [Auto-open a task pane with a document](https://github.com/OfficeDev/Office-Add-in-samples/tree/main/Samples/office-add-in-commands/auto-open-task-pane).
 - [Automatically open a task pane when an add-in is installed](automatically-open-on-installation.md)
 - [Learn about the Microsoft 365 Developer Program](https://aka.ms/m365devprogram)
+- [Managing trust options for Office Add-ins](../publish/manage-trust-options.md)

--- a/docs/develop/run-code-on-document-open.md
+++ b/docs/develop/run-code-on-document-open.md
@@ -2,7 +2,7 @@
 title: Run code in your Office Add-in when the document opens
 description: Learn how to run code in your Office Add-in add-in when the document opens.
 ms.topic: how-to
-ms.date: 07/11/2023
+ms.date: 09/22/2025
 ms.localizationpriority: medium
 ---
 
@@ -10,7 +10,7 @@ ms.localizationpriority: medium
 
 [!include[Shared runtime requirements](../includes/shared-runtime-requirements-note.md)]
 
-You can configure your Office Add-in to load and run code as soon as the document is opened. This is useful if you need to register event handlers, pre-load data for the task pane, synchronize UI, or perform other tasks before the add-in is visible. 
+You can configure your Office Add-in to load and run code as soon as the document is opened. This is useful if you need to register event handlers, pre-load data for the task pane, synchronize UI, or perform other tasks before the add-in is visible.
 
 > [!NOTE]
 > The configuration is implemented with a method that your code calls at runtime. This means that the add-in *won't* run the *first time* a user opens the document. The add-in must be opened manually for the first time on any document. After the method runs, either in [Office.initialize](/javascript/api/office#office-office-initialize-function(1)), [Office.onReady](/javascript/api/office#office-office-onready-function(1)), or because the user takes a code path that runs it; then whenever the document is reopened, the add-in loads immediately and any code in the `Office.initialize` or `Office.onReady` method runs.
@@ -110,3 +110,4 @@ let behavior = await Office.addin.getStartupBehavior();
 - [Share data and events between Excel custom functions and task pane tutorial](../tutorials/share-data-and-events-between-custom-functions-and-the-task-pane-tutorial.md)
 - [Work with Events using the Excel JavaScript API](../excel/excel-add-ins-events.md)
 - [Runtimes in Office Add-ins](../testing/runtimes.md)
+- [Managing trust options for Office Add-ins](../publish/manage-trust-options.md)

--- a/docs/publish/manage-trust-options.md
+++ b/docs/publish/manage-trust-options.md
@@ -20,7 +20,7 @@ The following scenarios trigger trust prompts when the required add-in isn't ins
 - Documents configured to [automatically open a task pane](../develop/automatically-open-a-task-pane-with-a-document.md).
 - Documents configured to [load add-ins when opened](../develop/run-code-on-document-open.md).
 
-You can prevent these prompts from appearing for users who don't have your add-in installed. Disable trust prompts in your document by setting the [Settings.set](/javascript/api/office/office.settings?view=excel-js-preview#office-office-settings-set-member(1)) method to set the `"Office.DisableTrustUX"` setting to `true`.
+You can prevent these prompts from appearing for users who don't have your add-in installed. Disable trust prompts in your document by setting the [Settings.set](/javascript/api/office/office.settings#office-office-settings-set-member(1)) method to set the `"Office.DisableTrustUX"` setting to `true`.
 
 ```javascript
 Office.context.document.settings.set("Office.DisableTrustUX", true);

--- a/docs/publish/manage-trust-options.md
+++ b/docs/publish/manage-trust-options.md
@@ -8,7 +8,7 @@ ms.localizationpriority: medium
 
 # Managing trust options for Office Add-ins
 
-Office trust prompts help protect users by asking for consent before add-ins access their documents or launch from external protocols. While these security measures are important, there are scenarios where you want to not prompt users to improve their experiences. This article covers how to disable trust prompts when the related add-in is not installed and how to configure protocol handler trust policies.
+Office trust prompts help protect users by asking for consent before add-ins access their documents or launch from external protocols. While these security measures are important, there are scenarios where you don't want to prompt users to improve their experiences. This article covers how to disable trust prompts when the related add-in is not installed and how to configure protocol handler trust policies.
 
 ## Disable trust prompts for add-ins that aren't installed
 

--- a/docs/publish/manage-trust-options.md
+++ b/docs/publish/manage-trust-options.md
@@ -1,23 +1,49 @@
 ---
-title: Trust custom protocol handlers that launch add-ins
-description: How to use group policies for protocol handler trust in the registry to launch add-ins.
+title: Managing trust options for Office Add-ins
+description: How to disable trust prompts for users without installed add-ins and how to use group policies for protocol handler trust in the registry when launching add-ins.
 ms.topic: how-to
-ms.date: 08/15/2025
+ms.date: 09/22/2025
 ms.localizationpriority: medium
 ---
 
-# Trust custom protocol handlers to launch add-ins
+# Managing trust options for Office Add-ins
+
+Office trust prompts help protect users by asking for consent before add-ins access their documents or launch from external protocols. While these security measures are important, there are scenarios where you want to not prompt users to improve their experiences. This article covers how to disable trust prompts when the related add-in is not installed and how to configure protocol handler trust policies.
+
+## Disable trust prompts for add-ins that aren't installed
+
+When you share documents that contain add-in metadata, users without the required add-in installed may see trust prompts. These prompts appear when a document includes settings that instruct Office to automatically launch an add-in.
+
+The following scenarios trigger trust prompts when the required add-in isn't installed.
+
+- Documents with custom functions that use a [shared runtime](../develop/configure-your-add-in-to-use-a-shared-runtime.md).
+- Documents configured to [automatically open a task pane](../develop/automatically-open-a-task-pane-with-a-document.md).
+- Documents configured to [load add-ins when opened](../develop/run-code-on-document-open.md).
+
+You can prevent these prompts from appearing for users who don't have your add-in installed. Disable trust prompts in your document by setting the [Settings.set](/javascript/api/office/office.settings?view=excel-js-preview#office-office-settings-set-member(1)) method to set the `"Office.DisableTrustUX"` setting to `true`.
+
+```javascript
+Office.context.document.settings.set("Office.DisableTrustUX", true);
+Office.context.document.settings.saveAsync(); 
+```
+
+This setting is saved in the document's OOXML metadata. When enabled, it prevents trust prompts in all the scenarios listed earlier in this section. This provides a better experience for users who don't need the add-in.
+
+> [!IMPORTANT]
+> This setting applies to Office on Windows only.
+
+## Trust custom protocol handlers to launch add-ins
 
 Let your Office Add-in launch from a custom protocol handler (like `mailto:` or your own scheme) without prompting users for consent. This is useful when you want a seamless experience for users, or when your organization needs to centrally manage which add-ins launch from which protocols.
 
 > [!IMPORTANT]
 > This article applies to Windows only. Support for this feature starts with Office Version 2408 (Build 17928.20018).
 
-## How protocol handler trust works
+### How protocol handler trust works
 
 A protocol handler lets an app or add-in launch from a URI (for example, clicking a `mailto:` link opens your email client). Office add-ins also launch this way. By default, users are prompted to trust each add-in and protocol pair. As an admin, pre-approve or block these pairs using group policy and the Windows registry.
 
-## Registry key format
+### Registry key format
 
 To automatically trust a custom protocol handler for an add-in, create a registry key at one of the following locations (replace `<add-in ID>` with your add-in's [manifest ID](/javascript/api/manifest/id) or unified manifest [`id`](/microsoft-365/extensibility/schema/root#id).
 
@@ -30,11 +56,11 @@ Add the following values to the key.
 - **Type:** REG_SZ
 - **Data:** `Allow` or `Block`
 
-## Set group policies
+### Set group policies
 
 Admins use group policy to manage protocol handler trust across the organization. The following sample files show how to set up these policies.
 
-### Sample ADMX file
+#### Sample ADMX file
 
 ```xml
 <?xml version="1.0" encoding="utf-16"?> 
@@ -71,7 +97,7 @@ Admins use group policy to manage protocol handler trust across the organization
 </policyDefinitions> 
 ```
 
-### Sample ADML file
+#### Sample ADML file
 
 ```xml
 <?xml version="1.0" encoding="utf-16"?> 
@@ -94,7 +120,7 @@ Admins use group policy to manage protocol handler trust across the organization
 </policyDefinitionResources> 
 ```
 
-### Sample .REG file
+#### Sample .REG file
 
 The following example shows how to configure the registry directly using a .REG file.
 

--- a/docs/publish/manage-trust-options.md
+++ b/docs/publish/manage-trust-options.md
@@ -2,7 +2,7 @@
 title: Managing trust options for Office Add-ins
 description: How to disable trust prompts for users without installed add-ins and how to use group policies for protocol handler trust in the registry when launching add-ins.
 ms.topic: how-to
-ms.date: 09/22/2025
+ms.date: 09/24/2025
 ms.localizationpriority: medium
 ---
 
@@ -30,14 +30,14 @@ Office.context.document.settings.saveAsync();
 This setting is saved in the document's OOXML metadata. When enabled, it prevents trust prompts in all the scenarios listed earlier in this section. This provides a better experience for users who don't need the add-in.
 
 > [!IMPORTANT]
-> This setting applies to Office on Windows only.
+> This setting only applies to Office on Windows and Mac.
 
 ## Trust custom protocol handlers to launch add-ins
 
 Let your Office Add-in launch from a custom protocol handler (like `mailto:` or your own scheme) without prompting users for consent. This is useful when you want a seamless experience for users, or when your organization needs to centrally manage which add-ins launch from which protocols.
 
 > [!IMPORTANT]
-> This article applies to Windows only. Support for this feature starts with Office Version 2408 (Build 17928.20018).
+> This section applies to Windows only. Support for this feature starts with Office Version 2408 (Build 17928.20018).
 
 ### How protocol handler trust works
 

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -479,7 +479,7 @@ items:
     - name: Maintain your Office Add-in
       href: publish/maintain-breaking-changes.md
     - name: Trust custom protocol handlers to launch add-ins
-      href: publish/custom-protocol-handler.md
+      href: publish/manage-trust-options.md
 
 - name: Excel
   items: 


### PR DESCRIPTION
A new setting, `Office.context.document.settings.set("Office.DisableTrustUX", true);` can be used to stop Office from prompting users to trust an add-in that they don't have, but the document references.  