### PR TITLE
[All Hosts] (manifest) add requirements article to ToC

### DIFF
--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -130,6 +130,8 @@
         items: 
         - name: Office Add-ins with the unified manifest for Microsoft 365
           href: develop/unified-manifest-overview.md
+        - name: Specify Office Add-in requirements in the unified manifest for Microsoft 365
+          href: develop/requirements-property-unified-manifest.md
         - name: Compare the add-in only manifest with the unified manifest for Microsoft 365
           href: develop/json-manifest-overview.md
         - name: Convert an add-in to use the unified manifest for Microsoft 365


### PR DESCRIPTION
This article was left out of the ToC because we thought it would eventually be in a common M365 doc set. It's now unlikely that there will ever be a common doc set, so I'm adding it to the ToC. 

This doesn't need a review. 