### PR TITLE
[all hosts] (auto-publish) Update to use node.js LTS

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -2,7 +2,7 @@ name: auto-publish
 run-name: Automatically publish documentation
 on:
   schedule:
-    # Run at 2:00 AM UTC on Wednesday and Friday
+    # Run at 2:00 AM UTC on Wednesday and Friday.
     - cron: '0 2 * * WED,FRI'
 jobs:
   auto-publish:
@@ -15,7 +15,7 @@ jobs:
         working-directory: ./
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Check out main


### PR DESCRIPTION
Updated the job to use the active LTS version and updated the dependent actions to versions that support the active LTS version. Addresses run warnings.

I did an ad-hoc run of the office-js-docs-reference autogen-docs workflow and found no issues.