### PR TITLE
Remove Outlook Add-in GifMe link from fabric-core.md

### DIFF
--- a/docs/design/fabric-core.md
+++ b/docs/design/fabric-core.md
@@ -54,7 +54,6 @@ The following sample add-ins use Fabric Core and/or Office UI Fabric JS componen
 - [Excel Add-in WoodGrove Expense Trends](https://github.com/OfficeDev/Excel-Add-in-WoodGrove-Expense-Trends)
 - [Office Add-in Fabric UI Sample](https://github.com/OfficeDev/Office-Add-in-Fabric-UI-Sample)
 - [Office-Add-in-UX-Design-Patterns-Code](https://github.com/OfficeDev/Office-Add-in-UX-Design-Patterns-Code)
-- [Outlook Add-in GifMe](https://github.com/OfficeDev/Outlook-Add-in-GifMe)
 - [PowerPoint Add-in Microsoft Graph ASPNET InsertChart](https://github.com/OfficeDev/PowerPoint-Add-in-Microsoft-Graph-ASPNET-InsertChart)
 - [Word Add-in Angular2 StyleChecker](https://github.com/OfficeDev/Word-Add-in-Angular2-StyleChecker)
 - [Word Add-in JS Redact](https://github.com/OfficeDev/Word-Add-in-JS-Redact)


### PR DESCRIPTION
Removed the link to the Outlook Add-in GifMe from the documentation.