### PR TITLE
[excel] (Custom Functions) Clarify CF visibility uses IDs, not function names

### DIFF
--- a/docs/excel/custom-functions-visibility.md
+++ b/docs/excel/custom-functions-visibility.md
@@ -1,7 +1,7 @@
 ---
 title: Manage custom function visibility
 description: Show or hide custom functions from the Excel UI.
-ms.date: 11/25/2025
+ms.date: 08/10/2026
 ms.topic: how-to
 ms.localizationpriority: medium
 ---
@@ -13,42 +13,54 @@ Control which custom functions display in Excel AutoComplete and the Formula Bui
 > [!NOTE]
 > To hide custom functions before an add-in launches, use the [`excludeFromAutoComplete` JSDoc tag](custom-functions-json-autogeneration.md#excludeFromAutoComplete) or set the [`excludeFromAutoComplete` property](custom-functions-json.md#options) to `true`.
 
-The following code sample shows how to map functions to different categories of add-in users so that the functions are programmatically visible or hidden for each user type. The sample assumes that four functions already exist, `functionBasic`, `functionA`, `functionB`, and `functionC`, and maps these functions to **banker**, **trader**, and **analyst** user types in an investment banking organization.
+The following code sample maps functions to different categories of add-in users so that the functions are programmatically visible or hidden for each user type. `FUNCTIONBASIC`, `FUNCTIONA`, `FUNCTIONB`, and `FUNCTIONC` are the exact short names from the functions' JSON metadata.
 
 ```typescript
 /**
  * This code snippet maps existing custom functions to add-in user types.
- * The primary function, functionBasic, is visible for all user types. 
- * The other three functions, functionA, functionB, and functionC, are only visible to specific user types.
+ * The primary function, FUNCTIONBASIC, is visible for all user types.
+ * The other three functions are only visible to specific user types.
  */
-const allFunctions = ["functionBasic", "functionA", "functionB", "functionC"];
+const allFunctions = [
+    "FUNCTIONBASIC",
+    "FUNCTIONA",
+    "FUNCTIONB",
+    "FUNCTIONC",
+];
 
 // Assign each function to a user type.
 const userFunctionMapping = new Map<string, string[]>([
-    ["banker", ["functionBasic", "functionA", "functionB"]],
-    ["trader", ["functionBasic", "functionB"]],
-    ["analyst", ["functionBasic", "functionA", "functionC"]]
+    ["banker", ["FUNCTIONBASIC", "FUNCTIONA", "FUNCTIONB"]],
+    ["trader", ["FUNCTIONBASIC", "FUNCTIONB"]],
+    ["analyst", ["FUNCTIONBASIC", "FUNCTIONA", "FUNCTIONC"]],
 ]);
 
 // Create a placeholder to retrieve the current user type.
 (async () => {
     await Office.onReady();
-    let userType = getCurrentUser(); // Implement `getCurrentUser()` to return the current user type (banker, trader, or analyst).
+    const userType = getCurrentUser(); // Implement `getCurrentUser()` to return the current user type (banker, trader, or analyst).
     await showFunctionsBasedOnUserType(userType);
-});
+})();
 
 // Show the correct functions based on the current user type.
 async function showFunctionsBasedOnUserType(userType: string) {
-    let availableFunctions: string[] = userFunctionMapping.get(userType);
-    let customFunctionVisibilityOptions: Excel.CustomFunctionVisibilityOptions = {
-        show: availableFunctions,
+    const functionsToShow = userFunctionMapping.get(userType) ?? [];
+    const functionsToHide = allFunctions.filter((name) => !functionsToShow.includes(name));
+    const customFunctionVisibilityOptions: Excel.CustomFunctionVisibilityOptions = {
+        show: functionsToShow,
+        hide: functionsToHide,
     };
-    // If functionA, functionB, and functionC are initially hidden with `excludeFromAutoComplete`, adjust visibility so the correct functions are shown.
     await Excel.CustomFunctionManager.setVisibility(customFunctionVisibilityOptions);
 }
 ```
+
+> [!IMPORTANT]
+> Values in the `show` and `hide` arrays must exactly match the short custom function names in the generated or manually authored JSON metadata. Matching is case-sensitive, so preserve the capitalization in the metadata. Don't include the manifest namespace. For example, if Excel displays `CONTOSO.CLOCK` and the metadata name is `CLOCK`, pass `"CLOCK"`, not `"CONTOSO.CLOCK"`. Don't assume the exported JavaScript or TypeScript implementation name is the required value. For example, `logMessage` in the preceding metadata has the short name `LOG`, so pass `"LOG"`.
+
+The `show` array reveals the listed functions, and the `hide` array hides the listed functions. Omitting a function from `show` doesn't automatically hide it. Visibility affects AutoComplete and the Formula Builder only. It doesn't unregister a custom function or prevent a user from entering its formula manually.
 
 ## See also
 
 - [Manually create JSON metadata for custom functions](custom-functions-json.md)
 - [Autogenerate JSON metadata for custom functions](custom-functions-json-autogeneration.md)
+- [What's new in Excel JavaScript API 1.20](/javascript/api/requirement-sets/excel/excel-api-1-20-requirement-set)


### PR DESCRIPTION
We had a customer comment that the article was ambiguous about function IDs versus names. This PR clarifies that ID needs to be used, along with some other things I learned on the journey.  