### PR TITLE
[all hosts] Update default ms.topic value

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -41,7 +41,7 @@
       "ms.suite": "office",
       "ms.author": "o365devx",
       "author": "o365devx",
-      "ms.topic": "conceptual",
+      "ms.topic": "article",
       "ms.service": "microsoft-365",
       "ms.subservice": "add-ins",
       "feedback_system": "OpenSource",


### PR DESCRIPTION
"conceptual" value has been deprecated and "article" is the recommended default value.