### PR TITLE
[Outlook] (unified manifest) Remove displayName property

### DIFF
--- a/docs/excludes/outlook-quickstart-json-manifest-typescript.md
+++ b/docs/excludes/outlook-quickstart-json-manifest-typescript.md
@@ -1,7 +1,7 @@
 ﻿---
 title: Build an Outlook add-in with the unified manifest for Microsoft 365
 description: Learn how to build a simple Outlook task pane add-in with the unified manifest for Microsoft 365.
-ms.date: 05/19/2025
+ms.date: 11/18/2025
 ms.service: outlook
 ms.localizationpriority: high
 ---
@@ -173,8 +173,7 @@ Add a custom button to the ribbon that inserts text into a message body.
         "actions": [
             {
                 "id": "insertHelloWorld",
-                "type": "executeFunction",
-                "displayName": "insertHelloWorld"
+                "type": "executeFunction"
             }
         ]
     }

--- a/docs/outlook/append-on-send.md
+++ b/docs/outlook/append-on-send.md
@@ -1,7 +1,7 @@
 ﻿---
 title: Prepend or append content to a message or appointment body on send
 description: Learn how to prepend or append content to a message or appointment body when the mail item is sent.
-ms.date: 08/01/2025
+ms.date: 11/18/2025
 ms.topic: how-to
 ms.localizationpriority: medium
 ---
@@ -65,13 +65,11 @@ The following shows how to configure your unified manifest to enable the prepend
         "actions": [
             {
                 "id": "prependHeaderOnSend",
-                "type": "executeFunction",
-                "displayName": "prependHeaderOnSend"
+                "type": "executeFunction"
             },
             {
                 "id": "appendDisclaimerOnSend",
-                "type": "executeFunction",
-                "displayName": "appendDisclaimerOnSend"
+                "type": "executeFunction"
             }
         ]
     }

--- a/docs/outlook/on-new-compose-events-walkthrough.md
+++ b/docs/outlook/on-new-compose-events-walkthrough.md
@@ -1,7 +1,7 @@
 ﻿---
 title: Automatically set the subject of a new message or appointment
 description: Learn how to implement an event-based add-in that automatically sets the subject of a new message or appointment.
-ms.date: 08/01/2025
+ms.date: 11/18/2025
 ms.topic: how-to
 ms.localizationpriority: medium
 ---
@@ -80,13 +80,11 @@ To configure the manifest, select the tab for the type of manifest you're using.
         "actions": [
             {
                 "id": "onNewMessageComposeHandler",
-                "type": "executeFunction",
-                "displayName": "onNewMessageComposeHandler"
+                "type": "executeFunction"
             },
             {
                 "id": "onNewAppointmentComposeHandler",
-                "type": "executeFunction",
-                "displayName": "onNewAppointmentComposeHandler"
+                "type": "executeFunction"
             }
         ]
     }

--- a/docs/outlook/online-meeting.md
+++ b/docs/outlook/online-meeting.md
@@ -1,7 +1,7 @@
 ﻿---
 title: Create an Outlook add-in for an online-meeting provider
 description: Discusses how to set up an Outlook add-in for an online-meeting service provider.
-ms.date: 08/07/2025
+ms.date: 11/18/2025
 ms.topic: how-to
 ms.localizationpriority: medium
 ---
@@ -76,8 +76,7 @@ The steps for configuring the manifest depend on which type of manifest you sele
         "actions": [
             {
                 "id": "insertContosoMeeting",
-                "type": "executeFunction",
-                "displayName": "insertContosoMeeting"
+                "type": "executeFunction"
             }
         ]
     }

--- a/docs/outlook/onmessagefromchanged-onappointmentfromchanged-events.md
+++ b/docs/outlook/onmessagefromchanged-onappointmentfromchanged-events.md
@@ -1,7 +1,7 @@
 ﻿---
 title: Automatically update your signature when switching between Exchange accounts
 description: Learn how to automatically update your signature when switching between Exchange accounts through the OnMessageFromChanged and OnAppointmentFromChanged events in your event-based activation Outlook add-in.
-ms.date: 10/28/2025
+ms.date: 11/18/2025
 ms.topic: how-to
 ms.localizationpriority: medium
 ---
@@ -113,13 +113,11 @@ Complete the [Outlook quick start](../quickstarts/outlook-quickstart-yo.md), whi
         "actions": [
             {
                 "id": "onMessageFromChangedHandler",
-                "type": "executeFunction",
-                "displayName": "onMessageFromChangedHandler"
+                "type": "executeFunction"
             },
             {
                 "id": "onNewMessageComposeHandler",
-                "type": "executeFunction",
-                "displayName": "onNewMessageComposeHandler"
+                "type": "executeFunction"
             }
         ]
     }

--- a/docs/outlook/pinnable-taskpane.md
+++ b/docs/outlook/pinnable-taskpane.md
@@ -1,7 +1,7 @@
 ﻿---
 title: Implement a pinnable task pane in an Outlook add-in
 description: The task pane UX shape for add-in commands opens a vertical task pane to the right of an open message or meeting request, allowing the add-in to provide UI for more detailed interactions.
-ms.date: 11/06/2025
+ms.date: 11/18/2025
 ms.topic: how-to
 ms.localizationpriority: medium
 ---
@@ -46,7 +46,6 @@ Add a `"pinnable"` property, set to `true`, to the object in the [`"actions"`](/
         "id": "OpenTaskPane",
         "type": "openPage",
         "view": "TaskPaneView",
-        "displayName": "OpenTaskPane",
         "pinnable": true
     }
 ]

--- a/docs/outlook/smart-alerts-onmessagesend-walkthrough.md
+++ b/docs/outlook/smart-alerts-onmessagesend-walkthrough.md
@@ -1,7 +1,7 @@
 ﻿---
 title: Automatically check for an attachment before a message is sent
 description: Learn how to implement an event-based add-in that implements Smart Alerts to automatically check a message for an attachment before it's sent.
-ms.date: 08/26/2025
+ms.date: 11/18/2025
 ms.topic: how-to
 ms.localizationpriority: medium
 ---
@@ -62,8 +62,7 @@ To configure the manifest, select the tab for the type of manifest you are using
         "actions": [
             {
                 "id": "onMessageSendHandler",
-                "type": "executeFunction",
-                "displayName": "onMessageSendHandler"
+                "type": "executeFunction"
             }
         ]
     }

--- a/docs/tutorials/outlook-tutorial.md
+++ b/docs/tutorials/outlook-tutorial.md
@@ -1,7 +1,7 @@
 ﻿---
 title: 'Tutorial: Build a message compose Outlook add-in'
 description: In this tutorial, you will build an Outlook add-in that inserts GitHub gists into the body of a new message.
-ms.date: 01/07/2025
+ms.date: 11/18/2025
 ms.service: outlook
 #Customer intent: As a developer, I want to create a message compose Outlook add-in.
 ms.localizationpriority: high
@@ -245,8 +245,7 @@ Take the following steps:
         "actions": [
             {
                 "id": "insertDefaultGist",
-                "type": "executeFunction",
-                "displayName": "action"
+                "type": "executeFunction"
             }
         ]
     }


### PR DESCRIPTION
Removes the `"displayName"` property from the Outlook samples since this property only applies to the custom keyboard shortcuts feature.