### PR TITLE
[Word, Excel, PowerPoint] (DevX) Remove Dev Kit preview note consistently across docs

### DIFF
--- a/docs/develop/develop-add-ins-vscode.md
+++ b/docs/develop/develop-add-ins-vscode.md
@@ -2,7 +2,7 @@
 title: Develop Office Add-ins with Visual Studio Code
 description: How to develop Office Add-ins with Visual Studio Code.
 ms.topic: overview
-ms.date: 08/15/2024
+ms.date: 10/08/2025
 ms.localizationpriority: high
 ---
 
@@ -33,7 +33,7 @@ When the Yeoman generator finishes creating the add-in project, open the root fo
 
 The Yeoman generator creates a basic add-in with limited functionality. You can customize the add-in by editing the [manifest](add-in-manifests.md), HTML, JavaScript or TypeScript, and CSS files in VS Code. For a high-level description of the project structure and files in the add-in project that the Yeoman generator creates, see the Yeoman generator guidance within the [5-minute quick start](../index.yml) that corresponds to the type of add-in you've created.
 
-### Create the add-in project using the Office Add-ins Development Kit (preview)
+### Create the add-in project using the Office Add-ins Development Kit
 
 The [Office Add-ins Development Kit](https://marketplace.visualstudio.com/items?itemName=msoffice.microsoft-office-add-in-debugger) is a Visual Studio Code extension that allows you to create new projects directly from VS Code. For information on installing the extension and creating projects from templates and samples, see [Create Office Add-in projects using Office Add-ins Development Kit for Visual Studio Code](development-kit-overview.md).
 

--- a/docs/develop/develop-overview.md
+++ b/docs/develop/develop-overview.md
@@ -2,7 +2,7 @@
 title: Develop Office Add-ins
 description: An introduction to developing Office Add-ins.
 ms.topic: overview
-ms.date: 05/19/2025
+ms.date: 10/08/2025
 ms.localizationpriority: high
 ---
 
@@ -39,7 +39,7 @@ Visual Studio can be used to create Office Add-ins for Excel, Outlook, Word, and
 
 The Agents Toolkit can be used to create almost any kind of Microsoft 365 extension. For details about creating an add-in, see [Create Office Add-in projects with Microsoft 365 Agents Toolkit](agents-toolkit-overview.md).
 
-### Office Add-ins Development Kit (preview)
+### Office Add-ins Development Kit
 
 The Office Add-ins Development Kit is an extension for Visual Studio Code. It lets you create new add-in projects and load samples directly from the IDE. Download the extension from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=msoffice.microsoft-office-add-in-debugger) or learn more in the article [Create Office Add-in projects using Office Add-ins Development Kit for Visual Studio Code](development-kit-overview.md).
 

--- a/docs/develop/development-kit-overview.md
+++ b/docs/develop/development-kit-overview.md
@@ -1,7 +1,7 @@
 ---
 title: Create Office Add-in projects using Office Add-ins Development Kit for Visual Studio Code
 description: Learn how to create Office Add-in projects using Office Add-ins Development Kit extension.
-ms.date: 12/19/2024
+ms.date: 10/08/2025
 ms.localizationpriority: high
 ---
 

--- a/docs/overview/set-up-your-dev-environment.md
+++ b/docs/overview/set-up-your-dev-environment.md
@@ -1,7 +1,7 @@
 ---
 title: Set up your development environment
 description:  Set up your developer environment to build Office Add-ins.
-ms.date: 05/19/2025
+ms.date: 10/08/2025
 ms.topic: install-set-up-deploy
 ms.localizationpriority: medium
 ---
@@ -126,7 +126,7 @@ Get the latest version of Visual Studio Code from [Visual Studio Code homepage](
 
 ### Install a project creation tool
 
-You can create Office add-in projects in Visual Studio Code with either Agents Toolkit or Office Add-ins Development Kit extensions. Currently, the Office Add-ins Development Kit is in preview and only focuses on Excel, PowerPoint, and Word experiences.
+You can create Office add-in projects in Visual Studio Code with either Agents Toolkit or Office Add-ins Development Kit extensions. The Office Add-ins Development Kit currently focuses on Excel, PowerPoint, and Word experiences.
 
 #### Install Agents Toolkit
 


### PR DESCRIPTION
The Office Add-ins Development Kit was sometimes tagged as "Preview" in our docs. It's not in that state anymore.