### PR TITLE
[All hosts] Remove retired code editor

### DIFF
--- a/docs/overview/set-up-your-dev-environment.md
+++ b/docs/overview/set-up-your-dev-environment.md
@@ -43,7 +43,7 @@ This guide assumes that you know how to use a command-line tool.
 
 ### Install a code editor
 
-You can use any code editor or IDE that supports client-side development to build your web part, such as [Visual Studio Code](https://code.visualstudio.com/) (recommended).
+You can use any code editor or IDE that supports client-side development to build your web part, such as [Visual Studio Code](https://code.visualstudio.com/).
 
 ### Install the Yeoman generator &mdash; Yo Office
 


### PR DESCRIPTION
Removes Atom from our documentation as this code editor has been retired (see https://github.blog/news-insights/product-news/sunsetting-atom/).