### PR TITLE
[Outlook](known issues) PIM-enabled tenants can't use central deployment

### DIFF
--- a/docs/resources/resources-office-add-in-known-issues.md
+++ b/docs/resources/resources-office-add-in-known-issues.md
@@ -21,7 +21,7 @@ When using Azure AD Privileged Identity Management (PIM) to activate admin roles
 
 #### STATUS
 
-We're currently working on a fix.
+Open; tracking id: 11126536
 
 #### IMPACT
 


### PR DESCRIPTION
Adds new known issue about PIM-enabled tenants blocked from deploying Outlook add-ins via central deployment.