### PR TITLE
[all hosts] (Initialization) Add note about onReady not resolving when office.js is blocked

### DIFF
--- a/docs/develop/initialize-add-in.md
+++ b/docs/develop/initialize-add-in.md
@@ -1,7 +1,7 @@
 ---
 title: Initialize your Office Add-in
 description: Learn how to initialize your Office Add-in.
-ms.date: 08/18/2023
+ms.date: 10/16/2025
 ms.localizationpriority: medium
 ---
 
@@ -86,6 +86,9 @@ Office.onReady(function() {
 However, there are exceptions to this practice. For example, suppose you want to open your add-in in a browser (instead of sideload it in an Office application) in order to debug your UI with browser tools. In this scenario, once Office.js determines that it is running outside of an Office host application, it will call the callback and resolve the promise with `null` for both the host and platform.
 
 Another exception would be if you want a progress indicator to appear in the task pane while the add-in is loading. In this scenario, your code should call the jQuery `ready` and use its callback to render the progress indicator. Then the `Office.onReady` callback can replace the progress indicator with the final UI.
+
+> [!IMPORTANT]
+> If the Office JavaScript API library files are blocked by network filters, firewalls, or browser extensions, `Office.onReady` will never resolve.
 
 ## Initialize with Office.initialize
 

--- a/docs/develop/loading-the-dom-and-runtime-environment.md
+++ b/docs/develop/loading-the-dom-and-runtime-environment.md
@@ -1,7 +1,7 @@
 ﻿---
 title: Loading the DOM and runtime environment
 description: Load the DOM and Office Add-ins runtime environment.
-ms.date: 05/20/2023
+ms.date: 10/16/2025
 ms.localizationpriority: medium
 ---
 
@@ -29,6 +29,9 @@ The following events occur when a content or task pane add-in starts.
 4. The webview control loads the DOM and HTML body, and calls the event handler for the `window.onload` event.
 
 5. The Office client application loads the runtime environment, which downloads and caches the Office JavaScript API library files from the content distribution network (CDN) server, and then calls the add-in's event handler for the [initialize](/javascript/api/office#Office_initialize_reason_) event of the [Office](/javascript/api/office) object, if a handler has been assigned to it. At this time it also checks to see if any callbacks (or chained `then()` method) have been passed (or chained) to the `Office.onReady` handler. For more information about the distinction between `Office.initialize` and `Office.onReady`, see [Initialize your add-in](initialize-add-in.md).
+
+    > [!IMPORTANT]
+    > If the Office JavaScript API library files are blocked by network filters, firewalls, or browser extensions, `Office.onReady` will never resolve.
 
 6. When the DOM and HTML body finish loading and the add-in finishes initializing, the main function of the add-in can proceed.
 


### PR DESCRIPTION
In response to https://github.com/OfficeDev/office-js/issues/6148, this PR adds a note to the docs about `Office.onReady` not resolving when Office JS API library files are blocked.