### PR TITLE
[Outlook] (attachments) Add guidance about inline image representation in the HTML body

### DIFF
--- a/docs/outlook/add-and-remove-attachments-to-an-item-in-a-compose-form.md
+++ b/docs/outlook/add-and-remove-attachments-to-an-item-in-a-compose-form.md
@@ -246,7 +246,7 @@ In the HTML body of a mail item, inline images are represented by a content ID (
 The following is an example.
 
 ```html
-<img src="cid:ee058cc2-ad96-485f-95c7-44b2f40cb987" style="max-width: 1281px;"originalsrc="cid:ee058cc2-ad96-485f-95c7-44b2f40cb987" size="19720" contenttype="image/png">
+<img src="cid:ee058cc2-ad96-485f-95c7-44b2f40cb987" style="max-width: 1281px;" originalsrc="cid:ee058cc2-ad96-485f-95c7-44b2f40cb987" size="19720" contenttype="image/png">
 ```
 
 ## See also


### PR DESCRIPTION
Documents how inline images are represented in the HTML body based on the changes outlined in [Changes to inline image representation in Outlook on the web and new Outlook for Windows](https://devblogs.microsoft.com/microsoft365dev/changes-to-inline-images-in-outlook).