### PR TITLE
[Excel] (contextual tab) Clarify implementation guidance

### DIFF
--- a/docs/design/contextual-tabs.md
+++ b/docs/design/contextual-tabs.md
@@ -1,7 +1,7 @@
 ﻿---
 title: Create custom contextual tabs in Office Add-ins
 description: Learn how to add custom contextual tabs to your Office Add-in.
-ms.date: 04/21/2026
+ms.date: 04/28/2026
 ms.topic: how-to
 ms.localizationpriority: medium
 ---
@@ -29,6 +29,14 @@ Additionally, custom contextual tabs only work on platforms that support the fol
 > [!TIP]
 > Use the runtime checks in your code to test whether the user's host and platform combination supports these requirement sets as described in [Check for API availability at runtime](../develop/specify-api-requirements-runtime.md). (The technique of specifying the requirement sets in the manifest, which is also described in that article, doesn't currently work for RibbonApi 1.2.) Alternatively, you can [implement an alternate UI experience when custom contextual tabs aren't supported](#implement-an-alternate-ui-experience-when-custom-contextual-tabs-arent-supported).
 
+## Try out a sample add-in
+
+To immediately test an add-in that implements a custom contextual tab, try out the [Create custom contextual tabs on a the ribbon sample](https://github.com/OfficeDev/Office-Add-in-samples/tree/main/Samples/office-contextual-tabs).
+
+Watch a demo of this sample.
+
+> [!VIDEO https://www.youtube.com/embed/9tLfm4boQIo]
+
 ## Behavior of custom contextual tabs
 
 The user experience for custom contextual tabs follows the pattern of built-in Office contextual tabs. The following are the basic principles for the placement of custom contextual tabs.
@@ -44,7 +52,6 @@ The user experience for custom contextual tabs follows the pattern of built-in O
 The following are the major steps for including a custom contextual tab in an add-in.
 
 1. [Configure the add-in to use a shared runtime](#configure-the-add-in-to-use-a-shared-runtime).
-1. [Specify the icons for your contextual tab](#specify-the-icons-for-your-contextual-tab).
 1. [Define the groups and controls that appear on the tab](#define-the-groups-and-controls-that-appear-on-the-tab).
 1. [Register the contextual tab with Office](#register-the-contextual-tab-with-office-with-requestcreatecontrols).
 1. [Specify the circumstances when the tab will be visible](#specify-the-contexts-when-the-tab-will-be-visible-with-requestupdate).
@@ -53,113 +60,23 @@ The following are the major steps for including a custom contextual tab in an ad
 
 Adding custom contextual tabs requires your add-in to use the [shared runtime](../testing/runtimes.md#shared-runtime). For more information, see [Configure an add-in to use a shared runtime](../develop/configure-your-add-in-to-use-a-shared-runtime.md).
 
-## Specify the icons for your contextual tab
-
-Before you can customize your contextual tab, you must first specify any icons that will appear on it in your add-in's manifest. Each icon must have at least three sizes: 16x16 px, 32x32 px, and 80x80 px. Select the tab for the type of manifest your add-in uses.
-
-# [Unified manifest for Microsoft 365](#tab/jsonmanifest)
-
-In the [`"extensions.ribbons.tabs.groups.icons"`](/microsoft-365/extensibility/schema/extension-ribbons-custom-tab-groups-item#icons) array, specify the icons for the group of contextual tab controls that will be displayed on the host's ribbon. For icons that will be used by the tab's buttons and menus, specify these in the `"icons"` property of the [`"extensions.ribbons.tabs.groups.controls"`](/microsoft-365/extensibility/schema/extension-ribbons-custom-tab-groups-item#controls) object.
-
-Because the contextual tab will only be shown when a certain event occurs, you must also set the [`"extensions.ribbons.tabs.groups.controls.overriddenByRibbonApi"`](/microsoft-365/extensibility/schema/extension-common-custom-group-controls-item#overriddenbyribbonapi) property to `true`.
-
-The following is an example.
-
-```json
-"ribbons": [
-    {
-        ...
-        "tabs": [
-            "groups": [
-                {
-                    "id": "ContosoGroup",
-                    ...
-                    "icons": [
-                        {
-                            "size": 16,
-                            "url": "https://cdn.contoso.com/addins/datainsertion/Images/Group16x16.png"
-                        },
-                        {
-                            "size": 32,
-                            "url": "https://cdn.contoso.com/addins/datainsertion/Images/Group32x32.png"
-                        },
-                        {
-                            "size": 80,
-                            "url": "https://cdn.contoso.com/addins/datainsertion/Images/Group80x80.png"
-                        }
-                    ],
-                    "controls": [
-                        {
-                            "id": "WriteDataButton",
-                            ...
-                            "icons": [
-                                {
-                                    "size": 16,
-                                    "url": "https://cdn.contoso.com/addins/datainsertion/Images/WriteDataButton16x16.png"
-                                },
-                                {
-                                    "size": 32,
-                                    "url": "https://cdn.contoso.com/addins/datainsertion/Images/WriteDataButton32x32.png"
-                                },
-                                {
-                                    "size": 80,
-                                    "url": "https://cdn.contoso.com/addins/datainsertion/Images/WriteDataButton80x80.png"
-                                }
-                            ],
-                            ...
-                            "overriddenByRibbonApi": true
-                        },
-                        ...
-                    ]
-                }
-            ]
-        ]
-    }
-],
-```
-
-# [Add-in only manifest](#tab/xmlmanifest)
-
-Use the [Image](/javascript/api/manifest/image) element in the [Resources](/javascript/api/manifest/resources) section of your add-in's manifest to specify the icons for your contextual tab.
-
-The following is an example.
-
-```xml
-<Resources>
-    <bt:Images>
-        <bt:Image id="contextual-tab-icon-16" DefaultValue="https://cdn.contoso.com/addins/datainsertion/Images/Group16x16.png"/>
-        <bt:Image id="contextual-tab-icon-32" DefaultValue="https://cdn.contoso.com/addins/datainsertion/Images/Group32x32.png"/>
-        <bt:Image id="contextual-tab-icon-80" DefaultValue="https://cdn.contoso.com/addins/datainsertion/Images/Group80x80.png"/>
-        <bt:Image id="contextual-button-icon-16" DefaultValue="https://cdn.contoso.com/addins/datainsertion/Images/WriteDataButton16x16.png"/>
-        <bt:Image id="contextual-button-icon-32" DefaultValue="https://cdn.contoso.com/addins/datainsertion/Images/WriteDataButton32x32.png"/>
-        <bt:Image id="contextual-button-icon-80" DefaultValue="https://cdn.contoso.com/addins/datainsertion/Images/WriteDataButton80x80.png"/>
-    </bt:Images>
-    ...
-</Resources>
-```
-
----
-
-> [!IMPORTANT]
-> When you move your add-in from development to staging or production, remember to update the URLs in your manifest as needed (such as changing the domain from `localhost` to `contoso.com`).
-
 ## Define the groups and controls that appear on the tab
 
-Unlike custom core tabs, which are defined in the manifest, custom contextual tabs are defined at runtime with a JSON blob. Your code parses the blob into a JavaScript object, and then passes the object to the [Office.ribbon.requestCreateControls](/javascript/api/office/office.ribbon?view=common-js&preserve-view=true#office-office-ribbon-requestcreatecontrols-member(1)) method. Custom contextual tabs are only present in documents on which your add-in is currently running. This is different from custom core tabs which are added to the Office application ribbon when the add-in is installed and remain present when another document is opened. Also, the `requestCreateControls` method may be run only once in a session of your add-in. If it's called again, an error is thrown.
+Unlike custom core tabs, which are defined in the manifest, custom contextual tabs are defined at runtime with a JavaScript object that you pass to the [Office.ribbon.requestCreateControls](/javascript/api/office/office.ribbon?view=common-js&preserve-view=true#office-office-ribbon-requestcreatecontrols-member(1)) method. You can define the object directly as a JavaScript object literal or you can define it as a JSON string and convert it to an object with `JSON.parse` before passing it. Custom contextual tabs are only present in documents on which your add-in is currently running. This is different from custom core tabs which are added to the Office application ribbon when the add-in is installed and remain present when another document is opened. Also, the `requestCreateControls` method may be run only once in a session of your add-in. If it's called again, an error is thrown.
 
-We'll construct an example of a contextual tabs JSON blob step-by-step. The full schema for the contextual tab JSON is at [dynamic-ribbon.schema.json](https://developer.microsoft.com/json-schemas/office-js/dynamic-ribbon.schema.json). If you're working in Visual Studio Code, you can use this file to get IntelliSense and to validate your JSON. For more information, see [Editing JSON with Visual Studio Code - JSON schemas and settings](https://code.visualstudio.com/docs/languages/json#_json-schemas-and-settings).
+We'll construct an example of a contextual tab object step-by-step. The full schema for the contextual tab JSON is at [dynamic-ribbon.schema.json](https://developer.microsoft.com/json-schemas/office-js/dynamic-ribbon.schema.json). If you're working in Visual Studio Code, you can use this file to get IntelliSense and to validate your JSON. For more information, see [Editing JSON with Visual Studio Code - JSON schemas and settings](https://code.visualstudio.com/docs/languages/json#_json-schemas-and-settings).
 
-1. Begin by creating a JSON string with two array properties named `actions` and `tabs`. The `actions` array is a specification of all the functions that can be executed by controls on the contextual tab. The `tabs` array defines one or more contextual tabs.
+1. Begin by creating a JavaScript object with two array properties named `actions` and `tabs`. The `actions` array is a specification of all the functions that can be executed by controls on the contextual tab. The `tabs` array defines one or more contextual tabs.
 
-    ```json
-    '{
+    ```javascript
+    {
       "actions": [
 
       ],
       "tabs": [
 
       ]
-    }'
+    }
     ```
 
 1. This simple example of a contextual tab will have only a single button and, thus, only a single action. Add the following as the only member of the `actions` array. About this markup, note:
@@ -172,7 +89,7 @@ We'll construct an example of a contextual tabs JSON blob step-by-step. The full
       - **Add-in only manifest**: Located in the [\<FunctionFile\>](/javascript/api/manifest/functionfile) element.
     - In a later step, you'll map this action to a button on the contextual tab.
 
-    ```json
+    ```javascript
     {
       "id": "executeWriteData",
       "type": "ExecuteFunction",
@@ -189,7 +106,7 @@ We'll construct an example of a contextual tabs JSON blob step-by-step. The full
     > [!NOTE]
     > The tab object can also have an optional `visible` property that specifies whether the tab is visible immediately when the add-in starts up. Since contextual tabs are normally hidden until a user event triggers their visibility (such as the user selecting an entity of some type in the document), the `visible` property defaults to `false` when not present. In a later section, we show how to set the property to `true` in response to an event.
 
-    ```json
+    ```javascript
     {
       "id": "CtxTab1",
       "label": "Contoso Data",
@@ -207,7 +124,7 @@ We'll construct an example of a contextual tabs JSON blob step-by-step. The full
     - The `icon` property's value is an array of objects that specify the icons that the group will have on the ribbon depending on the size of the ribbon and the Office application window.
     - The `controls` property's value is an array of objects that specify the buttons and menus in the group. There must be at least one.
 
-    ```json
+    ```javascript
     {
         "id": "CustomGroup111",
         "label": "Insertion",
@@ -224,16 +141,12 @@ We'll construct an example of a contextual tabs JSON blob step-by-step. The full
 
     - Both the properties are required.
     - The `size` property unit of measure is pixels. Icons are always square, so the number is both the height and the width.
-    - The `sourceLocation` property specifies the full URL to the icon. Its value must match the URL specified in the add-in's manifest. The location of the icon URL depends on the type of manifest your add-in uses.
+    - The `sourceLocation` property specifies the full URL to the icon.
 
-      - **Unified manifest for Microsoft 365**: Located in the [`"icons"`](/microsoft-365/extensibility/schema/extension-ribbons-custom-tab-groups-item#icons) property of the applicable `"extensions.ribbons.tabs.groups"` object.
-      - **Add-in only manifest**: Located in the [\<Image\>](/javascript/api/manifest/image) element of the [\<Resources\>](/javascript/api/manifest/resources) section.
+        > [!IMPORTANT]
+        > Just as you typically must change the URLs in the add-in's manifest when you move from development to production, you must also change the URLs in your contextual tabs JSON.
 
-      For guidance, see [Specify the icons for your contextual tab](#specify-the-icons-for-your-contextual-tab).
-    > [!IMPORTANT]
-    > Just as you typically must change the URLs in the add-in's manifest when you move from development to production, you must also change the URLs in your contextual tabs JSON.
-
-    ```json
+    ```javascript
     {
         "size": 16,
         "sourceLocation": "https://cdn.contoso.com/addins/datainsertion/Images/Group16x16.png"
@@ -259,7 +172,7 @@ We'll construct an example of a contextual tabs JSON blob step-by-step. The full
     - `icon` specifies the icons for the button. The previous remarks about the group icon apply here too.
     - `enabled` (optional) specifies whether the button is enabled when the contextual tab first appears. The default if not present is `true`.
 
-    ```json
+    ```javascript
     {
         "type": "Button",
         "id": "CtxBt112",
@@ -287,9 +200,9 @@ We'll construct an example of a contextual tabs JSON blob step-by-step. The full
     }
     ```
 
-The following is the complete example of the JSON blob.
+The following is the complete example of the contextual tab object.
 
-```json
+```javascript
 {
   "actions": [
     {
@@ -361,10 +274,21 @@ The contextual tab is registered with Office by calling the [Office.ribbon.reque
 > [!IMPORTANT]
 > The `requestCreateControls` method may be called only once in a given session of an add-in. An error is thrown if it's called again.
 
-The following is an example. Note that the JSON string must be converted to a JavaScript object with the `JSON.parse` method before it can be passed to a JavaScript function.
+The following examples show both approaches.
+
+**JavaScript object literal**
 
 ```javascript
-Office.onReady(async () => {
+Office.onReady(async () => {
+    const contextualTab = { ... }; // Assign the object such as the one at the end of the preceding section.
+    await Office.ribbon.requestCreateControls(contextualTab);
+});
+```
+
+**JSON string parsed at runtime**
+
+```javascript
+Office.onReady(async () => {
     const contextualTabJSON = ` ... `; // Assign the JSON string such as the one at the end of the preceding section.
     const contextualTab = JSON.parse(contextualTabJSON);
     await Office.ribbon.requestCreateControls(contextualTab);
@@ -379,8 +303,7 @@ Begin by assigning handlers. This is commonly done in the `Office.onReady` funct
 
 ```javascript
 Office.onReady(async () => {
-    const contextualTabJSON = ` ... `; // Assign the JSON string.
-    const contextualTab = JSON.parse(contextualTabJSON);
+    const contextualTab = { ... }; // Assign the object or use JSON.parse() on a JSON string.
     await Office.ribbon.requestCreateControls(contextualTab);
 
     await Excel.run(context => {
@@ -485,7 +408,7 @@ function myContextChanges() {
 
 To open your task pane from a button on a custom contextual tab, create an action in the JSON with a `type` of `ShowTaskpane`. Then define a button with the `actionId` property set to the `id` of the action. This opens the default task pane specified in your manifest.
 
-```json
+```javascript
 {
   "actions": [
     {
@@ -496,10 +419,10 @@ To open your task pane from a button on a custom contextual tab, create an actio
   ],
   "tabs": [
     {
-      // some tab properties omitted
+      // Some tab properties omitted.
       "groups": [
         {
-          // some group properties omitted
+          // Some group properties omitted.
           "controls": [
             {
                 "type": "Button",
@@ -507,7 +430,7 @@ To open your task pane from a button on a custom contextual tab, create an actio
                 "actionId": "openChartsTaskpane",
                 "enabled": false,
                 "label": "Open Charts Taskpane",
-                // some control properties omitted
+                // Some control properties omitted.
             }
           ]
         }
@@ -524,7 +447,7 @@ To open any task pane that's not the default task pane, specify a `sourceLocatio
 > - When a `sourceLocation` is specified for the action, then the task pane does *not* use the shared runtime. It runs in a new separate runtime.
 > - No more than one task pane can use the shared runtime, so no more than one action of type `ShowTaskpane` can omit the `sourceLocation` property.
 
-```json
+```javascript
 {
   "actions": [
     {
@@ -541,10 +464,10 @@ To open any task pane that's not the default task pane, specify a `sourceLocatio
   ],
   "tabs": [
     {
-      // some tab properties omitted
+      // Some tab properties omitted.
       "groups": [
         {
-          // some group properties omitted
+          // Some group properties omitted.
           "controls": [
             {
                 "type": "Button",
@@ -552,7 +475,7 @@ To open any task pane that's not the default task pane, specify a `sourceLocatio
                 "actionId": "openChartsTaskpane",
                 "enabled": false,
                 "label": "Open Charts Taskpane",
-                // some control properties omitted
+                // Some control properties omitted.
             },
             {
                 "type": "Button",
@@ -560,7 +483,7 @@ To open any task pane that's not the default task pane, specify a `sourceLocatio
                 "actionId": "openTablesTaskpane",
                 "enabled": false,
                 "label": "Open Tables Taskpane",
-                // some control properties omitted
+                // Some control properties omitted.
             }
           ]
         }
@@ -570,56 +493,56 @@ To open any task pane that's not the default task pane, specify a `sourceLocatio
 }
 ```
 
-## Localize the JSON text
+## Localize the contextual tab object
 
-The JSON blob that's passed to `requestCreateControls` isn't localized the same way that the manifest markup for custom core tabs is localized (which is described at [Control localization from the manifest](../develop/localization.md#control-localization-from-the-manifest)). Instead, the localization must occur at runtime using distinct JSON blobs for each locale. We suggest that you use a `switch` statement that tests the [Office.context.displayLanguage](/javascript/api/office/office.context#office-office-context-displaylanguage-member) property. The following is an example.
+The object that's passed to `requestCreateControls` isn't localized the same way that the manifest markup for custom core tabs is localized (which is described at [Control localization from the manifest](../develop/localization.md#control-localization-from-the-manifest)). Instead, the localization must occur at runtime using distinct objects for each locale. We suggest that you use a `switch` statement that tests the [Office.context.displayLanguage](/javascript/api/office/office.context#office-office-context-displaylanguage-member) property. The following is an example.
 
 ```javascript
-function GetContextualTabsJsonSupportedLocale () {
+function getContextualTabForLocale () {
     const displayLanguage = Office.context.displayLanguage;
 
         switch (displayLanguage) {
             case 'en-US':
-                return `{
+                return {
                     "actions": [
-                        // actions omitted
+                        // Actions omitted.
                      ],
                     "tabs": [
                         {
                           "id": "CtxTab1",
                           "label": "Contoso Data",
                           "groups": [
-                              // groups omitted
+                              // Groups omitted.
                           ]
                         }
                     ]
-                }`;
+                };
 
             case 'fr-FR':
-                return `{
+                return {
                     "actions": [
-                        // actions omitted 
+                        // Actions omitted.
                     ],
                     "tabs": [
                         {
                           "id": "CtxTab1",
                           "label": "Contoso Données",
                           "groups": [
-                              // groups omitted
+                              // Groups omitted.
                           ]
                        }
                     ]
-               }`;
+               };
 
-            // Other cases omitted
+            // Other cases omitted.
        }
 }
 ```
 
-Then your code calls the function to get the localized blob that's passed to `requestCreateControls`, as in the following example.
+Then your code calls the function to get the localized object that's passed to `requestCreateControls`, as in the following example.
 
 ```javascript
-const contextualTabJSON = GetContextualTabsJsonSupportedLocale();
+const contextualTab = getContextualTabForLocale();
 ```
 
 ## Best practices for custom contextual tabs
@@ -787,9 +710,10 @@ function showDataTab() {
 }
 ```
 
-## Resources
+## See also
 
 - [Code sample: Create custom contextual tabs on the ribbon](https://github.com/OfficeDev/Office-Add-in-samples/tree/main/Samples/office-contextual-tabs)
-- Community demo of contextual tabs sample
-
-    > [!VIDEO https://www.youtube.com/embed/9tLfm4boQIo]
+- [Basic concepts for add-in commands](add-in-commands.md)
+- [Change the availability of add-in commands](disable-add-in-commands.md)
+- [Configure an add-in to use a shared runtime](../develop/configure-your-add-in-to-use-a-shared-runtime.md)
+- [Show or hide the task pane of your Office Add-in](../develop/show-hide-add-in.md)


### PR DESCRIPTION
- Removes the step to specify icons for the contextual tab in the manifest. These icons are specified in the JavaScript object during runtime.
- Promotes the sample.
- Clarifies the `requestCreateControls` parameter.